### PR TITLE
controller: fix reclaimspacejob reason bug

### DIFF
--- a/controllers/reclaimspacejob_controller.go
+++ b/controllers/reclaimspacejob_controller.go
@@ -51,6 +51,9 @@ const (
 
 	// failed condition type.
 	conditionFailed = "Failed"
+	// failed reason type.
+	// TODO: add more useful reason types.
+	reasonFailed = "failed"
 )
 
 // ReclaimSpaceJobReconciler reconciles a ReclaimSpaceJob object.
@@ -429,6 +432,7 @@ func setFailedCondition(
 		ObservedGeneration: observedGeneration,
 		LastTransitionTime: metav1.NewTime(time.Now()),
 		Message:            message,
+		Reason:             reasonFailed,
 	}
 	for i := range *conditions {
 		if (*conditions)[i].Type == conditionFailed {

--- a/controllers/reclaimspacejob_controller_test.go
+++ b/controllers/reclaimspacejob_controller_test.go
@@ -45,7 +45,7 @@ func TestSetFailedCondition(t *testing.T) {
 						Status:             v1.ConditionTrue,
 						ObservedGeneration: 0,
 						LastTransitionTime: v1.NewTime(time.Now()),
-						Reason:             "",
+						Reason:             reasonFailed,
 						Message:            "err 1",
 					},
 				},


### PR DESCRIPTION
Status.Condition[*].Reason is a required field
and it needs a camelCase string to be given.
If not given, object Update will fail.

Signed-off-by: Rakshith R <rar@redhat.com>

```
1.6424997219990551e+09  ERROR   controller.reclaimspacejob      Failed to update status {"reconciler group": "csiaddons.openshift.io", "reconciler kind": "ReclaimSpaceJob", "name": "reclaimspacejob-sample", "namespace": "rook-ceph", "PVCName": "rbd-1", "PVCNamespace": "rook-ceph", "error": "ReclaimSpaceJob.csiaddons.openshift.io \"reclaimspacejob-sample\" is invalid: status.conditions.reason: Invalid value: \"\": status.conditions.reason in body should be at least 1 chars long"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
        /home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227
```