### PR TITLE
Require passing of Golang CI jobs before merging

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -24,6 +24,9 @@ pull_request_rules:
       - "status-success=codespell"
       - "status-success=build_controller"
       - "status-success=build_sidecar"
+      - "status-success=go_mod_verify"
+      - "status-success=go_mod_vendor"
+      - "status-success=make_test"
     actions:
       merge: {}
       dismiss_reviews: {}
@@ -39,6 +42,9 @@ pull_request_rules:
       - "status-success=codespell"
       - "status-success=build_controller"
       - "status-success=build_sidecar"
+      - "status-success=go_mod_verify"
+      - "status-success=go_mod_vendor"
+      - "status-success=make_test"
     actions:
       merge: {}
       dismiss_reviews: {}


### PR DESCRIPTION
The jobs in the .github/workflows/test-golang.yaml workflow are stable
and pass on the current main branch. These jobs can now be required for
merging PRs.

**_Note:_** this requires manual merging as it updates the Mergify config.