### PR TITLE
ci: add a job to run "make test"

### DIFF
--- a/.github/workflows/test-golang.yaml
+++ b/.github/workflows/test-golang.yaml
@@ -7,6 +7,24 @@ on:
       - "*"
 
 jobs:
+  make_test:
+    name: Basic testing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Run "make test"
+        run: make test
+
+      - name: Check for uncommitted changes
+        run: make check-all-committed
+
   go_mod_verify:
     name: Verify the contents of the vendor/ directory
     runs-on: ubuntu-latest


### PR DESCRIPTION
"make test" is an available Makefile target that runs several checks for
Golang coding standards and code generation. In case the command fails,
or uncommitted changes are detected, the job will fail.