### PR TITLE
bundle: drop fixed `:latest` version from controller image-name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/csiaddons/k8s-controller:latest
+CONTROLLER_IMG ?= quay.io/csiaddons/k8s-controller
 SIDECAR_IMG ?= quay.io/csiaddons/k8s-sidecar
 BUNDLE_IMG ?= quay.io/csiaddons/k8s-bundle
 
@@ -54,7 +54,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: bundle
 bundle: kustomize operator-sdk
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG):$(TAG)
+	cd config/manager && $(KUSTOMIZE) edit set image controller=$(CONTROLLER_IMG):$(TAG)
 	$(KUSTOMIZE) build config/default | $(OPERATOR_SDK) generate bundle --manifests --metadata --package=csi-addons --version=$(BUNDLE_VERSION)
 	mkdir -p ./bundle/tests/scorecard && $(KUSTOMIZE) build config/scorecard --output=./bundle/tests/scorecard/config.yaml
 
@@ -96,11 +96,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build -t ${CONTROLLER_IMG}:${TAG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	docker push ${CONTROLLER_IMG}:${TAG}
 
 .PHONY: docker-build-sidecar
 docker-build-sidecar:
@@ -134,7 +134,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG}:${TAG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy

--- a/config/manifests/bases/csi-addons.clusterserviceversion.yaml
+++ b/config/manifests/bases/csi-addons.clusterserviceversion.yaml
@@ -36,7 +36,7 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace


### PR DESCRIPTION
The controller image-name should use the `TAG` just as other images.
When this is not done, the bundle includes the following reference to
the image, and fails to deploy:

    quay.io/csiaddons/k8s-controller:latest:latest`

By using `TAG` as the other container images do, the bundle will refer
to the image with `:latest`, or the `TAG` that was used for creating a
release.

The InstallMode `OwnNamespace` is required for deploying with
odf-operator. If this is not set, deploying fails with the following
error:

    OwnNamespace InstallModeType not supported, cannot configure to watch own namespace

Tested-with: red-hat-storage/odf-operator#165
