### PR TITLE
build: use Golang 1.17 when building the bundle container-image

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -15,6 +15,11 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
+      - name: Install Go 1.17
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+
       - name: Generate the bundle contents
         run: make bundle
 


### PR DESCRIPTION
When the GitHub Worflow to push the bundle container-image runs, it uses
the standard version of Go that is installed on the Ubuntu worker. This
version does not work while building `kustomize`:

    go build -o /home/runner/work/kubernetes-csi-addons/kubernetes-csi-addons/bin/kustomize ./vendor/sigs.k8s.io/kustomize/kustomize/v4
    # sigs.k8s.io/kustomize/kyaml/filesys
    vendor/sigs.k8s.io/kustomize/kyaml/filesys/fsondisk.go:115:21: undefined: os.ReadDir

The project requires Go 1.17, so we should use that while building the
bundle container-image as well.

Fixes: https://github.com/csi-addons/kubernetes-csi-addons/runs/4798369471?check_suite_focus=true