### PR TITLE
build: make kube-rbac-proxy container-image configurable

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -72,3 +72,8 @@ vars:
 #    kind: Service
 #    version: v1
 #    name: webhook-service
+
+images:
+- name: rbac-proxy
+  newName: gcr.io/kubebuilder/kube-rbac-proxy
+  newTag: v0.8.0

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: rbac-proxy
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
By setting RBAC_PROXY_IMG to a different container-image, new versions
of the kube-rbac-proxy can easily be tested. Products that include
CSI-Addons may want to provide a different location of the
container-image.

Depends-on: #86