### PR TITLE
doc: add a minimal description for `make deploy`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= quay.io/csiaddons/k8s-controller:latest
 SIDECAR_IMG ?= quay.io/csiaddons/k8s-sidecar
 TAG?= latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.

--- a/README.md
+++ b/README.md
@@ -48,5 +48,46 @@ By listing the `CSIAddonsNode` CRs, the CSI-Addons Controller knows how to
 connect to the side-cars. By checking the supported capabilities of the
 side-cars, it can decide where to execute operations that the user requested.
 
+### Installation
+
+This project uses `kustomize` and a `Makefile` for deploying. By running the
+command
+
+```console
+$ make deploy
+...
+customresourcedefinition.apiextensions.k8s.io/csiaddonsnodes.csiaddons.openshift.io created
+customresourcedefinition.apiextensions.k8s.io/reclaimspacejobs.csiaddons.openshift.io created
+serviceaccount/csi-addons-controller-manager created
+role.rbac.authorization.k8s.io/csi-addons-leader-election-role created
+clusterrole.rbac.authorization.k8s.io/csi-addons-manager-role created
+clusterrole.rbac.authorization.k8s.io/csi-addons-metrics-reader created
+clusterrole.rbac.authorization.k8s.io/csi-addons-proxy-role created
+rolebinding.rbac.authorization.k8s.io/csi-addons-leader-election-rolebinding created
+clusterrolebinding.rbac.authorization.k8s.io/csi-addons-manager-rolebinding created
+clusterrolebinding.rbac.authorization.k8s.io/csi-addons-proxy-rolebinding created
+configmap/csi-addons-manager-config created
+service/csi-addons-controller-manager-metrics-service created
+deployment.apps/csi-addons-controller-manager created
+```
+
+the different components for the Controller will get deployed in the
+`csi-addons-system` Namespace.
+
+```console
+$ kubectl -n csi-addons-system get all
+NAME                                                 READY   STATUS    RESTARTS   AGE
+pod/csi-addons-controller-manager-687d47b8c7-9m56f   2/2     Running   0          49s
+
+NAME                                                    TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+service/csi-addons-controller-manager-metrics-service   ClusterIP   172.30.153.17   <none>        8443/TCP   49s
+
+NAME                                            READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/csi-addons-controller-manager   1/1     1            1           49s
+
+NAME                                                       DESIRED   CURRENT   READY   AGE
+replicaset.apps/csi-addons-controller-manager-687d47b8c7   1         1         1       49s
+```
+
 [csi_addons]: https://github.com/csi-addons/spec/
 [csi]: https://kubernetes-csi.github.io/docs/


### PR DESCRIPTION
Deploying with `make deploy` is the easiest while testing and
developing. This is the recommended method for now.

Updates: #14 