### PR TITLE
Bug fixes for NetworkFence

### DIFF
--- a/api/v1alpha1/networkfence_types.go
+++ b/api/v1alpha1/networkfence_types.go
@@ -71,15 +71,12 @@ type NetworkFenceStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-
 //+kubebuilder:printcolumn:name="Driver",type="string",JSONPath=".spec.driver"
 //+kubebuilder:printcolumn:name="Cidrs",type="string",JSONPath=".spec.cidrs"
 //+kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
 //+kubebuilder:printcolumn:JSONPath=".status.result",name=Result,type=string
-
-//+kubebuilder:object:root=true
-
 //+kubebuilder:resource:path=networkfences,scope=Cluster,singular=networkfence
+
 // NetworkFence is the Schema for the networkfences API
 type NetworkFence struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
+++ b/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
@@ -15,7 +15,20 @@ spec:
     singular: networkfence
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.driver
+      name: Driver
+      type: string
+    - jsonPath: .spec.cidrs
+      name: Cidrs
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.result
+      name: Result
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: NetworkFence is the Schema for the networkfences API
@@ -148,6 +161,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/controllers/networkfence_controller.go
+++ b/controllers/networkfence_controller.go
@@ -137,7 +137,7 @@ func (r *NetworkFenceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	nwFence.Status.Result = csiaddonsv1alpha1.FencingOperationResultSucceeded
 	nwFence.Status.Message = "NetworkFence operation succeeded"
-	if err := r.Client.Update(ctx, nwFence); err != nil {
+	if err := r.Client.Status().Update(ctx, nwFence); err != nil {
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
This PR fixes the following bugs in NetworkFence:

1. Due to incorrect implementation of markers, the additional columns were not getting displayed. 
   This is now updated to show all the intended columns.

Old :
 ```
[yuggupta@fedora kubernetes-csi-addons]$ kubectl get networkfence
NAME                         AGE
networkfence-sample          3d17h
```

   New:
```
[yuggupta@fedora kubernetes-csi-addons]$ kubectl get networkfences
NAME                         DRIVER                       CIDRS                                AGE     RESULT
networkfence-sample          rook-ceph.rbd.csi.ceph.com   ["192.2.3.1/32","88.168.23.45/32"]   3d20h   Succeeded
```


2. The correct status of Networkfence CR was not getting updated after a successful operation. Added a commit to fix the same.