### PR TITLE
ci: limit the platforms that are build

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -64,7 +64,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ secrets.BUILD_PLATFORMS }}
           push: true
           tags: quay.io/csiaddons/k8s-controller:latest
 
@@ -94,6 +94,6 @@ jobs:
         with:
           context: .
           file: build/Containerfile.sidecar
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ secrets.BUILD_PLATFORMS }}
           push: true
           tags: quay.io/csiaddons/k8s-sidecar:latest

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ secrets.BUILD_PLATFORMS }}
           push: false
           tags: quay.io/csiaddons/k8s-controller:latest
 
@@ -73,6 +73,6 @@ jobs:
         with:
           context: .
           file: build/Containerfile.sidecar
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ secrets.BUILD_PLATFORMS }}
           push: false
           tags: quay.io/csiaddons/k8s-sidecar:latest

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -9,7 +9,6 @@ on:
 jobs:
   build_bundle:
     name: build_bundle
-    if: github.repository == 'csi-addons/kubernetes-csi-addons'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,28 @@
+# Continuous Integration
+
+## GitHub Workflows
+
+The GitHub Workflows under [`.github/workflows/][workflows] contain jobs that
+are started when Pull-Requests are created or updated. Some of the jobs can
+build container-images for multiple architectures. Not everyone or all
+environmens wants to run the build tests for all platforms. The workflows can
+be configured to select platforms that the `docker/setup-buildx-action`
+supports.
+
+For this configuration, a new Secret should be created in the GitHub
+Settings of the repository. 'Normal' environment variables seem not possible.
+
+An example of the GitHub Secret that will build the container-images on AMD64,
+and both 32-bit and 64-bit Arm platforms:
+
+- `BUILD_PLATFORMS`: `linux/amd64,linux/arm64,linux/arm/v7`
+
+Detailed steps on creating the GitHub Secret can be found in [the GitHub
+Documentation][gh_doc_secret].
+
+In case the `BUILD_PLATFORMS` environment variable is not set, the
+`docker/setup-buildx-action` action defaults to the single architecture where
+the workflow is run (usually `linux/amd64`).
+
+[workflows]: .github/workflows/
+[gh_doc_secret]: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository


### PR DESCRIPTION
Document the GitHub Environment variable `BUILD_PLATFORMS` that is now
used in the jobs that test building container-images.