### PR TITLE
build: version the bundle/CSV the same as the tag of the container-images

### DIFF
--- a/config/manifests/bases/csi-addons.clusterserviceversion.yaml
+++ b/config/manifests/bases/csi-addons.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: csi-addons.v0.0.0
+  name: csi-addons.v0.1.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -61,4 +61,4 @@ spec:
   maturity: alpha
   provider:
     name: CSI Addons Community
-  version: 0.0.0
+  version: 0.1.1


### PR DESCRIPTION
When a release is made, the git-tag is used for the version of the
container-images. It seems that ODF-Operator assumes the tag of the
container-image matches what is used as a version of the bundle/CSV.

There is no hard requirement that these versions are the same, it is
just an assumption of ODF-Operator. However, it is the first operator
that deploys CSI-Addons, and changing the operator seems more complex
than versioning csi-addons differently.

The default version in csi-addons.clusterserviceversion.yaml has now
been set to 0.1.1, the latest git-tag that was published.

Fixes: #82