### PR TITLE
controller: modify ConnectionPool.Get() to return a copy

### DIFF
--- a/internal/connection/connection_pool.go
+++ b/internal/connection/connection_pool.go
@@ -62,11 +62,21 @@ func (cp *ConnectionPool) Delete(key string) {
 	delete(cp.pool, key)
 }
 
-// Get returns map of connections and unlock function to be called
-// after parsing the connections.
-func (cp *ConnectionPool) Get() (*map[string]*Connection, func()) {
-	rlock := cp.rwlock.RLocker()
-	rlock.Lock()
+// GetByNodeID returns map of connections, filtered with given driverName and optional nodeID.
+func (cp *ConnectionPool) GetByNodeID(driverName, nodeID string) map[string]*Connection {
+	cp.rwlock.RLock()
+	defer cp.rwlock.RUnlock()
 
-	return &cp.pool, rlock.Unlock
+	newPool := make(map[string]*Connection)
+	for k, v := range cp.pool {
+		if v.DriverName != driverName {
+			continue
+		}
+		if nodeID != "" && v.NodeID != nodeID {
+			continue
+		}
+		newPool[k] = v
+	}
+
+	return newPool
 }


### PR DESCRIPTION
This commit modifies ConnectionPool.Get() to take in
driverName and optional nodeID as parameters and now
returns a filtered copy of connections map.
This is done to avoid any deadlock issue that can occur
when unlock function may not be called in previous iteration
of the function.
Unit tests have been added and it now uses assert package.

Signed-off-by: Rakshith R <rar@redhat.com>

- Further filtering using Capabilities seems a bit tricky, It can be done as a future enhancement. 