### PR TITLE
sidecar: pass Pod details as parameters

### DIFF
--- a/sidecar/internal/csiaddonsnode/csiaddonsnode.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode.go
@@ -147,6 +147,15 @@ func (mgr *Manager) getCSIAddonsNode() (*csiaddonsv1alpha1.CSIAddonsNode, error)
 	if mgr.PodUID == "" {
 		return nil, fmt.Errorf("%w: missing Pod UID", errInvalidConfig)
 	}
+	if mgr.Driver == "" {
+		return nil, fmt.Errorf("%w: missing drivername", errInvalidConfig)
+	}
+	if mgr.Endpoint == "" {
+		return nil, fmt.Errorf("%w: missing endpoint", errInvalidConfig)
+	}
+	if mgr.Node == "" {
+		return nil, fmt.Errorf("%w: missing node", errInvalidConfig)
+	}
 
 	return &csiaddonsv1alpha1.CSIAddonsNode{
 		ObjectMeta: v1.ObjectMeta{

--- a/sidecar/internal/csiaddonsnode/csiaddonsnode.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode.go
@@ -47,6 +47,11 @@ var (
 
 // Manager is a helper that creates the CSIAddonsNode for the running sidecar.
 type Manager struct {
+	// Client contains the gRPC connection to the CSI-driver that supports
+	// the CSI-Addons operations. This is used to get the identity of the
+	// CSI-driver that is included in the CSIAddonsNode object.
+	Client client.Client
+
 	// Config is a ReST Config for the Kubernets API.
 	Config *rest.Config
 

--- a/sidecar/internal/csiaddonsnode/csiaddonsnode_test.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode_test.go
@@ -27,33 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func Test_lookupEnv(t *testing.T) {
-
-	t.Run("Env Var set", func(t *testing.T) {
-		key := "hello"
-		value := "world"
-		t.Setenv(key, value)
-
-		got, err := lookupEnv(key)
-		if (err != nil) != false {
-			t.Errorf("lookupEnv() error = %v, wantErr %v", err, false)
-			return
-		}
-		if got != value {
-			t.Errorf("lookupEnv() = %v, want %v", got, value)
-		}
-	})
-
-	t.Run("Env Var not set", func(t *testing.T) {
-		key := "hello"
-		_, err := lookupEnv(key)
-		if err == nil {
-			t.Errorf("lookupEnv() error = %v, wantErr %v", err,
-				fmt.Errorf("Required environemental variable %q not found", key))
-		}
-	})
-}
-
 func Test_getCSIAddonsNode(t *testing.T) {
 	var (
 		podName     = "pod"

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -68,11 +68,6 @@ func main() {
 		klog.Fatalf("Failed to probe driver: %w", err)
 	}
 
-	driverName, err := csiClient.GetDriverName()
-	if err != nil {
-		klog.Fatalf("Failed to get driver name: %v", err)
-	}
-
 	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		klog.Fatalf("Failed to get cluster config: %w", err)
@@ -84,8 +79,8 @@ func main() {
 	}
 
 	nodeMgr := &csiaddonsnode.Manager{
+		Client:       csiClient,
 		Config:       cfg,
-		Driver:       driverName,
 		Node:         *nodeID,
 		Endpoint:     controllerEndpoint,
 		PodName:      *podName,

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -43,6 +43,9 @@ func main() {
 			"The TCP network port where the gRPC server for controller request, will listen (example: `8080`)")
 		controllerIP = flag.String("controller-ip", "",
 			"The TCP network ip address where the gRPC server for controller request, will listen (example: `192.168.61.228`)")
+		podName      = flag.String("pod", "", "name of the Pod that contains this sidecar")
+		podNamespace = flag.String("namespace", "", "namespace of the Pod that contains this sidecar")
+		podUID       = flag.String("pod-uid", "", "UID of the Pod that contains this sidecar")
 	)
 	klog.InitFlags(nil)
 	if err := flag.Set("logtostderr", "true"); err != nil {
@@ -81,10 +84,13 @@ func main() {
 	}
 
 	nodeMgr := &csiaddonsnode.Manager{
-		Config:   cfg,
-		Driver:   driverName,
-		Node:     *nodeID,
-		Endpoint: controllerEndpoint,
+		Config:       cfg,
+		Driver:       driverName,
+		Node:         *nodeID,
+		Endpoint:     controllerEndpoint,
+		PodName:      *podName,
+		PodNamespace: *podNamespace,
+		PodUID:       *podUID,
 	}
 	err = nodeMgr.Deploy()
 	if err != nil {

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -98,9 +98,9 @@ func main() {
 	}
 
 	sidecarServer := server.NewSidecarServer(controllerEndpoint)
-	sidecarServer.RegisterService(service.NewIdentityServer(csiClient.Client))
-	sidecarServer.RegisterService(service.NewReclaimSpaceServer(csiClient.Client, kubeClient, *stagingPath))
-	sidecarServer.RegisterService(service.NewNetworkFenceServer(csiClient.Client, kubeClient))
+	sidecarServer.RegisterService(service.NewIdentityServer(csiClient.GetGRPCClient()))
+	sidecarServer.RegisterService(service.NewReclaimSpaceServer(csiClient.GetGRPCClient(), kubeClient, *stagingPath))
+	sidecarServer.RegisterService(service.NewNetworkFenceServer(csiClient.GetGRPCClient(), kubeClient))
 
 	sidecarServer.Start()
 }

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -80,7 +80,13 @@ func main() {
 		klog.Fatalf("Failed to create client: %v", err)
 	}
 
-	err = csiaddonsnode.Deploy(cfg, driverName, *nodeID, controllerEndpoint)
+	nodeMgr := &csiaddonsnode.Manager{
+		Config:   cfg,
+		Driver:   driverName,
+		Node:     *nodeID,
+		Endpoint: controllerEndpoint,
+	}
+	err = nodeMgr.Deploy()
 	if err != nil {
 		klog.Fatalf("Failed to create csiaddonsnode: %v", err)
 	}


### PR DESCRIPTION
Using environment variables makes it difficult to see what parameters
are used by the sidecar. Instead of reading some configuration options
from environment variables, use parameters for the executable for all
options.