### PR TITLE
csiaddonsnode: update csiaddonsnode status

### DIFF
--- a/controllers/csiaddonsnode_controller.go
+++ b/controllers/csiaddonsnode_controller.go
@@ -110,7 +110,7 @@ func (r *CSIAddonsNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		errMessage := util.GetErrorMessage(err)
 		csiAddonsNode.Status.State = csiaddonsv1alpha1.CSIAddonsNodeStateFailed
 		csiAddonsNode.Status.Message = fmt.Sprintf("Failed to establish connection with sidecar: %v", errMessage)
-		statusErr := r.Client.Update(ctx, csiAddonsNode)
+		statusErr := r.Client.Status().Update(ctx, csiAddonsNode)
 		if statusErr != nil {
 			logger.Error(statusErr, "Failed to update status")
 


### PR DESCRIPTION
The correct status of csiaddonsnode CR was not
getting updated.
This commit fixes the issue.

See: https://github.com/csi-addons/kubernetes-csi-addons/pull/75#discussion_r785646113

Signed-off-by: Yug Gupta <yuggupta27@gmail.com>