### PR TITLE
ci: require passing test builds before merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
     rebase-strategy: "disabled"
     commit-message:
       prefix: "vendor"
+    labels:
+      - vendor

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -22,6 +22,8 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - "status-success=codespell"
+      - "status-success=build_container"
+      - "status-success=build_sidecar"
     actions:
       merge: {}
       dismiss_reviews: {}
@@ -35,6 +37,8 @@ pull_request_rules:
       - "approved-reviews-by=@csi-addons/kubernetes-csi-addons-contributors"
       - "approved-reviews-by=@csi-addons/kubernetes-csi-addons-reviewers"
       - "status-success=codespell"
+      - "status-success=build_container"
+      - "status-success=build_sidecar"
     actions:
       merge: {}
       dismiss_reviews: {}

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -50,6 +50,13 @@ pull_request_rules:
       label:
         add:
           - api
+  - name: label vendor change
+    conditions:
+      - files~=^(vendor/)
+    actions:
+      label:
+        add:
+          - vendor
   - name: request reviews from reviewers for API change
     conditions:
       - files~=^(api/)


### PR DESCRIPTION
In addition to the requirement of passing test container builds, the `vendor` label is set for vendored dependencies.

By default Dependabot labels PRs it creates with `dependency`. As this
is a Golang project, we ideally use `vendor` instead. This needs adoption in the Dependabot config too.
