### PR TITLE
sidecar: use <POD_IP>:<PORT> for controller endpoint

### DIFF
--- a/sidecar/internal/csiaddonsnode/csiaddonsnode.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode.go
@@ -35,7 +35,6 @@ const (
 	podNameEnvKey      = "POD_NAME"
 	podNamespaceEnvKey = "POD_NAMESPACE"
 	podUIDEnvKey       = "POD_UID"
-	podIPEnvKey        = "POD_IP"
 )
 
 // Deploy creates CSIAddonsNode custom resource with all required information.
@@ -100,10 +99,6 @@ func getCSIAddonsNode(driverName, endpoint, nodeID string) (*csiaddonsv1alpha1.C
 	if err != nil {
 		return nil, err
 	}
-	podIP, err := lookupEnv(podIPEnvKey)
-	if err != nil {
-		return nil, err
-	}
 
 	return &csiaddonsv1alpha1.CSIAddonsNode{
 		ObjectMeta: v1.ObjectMeta{
@@ -121,7 +116,7 @@ func getCSIAddonsNode(driverName, endpoint, nodeID string) (*csiaddonsv1alpha1.C
 		Spec: csiaddonsv1alpha1.CSIAddonsNodeSpec{
 			Driver: csiaddonsv1alpha1.CSIAddonsNodeDriver{
 				Name:     driverName,
-				EndPoint: podIP + ":" + endpoint,
+				EndPoint: endpoint,
 				NodeID:   nodeID,
 			},
 		},

--- a/sidecar/internal/csiaddonsnode/csiaddonsnode_test.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode_test.go
@@ -59,12 +59,10 @@ func Test_getCSIAddonsNode(t *testing.T) {
 		podName     = "pod"
 		podNamspace = "default"
 		podUID      = "123"
-		podIP       = "110"
 	)
 	t.Setenv(podNameEnvKey, podName)
 	t.Setenv(podNamespaceEnvKey, podNamspace)
 	t.Setenv(podUIDEnvKey, podUID)
-	t.Setenv(podIPEnvKey, podIP)
 
 	type args struct {
 		driverName string
@@ -82,7 +80,7 @@ func Test_getCSIAddonsNode(t *testing.T) {
 			name: "Test 1",
 			args: args{
 				driverName: "example.com",
-				endpoint:   "6060",
+				endpoint:   "192.168.61.228:6060",
 				nodeID:     "123",
 			},
 			want: &csiaddonsv1alpha1.CSIAddonsNode{
@@ -102,7 +100,7 @@ func Test_getCSIAddonsNode(t *testing.T) {
 				Spec: csiaddonsv1alpha1.CSIAddonsNodeSpec{
 					Driver: csiaddonsv1alpha1.CSIAddonsNodeDriver{
 						Name:     "example.com",
-						EndPoint: podIP + ":" + "6060",
+						EndPoint: "192.168.61.228:6060",
 						NodeID:   "123",
 					},
 				},
@@ -113,7 +111,7 @@ func Test_getCSIAddonsNode(t *testing.T) {
 			name: "Test 2",
 			args: args{
 				driverName: "csi.example.com",
-				endpoint:   "8060",
+				endpoint:   "[2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b]:8080",
 				nodeID:     "32532-1312-435354",
 			},
 			want: &csiaddonsv1alpha1.CSIAddonsNode{
@@ -133,7 +131,7 @@ func Test_getCSIAddonsNode(t *testing.T) {
 				Spec: csiaddonsv1alpha1.CSIAddonsNodeSpec{
 					Driver: csiaddonsv1alpha1.CSIAddonsNodeDriver{
 						Name:     "csi.example.com",
-						EndPoint: podIP + ":" + "8060",
+						EndPoint: "[2001:0db8:3c4d:0015:0000:0000:1a2f:1a2b]:8080",
 						NodeID:   "32532-1312-435354",
 					},
 				},

--- a/sidecar/internal/server/server.go
+++ b/sidecar/internal/server/server.go
@@ -53,7 +53,7 @@ func NewSidecarServer(endpoint string) *SidecarServer {
 	}
 
 	ss.scheme = "tcp"
-	ss.endpoint = ":" + endpoint
+	ss.endpoint = endpoint
 
 	return ss
 }

--- a/sidecar/internal/util/util.go
+++ b/sidecar/internal/util/util.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+)
+
+// ValidateControllerEndpoint validates given ip address and port,
+// returning valid endpoint containing both ip address and port.
+func ValidateControllerEndpoint(rawIP, rawPort string) (string, error) {
+	ip := net.ParseIP(rawIP)
+	if ip == nil {
+		return "", fmt.Errorf("invalid controller ip address %q", rawIP)
+	}
+
+	port, err := strconv.ParseUint(rawPort, 10, 16)
+	if err != nil {
+		return "", fmt.Errorf("invalid controller port %q: %w", rawPort, err)
+	}
+
+	if ip.To4() != nil {
+		return fmt.Sprintf("%s:%d", ip.String(), port), nil
+	}
+
+	return fmt.Sprintf("[%s]:%d", ip.String(), port), nil
+}

--- a/sidecar/internal/util/util_test.go
+++ b/sidecar/internal/util/util_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2022 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "testing"
+
+func TestValidateControllerEndpoint(t *testing.T) {
+	type args struct {
+		rawIP   string
+		rawPort string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "valid ipv4",
+			args: args{
+				rawIP:   "192.168.61.228",
+				rawPort: "8080",
+			},
+			want:    "192.168.61.228:8080",
+			wantErr: false,
+		},
+		{
+			name: "valid ipv6",
+			args: args{
+				rawIP:   "2001:db8:3c4d:15:0:1:1a2f:1a2b",
+				rawPort: "8080",
+			},
+			want:    "[2001:db8:3c4d:15:0:1:1a2f:1a2b]:8080",
+			wantErr: false,
+		},
+		{
+			name: "invalid ipv4",
+			args: args{
+				rawIP:   "192.168.61",
+				rawPort: "8080",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "invalid ipv6",
+			args: args{
+				rawIP:   "2001:db8:3c4d:15:0:1:1a2f",
+				rawPort: "8080",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "empty ip",
+			args: args{
+				rawIP:   "",
+				rawPort: "8080",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "invalid port",
+			args: args{
+				rawIP:   "2001:db8:3c4d:15:0:1:1a2f:1a2b",
+				rawPort: "-123",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateControllerEndpoint(tt.args.rawIP, tt.args.rawPort)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateControllerEndpoint() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ValidateControllerEndpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Just using port to start controller server leads to
grpc server listening on all available ip addresses.
This causes plugin pod running on host network to listen
to requests pointed towards pod ips on that particular port
which is undesirable.

Using `<POD_IP>:<PORT>` makes sure grpc server is listening
on its intended endpoint.

Signed-off-by: Rakshith R <rar@redhat.com>