### PR TITLE
build: tag images under the quay.io/csiaddons org

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -35,7 +35,7 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
           push: true
-          tags: quay.io/csi-addons/k8s-controller:latest
+          tags: quay.io/csiaddons/k8s-controller:latest
 
   push_sidecar:
     name: Push sidecar container image to quay.io
@@ -65,4 +65,4 @@ jobs:
           file: build/Containerfile.sidecar
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
           push: true
-          tags: quay.io/csi-addons/k8s-sidecar:latest
+          tags: quay.io/csiaddons/k8s-sidecar:latest

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -27,7 +27,7 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
           push: false
-          tags: quay.io/csi-addons/k8s-controller:latest
+          tags: quay.io/csiaddons/k8s-controller:latest
 
   build_sidecar:
     name: Test sidecar container image
@@ -49,4 +49,4 @@ jobs:
           file: build/Containerfile.sidecar
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
           push: false
-          tags: quay.io/csi-addons/k8s-sidecar:latest
+          tags: quay.io/csiaddons/k8s-sidecar:latest


### PR DESCRIPTION
It seems that quay.io does not allow a dash `-` in the name of the
organization. Therefore images should get tagged and pushed to
quay.io/csiaddons.

Closes: #11