### PR TITLE
build: generate a clusterserviceversion manifest with PACKAGE_NAME

### DIFF
--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: csi-addons.v0.1.1
+  name: @PACKAGE_NAME@.v0.1.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,0 +1,5 @@
+# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
+resources:
+- ../default
+- ../scorecard


### PR DESCRIPTION
When PACKAGE_NAME is set while building the bundle, the base for the
clusterserviceversion manifest is not detected correctly. When that
happens, operator-sdk generates a new clusterserviceversion manifest
with default values.

Because the values in the clusterserviceversion manifest have a meaning,
and were tested with different deployments, a default new manifest is
not what we want included in the bundle.

By replacing the @PACKAGE_NAME@ placeholder in the
clusterserviceversion.yaml.in file before generating the bundle, the
resulting bundle now contains all the values from the base manifest,
with the correct package name.

This can be verified by running commands like:

  - make bundle PACKAGE_NAME=hello-world
  - make bundle PACKAGE_NAME=hello-world TAG=v0.0.1-alpha.42