### PR TITLE
ci: add GitHub Workflow for building and pushing container-images

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -1,0 +1,68 @@
+---
+name: Publish container images in quay.io
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  push_controller:
+    name: Push controller container image to quay.io
+    if: github.repository == 'csi-addons/kubernetes-csi-addons'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push controller container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
+          push: true
+          tags: quay.io/csi-addons/k8s-controller:latest
+
+  push_sidecar:
+    name: Push sidecar container image to quay.io
+    if: github.repository == 'csi-addons/kubernetes-csi-addons'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push sidecar container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: build/Containerfile.sidecar
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
+          push: true
+          tags: quay.io/csi-addons/k8s-sidecar:latest

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,0 +1,52 @@
+---
+name: Test building container images
+
+on:
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  build_controller:
+    name: Build controller container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build container container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
+          push: false
+          tags: quay.io/csi-addons/k8s-controller:latest
+
+  build_sidecar:
+    name: Test sidecar container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build sidecar container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: build/Containerfile.sidecar
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
+          push: false
+          tags: quay.io/csi-addons/k8s-sidecar:latest


### PR DESCRIPTION
Two CI jobs are added:

1. Test building container images, so that Mergify can require 
  `build_controller` and `build_sidecar` as CI jobs.

2. The container images should get pushed to quay.io after a PR has been
  merged. This currently builds the container images for all the
  architectures that the golang base container and Docker Actions support.
