### PR TITLE
ci: build container image on one arch

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -33,7 +33,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: quay.io/csiaddons/k8s-controller:latest
 
@@ -63,6 +63,6 @@ jobs:
         with:
           context: .
           file: build/Containerfile.sidecar
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: quay.io/csiaddons/k8s-sidecar:latest

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: false
           tags: quay.io/csiaddons/k8s-controller:latest
 
@@ -47,6 +47,6 @@ jobs:
         with:
           context: .
           file: build/Containerfile.sidecar
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: false
           tags: quay.io/csiaddons/k8s-sidecar:latest


### PR DESCRIPTION
To fasten the CI jobs for testing builds, build container images only on one arch and when pushing build on all arch.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>