### PR TITLE
controller: add connection package 

### DIFF
--- a/internal/connection/connection.go
+++ b/internal/connection/connection.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2021 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connection
+
+import (
+	"context"
+	"time"
+
+	"github.com/csi-addons/spec/lib/go/identity"
+	"google.golang.org/grpc"
+)
+
+// Connection struct consists of to NodeID, DriverName, Capabilities for the controller
+// to pick sidecar connection and grpc Client to connect to the sidecar.
+type Connection struct {
+	Client       *grpc.ClientConn
+	Capabilities []*identity.Capability
+	NodeID       string
+	DriverName   string
+	Timeout      time.Duration
+}
+
+// NewConnection establishes connection with sidecar, fetches capability and returns Connection object
+// filled with required information.
+func NewConnection(ctx context.Context, endpoint, nodeID, driverName string) (*Connection, error) {
+	opts := grpc.WithInsecure()
+	cc, err := grpc.Dial(endpoint, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	conn := &Connection{
+		Client:     cc,
+		NodeID:     nodeID,
+		DriverName: driverName,
+		Timeout:    time.Minute,
+	}
+
+	err = conn.fetchCapabilities(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func (c *Connection) Close() {
+	if c.Client != nil {
+		c.Client.Close()
+	}
+}
+
+// fetchCapabilities fetches the capability of the connected CSI driver.
+func (c *Connection) fetchCapabilities(ctx context.Context) error {
+	newCtx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+
+	identityClient := identity.NewIdentityClient(c.Client)
+	res, err := identityClient.GetCapabilities(newCtx, &identity.GetCapabilitiesRequest{})
+	if err != nil {
+		return err
+	}
+
+	c.Capabilities = res.GetCapabilities()
+
+	return nil
+}

--- a/internal/connection/connection_pool.go
+++ b/internal/connection/connection_pool.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connection
+
+import "sync"
+
+// ConnectionPool consists of map of Connection objects and
+// methods Put, Get & Delete which operates with required rw locks
+// to ensure consistency.
+// CSIAddonsNode controller will use Put and Delete methods whereas
+// other controllers will make use of Get to choose and connect to sidecar.
+type ConnectionPool struct {
+	pool   map[string]*Connection
+	rwlock *sync.RWMutex
+}
+
+// NewConntionPool initializes and returns ConnectionPool object.
+func NewConnectionPool() *ConnectionPool {
+	return &ConnectionPool{
+		pool:   make(map[string]*Connection),
+		rwlock: &sync.RWMutex{},
+	}
+}
+
+// Put adds connection object into map.
+func (cp *ConnectionPool) Put(key string, conn *Connection) {
+	cp.rwlock.Lock()
+	defer cp.rwlock.Unlock()
+
+	oldConn, ok := cp.pool[key]
+	if ok {
+		oldConn.Close()
+	}
+
+	cp.pool[key] = conn
+}
+
+// Delete deletes connection object corresponding to given key.
+func (cp *ConnectionPool) Delete(key string) {
+	cp.rwlock.Lock()
+	defer cp.rwlock.Unlock()
+
+	conn, ok := cp.pool[key]
+	if ok {
+		conn.Close()
+	}
+
+	delete(cp.pool, key)
+}
+
+// Get returns map of connections and unlock function to be called
+// after parsing the connections.
+func (cp *ConnectionPool) Get() (*map[string]*Connection, func()) {
+	rlock := cp.rwlock.RLocker()
+	rlock.Lock()
+
+	return &cp.pool, rlock.Unlock
+}

--- a/internal/connection/connection_pool_test.go
+++ b/internal/connection/connection_pool_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2021 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package connection
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/csi-addons/spec/lib/go/identity"
+)
+
+func TestNewConnectionPool(t *testing.T) {
+	tests := []struct {
+		name string
+		want *ConnectionPool
+	}{
+		{
+			name: "Get new ConnectionPool object",
+			want: &ConnectionPool{
+				pool:   make(map[string]*Connection),
+				rwlock: &sync.RWMutex{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewConnectionPool(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewConnectionPool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConnectionPool_PutGetDelete(t *testing.T) {
+
+	t.Run(("test single Put, Get, Delete"), func(t *testing.T) {
+		cp := NewConnectionPool()
+		key1 := "one"
+		conn1 := &Connection{
+			Capabilities: []*identity.Capability{},
+			NodeID:       "one",
+			DriverName:   "example.io",
+			Timeout:      0,
+		}
+
+		cp.Put(key1, conn1)
+
+		conns, unLock := cp.Get()
+		if len(*conns) != 1 {
+			t.Errorf("connection map should contain only one value: %+v", *conns)
+		}
+		for k, v := range *conns {
+			if k == key1 {
+				if !reflect.DeepEqual(*v, *conn1) {
+					t.Errorf("expected value %+v is not equal to returned value %+v", Connection{}, *v)
+				}
+			}
+		}
+		unLock()
+
+		cp.Delete(key1)
+
+		conns, unLock = cp.Get()
+		defer unLock()
+		if len(*conns) != 0 {
+			t.Errorf("Connection map should be empty: %+v", *conns)
+		}
+	})
+
+	t.Run(("test Put with same key twice"), func(t *testing.T) {
+		cp := NewConnectionPool()
+		key1 := "one"
+		conn1 := &Connection{
+			Capabilities: []*identity.Capability{},
+			NodeID:       "one",
+			DriverName:   "example.io",
+			Timeout:      0,
+		}
+		conn2 := &Connection{
+			Capabilities: []*identity.Capability{},
+			NodeID:       "two",
+			DriverName:   "two.example.io",
+			Timeout:      0,
+		}
+
+		cp.Put(key1, conn1)
+
+		conns, unLock := cp.Get()
+		for k, v := range *conns {
+			if k == key1 {
+				if !reflect.DeepEqual(*v, *conn1) {
+					t.Errorf("expected value %+v is not equal to returned value %+v", *conn1, *v)
+				}
+			}
+		}
+		unLock()
+
+		cp.Put(key1, conn2)
+
+		conns, unLock = cp.Get()
+		for k, v := range *conns {
+			if k == key1 {
+				if !reflect.DeepEqual(*v, *conn2) {
+					t.Errorf("expected value %+v is not equal to returned value %+v", *conn2, *v)
+				}
+			}
+		}
+		unLock()
+
+		cp.Delete(key1)
+
+		conns, unLock = cp.Get()
+		defer unLock()
+		if len(*conns) != 0 {
+			t.Errorf("Connection map should be empty: %+v", *conns)
+		}
+	})
+
+	t.Run(("test Delete with same key twice"), func(t *testing.T) {
+		cp := NewConnectionPool()
+		key1 := "one"
+		conn1 := &Connection{
+			Capabilities: []*identity.Capability{},
+			NodeID:       "one",
+			DriverName:   "example.io",
+			Timeout:      0,
+		}
+		cp.Put(key1, conn1)
+
+		conns, unLock := cp.Get()
+		for k, v := range *conns {
+			if k == key1 {
+				if !reflect.DeepEqual(*v, *conn1) {
+					t.Errorf("expected value %+v is not equal to returned value %+v", *conn1, *v)
+				}
+			}
+		}
+		unLock()
+
+		cp.Delete(key1)
+		cp.Delete(key1)
+
+		conns, unLock = cp.Get()
+		defer unLock()
+		if len(*conns) != 0 {
+			t.Errorf("Connection map should be empty: %+v", *conns)
+		}
+	})
+
+}


### PR DESCRIPTION
### controller: add Connection struct to connection pkg 

Connection object will contain required details for controllers
to decide to which client to connect to.

Signed-off-by: Rakshith R <rar@redhat.com>

### controller: add connectionPool struct 

connectionPool contains a map of connection object,
which required functions Put, Delete and Get.

Signed-off-by: Rakshith R <rar@redhat.com>

---

A single ConnectionPool Object will be created in main.go and shared between all controllers.
CSIAddonsNode controller will take care of adding and deleting connections, while other controller can get the list and decide which connection to use.