### PR TITLE
logging: show the listening address in readable format

### DIFF
--- a/sidecar/internal/server/server.go
+++ b/sidecar/internal/server/server.go
@@ -77,7 +77,7 @@ func (ss *SidecarServer) Start() {
 
 	listener, err := net.Listen(ss.scheme, ss.endpoint)
 	if err != nil {
-		klog.Fatalf("failed to listen on %q: %w", listener.Addr().String(), err)
+		klog.Fatalf("failed to listen on %q: %w", listener.Addr(), err)
 	}
 
 	ss.serve(listener)
@@ -86,7 +86,7 @@ func (ss *SidecarServer) Start() {
 // serve starts the actual process of listening for requests on the gRPC
 // server.
 func (ss *SidecarServer) serve(listener net.Listener) {
-	klog.Infof("Listening for CSI-Addons requests on address: %#v", listener.Addr())
+	klog.Infof("Listening for CSI-Addons requests on address: %s", listener.Addr())
 
 	// start to serve requests
 	err := ss.server.Serve(listener)


### PR DESCRIPTION
Earlier the logs contained an entry like the following when the sidecar
started to listen:

    I0107 13:35:07.438390  329335 server.go:89] Listening for CSI-Addons requests on address: &net.TCPAddr{IP:net.IP{0xa, 0x0, 0x99, 0xe6}, Port:4080, Zone:""}

This is not particular readable. In the future, the log will contain:

    I0107 13:46:25.058413  341537 server.go:89] Listening for CSI-Addons requests on address: 10.0.153.230:4080