### PR TITLE
build: publish versioned container-images on pushing a git tag

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,100 @@
+---
+name: Build and release versioned container images
+
+on:
+  create
+
+jobs:
+  tag_bundle:
+    name: Build and release the bundle container-image
+    if: github.repository == 'csi-addons/kubernetes-csi-addons' && github.ref_type  == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Install Go 1.17
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
+
+      - name: Generate the bundle contents
+        run: make bundle
+
+      - name: Validate the bundle contents
+        run: make bundle-validate
+
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build bundle container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: bundle.Dockerfile
+          push: true
+          tags: quay.io/csiaddons/k8s-bundle:${{ github.ref_name }}
+
+  tag_controller:
+    name: Build and release the controller container-image
+    if: github.repository == 'csi-addons/kubernetes-csi-addons' && github.ref_type  == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push controller container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: quay.io/csiaddons/k8s-controller:${{ github.ref_name }}
+
+  tag_sidecar:
+    name: Build and release the sidecar container-image
+    if: github.repository == 'csi-addons/kubernetes-csi-addons' && github.ref_type  == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push sidecar container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: build/Containerfile.sidecar
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: quay.io/csiaddons/k8s-sidecar:${{ github.ref_name }}


### PR DESCRIPTION
When a release is tagged, the GitHub workflow will build the container
images and push them to Quay.io with the `:<git-tag>` version.

A test-run (without publishing) is available in my [personal fork](https://github.com/nixpanic/kubernetes-csi-addons/runs/4801220182?check_suite_focus=true).