### PR TITLE
controller: add ReclaimSpaceJob controller

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -43,6 +43,10 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+const (
+	defaultTimeout = time.Minute * 3
+)
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
@@ -54,11 +58,13 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var reclaimSpaceTimeout time.Duration
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.DurationVar(&reclaimSpaceTimeout, "reclaim-space-timeout", defaultTimeout, "Timeout for reclaimspace operation")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -92,8 +98,10 @@ func main() {
 	}
 
 	if err = (&controllers.ReclaimSpaceJobReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		ConnPool: connPool,
+		Timeout:  reclaimSpaceTimeout,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ReclaimSpaceJob")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,22 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - csiaddons.openshift.io
   resources:
   - csiaddonsnodes
@@ -83,3 +99,11 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/reclaimspacejob_controller_test.go
+++ b/controllers/reclaimspacejob_controller_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2022 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"testing"
+	"time"
+
+	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/v1alpha1"
+	"github.com/csi-addons/kubernetes-csi-addons/internal/proto"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSetFailedCondition(t *testing.T) {
+	type args struct {
+		conditions         *[]v1.Condition
+		message            string
+		observedGeneration int64
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "overwrite existing failed condition",
+			args: args{
+				conditions: &[]v1.Condition{
+					{
+						Type:               conditionFailed,
+						Status:             v1.ConditionTrue,
+						ObservedGeneration: 0,
+						LastTransitionTime: v1.NewTime(time.Now()),
+						Reason:             "",
+						Message:            "err 1",
+					},
+				},
+				message:            "err 2",
+				observedGeneration: 3,
+			},
+		},
+		{
+			name: "add failed condition",
+			args: args{
+				conditions:         &[]v1.Condition{},
+				message:            "err 1",
+				observedGeneration: 3,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setFailedCondition(tt.args.conditions, tt.args.message, tt.args.observedGeneration)
+			assert.Equal(t, tt.args.message, (*tt.args.conditions)[0].Message)
+			assert.Equal(t, tt.args.observedGeneration, (*tt.args.conditions)[0].ObservedGeneration)
+		})
+	}
+}
+
+func TestValidateReclaimSpaceJobSpec(t *testing.T) {
+	type args struct {
+		rsJob *csiaddonsv1alpha1.ReclaimSpaceJob
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "empty ReclaimSpaceJob.Spec.Target.PersistentVolumeClaim",
+			args: args{
+				rsJob: &csiaddonsv1alpha1.ReclaimSpaceJob{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "filled ReclaimSpaceJob.Spec.Target.PersistentVolumeClaim",
+			args: args{
+				rsJob: &csiaddonsv1alpha1.ReclaimSpaceJob{
+					Spec: csiaddonsv1alpha1.ReclaimSpaceJobSpec{
+						Target: csiaddonsv1alpha1.TargetSpec{
+							PersistentVolumeClaim: "pvc-1",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateReclaimSpaceJobSpec(tt.args.rsJob); (err != nil) != tt.wantErr {
+				t.Errorf("validateReclaimSpaceJobSpec() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCalculateReclaimedSpace(t *testing.T) {
+	type args struct {
+		PreUsage  *proto.StorageConsumption
+		PostUsage *proto.StorageConsumption
+	}
+	pre := int64(0)
+	post := int64(5)
+	result := post - pre
+	result2 := int64(0)
+	tests := []struct {
+		name string
+		args args
+		want *int64
+	}{
+		{
+			name: "both pre and post usage present",
+			args: args{
+				PreUsage: &proto.StorageConsumption{
+					UsageBytes: pre,
+				},
+				PostUsage: &proto.StorageConsumption{
+					UsageBytes: post,
+				},
+			},
+			want: &result,
+		},
+		{
+			name: "only post usage present",
+			args: args{
+				PreUsage: nil,
+				PostUsage: &proto.StorageConsumption{
+					UsageBytes: post,
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "only pre usage present",
+			args: args{
+				PreUsage: &proto.StorageConsumption{
+					UsageBytes: pre,
+				},
+				PostUsage: nil,
+			},
+			want: nil,
+		},
+		{
+			name: "reclaimed space is negative",
+			args: args{
+				PreUsage: &proto.StorageConsumption{
+					UsageBytes: pre,
+				},
+				PostUsage: &proto.StorageConsumption{
+					UsageBytes: -post,
+				},
+			},
+			want: &result2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateReclaimedSpace(tt.args.PreUsage, tt.args.PostUsage)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.43.0
 	google.golang.org/protobuf v1.27.1
+	k8s.io/api v0.23.1
 	k8s.io/apimachinery v0.23.1
 	k8s.io/client-go v0.23.1
 	k8s.io/klog/v2 v2.40.1
@@ -209,7 +210,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	helm.sh/helm/v3 v3.6.2 // indirect
-	k8s.io/api v0.23.1 // indirect
 	k8s.io/apiextensions-apiserver v0.23.0 // indirect
 	k8s.io/apiserver v0.23.0 // indirect
 	k8s.io/cli-runtime v0.21.0 // indirect


### PR DESCRIPTION
    This commit adds ReclaimSpaceJob controller code
    and unit tests for the same.
    
    ReclaimSpaceJob controller watches for ReclaimSpaceJob,
    validates resource, finds connections, makes respective
    grpc requests and updates the status.
Signed-off-by: Rakshith R <rar@redhat.com>
