### PR TITLE
sidecar: prevent failure and listen immediately

### DIFF
--- a/sidecar/internal/csiaddonsnode/csiaddonsnode.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 )
@@ -78,15 +77,15 @@ func Deploy(config *rest.Config, driverName, nodeID, endpoint string) error {
 // If the CSIAddonsNode object already exists, it will not be re-created or
 // modified, and the existing object is kept as-is.
 func newCSIAddonsNode(config *rest.Config, node *csiaddonsv1alpha1.CSIAddonsNode) error {
-	err := csiaddonsv1alpha1.AddToScheme(scheme.Scheme)
+	scheme, err := csiaddonsv1alpha1.SchemeBuilder.Build()
 	if err != nil {
 		return fmt.Errorf("failed to add scheme: %w", err)
 	}
 
 	crdConfig := *config
-	crdConfig.ContentConfig.GroupVersion = &csiaddonsv1alpha1.GroupVersion
+	crdConfig.GroupVersion = &csiaddonsv1alpha1.GroupVersion
 	crdConfig.APIPath = "/apis"
-	crdConfig.NegotiatedSerializer = serializer.NewCodecFactory(scheme.Scheme)
+	crdConfig.NegotiatedSerializer = serializer.NewCodecFactory(scheme)
 	crdConfig.UserAgent = rest.DefaultKubernetesUserAgent()
 
 	c, err := rest.UnversionedRESTClientFor(&crdConfig)

--- a/sidecar/internal/csiaddonsnode/csiaddonsnode.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode.go
@@ -100,7 +100,7 @@ func newCSIAddonsNode(config *rest.Config, node *csiaddonsv1alpha1.CSIAddonsNode
 		Name(node.Name).
 		Body(node).
 		Do(context.TODO()).
-		Into(nil)
+		Error()
 
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return fmt.Errorf("failed to create csiaddonsnode object: %w", err)


### PR DESCRIPTION
When the sidecar starts, the following fatal error is logged:

    failed to create csiaddonsnode object: no kind "CSIAddonsNode" is registered for the internal version of group "csiaddons.openshift.io" in scheme "k8s.io/client-go/kubernetes/scheme/register.go:74"

After that, the sidecar restarts.

Even though the error is handled as fatal, the new CSIAddonsNode object
is created successfully. After the restart, the new CSIAddonsNode is
found, and the sidecar continues to startup successfully.

It seems that placing the result `Into(nil)` causes the failure, as
opposed to the documentation. Getting the error from the `Do()` response
is sufficient here, and prevents the failure of calling `Into()`.
