### PR TITLE
ci: update mergifyio to request reviews 

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -44,3 +44,20 @@ pull_request_rules:
       label:
         add:
           - api
+  - name: request reviews from reviewers for API change
+    conditions:
+      - files~=^(api/)
+      - -closed
+      - -draft
+    actions:
+      request_reviews:
+        users_from_teams:
+          - "@csi-addons/kubernetes-csi-addons-reviewers"
+  - name: request reviews from regular contributors
+    conditions:
+      - -closed
+      - -draft
+    actions:
+      request_reviews:
+        users_from_teams:
+          - "@csi-addons/kubernetes-csi-addons-contributors"


### PR DESCRIPTION
Now mergify will request reviews from kubernetes-csi-addons-contributors
for every open non-draft pr and additional reviews from
kubernetes-csi-addons-reviews for API change.

Signed-off-by: Rakshith R <rar@redhat.com>