### PR TITLE
sidecar/reclaimspace: fix staging path and volCaps for raw block pvc

### DIFF
--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -34,7 +34,7 @@ import (
 func main() {
 	var (
 		defaultTimeout     = time.Minute * 3
-		defaultStagingPath = "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/"
+		defaultStagingPath = "/var/lib/kubelet/plugins/kubernetes.io/csi/"
 		timeout            = flag.Duration("timeout", defaultTimeout, "Timeout for waiting for response")
 		csiAddonsAddress   = flag.String("csi-addons-address", "/run/csi-addons/socket", "CSI Addons endopoint")
 		nodeID             = flag.String("node-id", "", "NodeID")


### PR DESCRIPTION
error: 
```
0121 04:58:01.040729   47272 utils.go:191] ID: 1792 GRPC call: /reclaimspace.ReclaimSpaceNode/NodeReclaimSpace
I0121 04:58:01.041711   47272 utils.go:195] ID: 1792 GRPC request: {"secrets":"***stripped***","staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-e1ba208a-00e7-438c-9b98-ff9ea9ed981f/globalmount","volume_capability":{"AccessType":null,"access_mode":{"mode":7}},"volume_id":"0001-0009-rook-ceph-0000000000000005-782366e2-7a76-11ec-946e-0242ac110003"}
I0121 04:58:01.053334   47272 cephcmds.go:56] ID: 1792 an error (exit status 1) occurred while running fstrim args: [/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-e1ba208a-00e7-438c-9b98-ff9ea9ed981f/globalmount/0001-0009-rook-ceph-0000000000000005-782366e2-7a76-11ec-946e-0242ac110003]
E0121 04:58:01.053645   47272 utils.go:200] ID: 1792 GRPC error: rpc error: code = Internal desc = failed to execute "fstrim" on "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-e1ba208a-00e7-438c-9b98-ff9ea9ed981f/globalmount/0001-0009-rook-ceph-0000000000000005-782366e2-7a76-11ec-946e-0242ac110003" (an error (exit status 1) occurred while running fstrim args: [/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-e1ba208a-00e7-438c-9b98-ff9ea9ed981f/globalmount/0001-0009-rook-ceph-0000000000000005-782366e2-7a76-11ec-946e-0242ac110003]): fstrim: cannot open /var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-e1ba208a-00e7-438c-9b98-ff9ea9ed981f/globalmount/0001-0009-rook-ceph-0000000000000005-782366e2-7a76-11ec-946e-0242ac110003: No such file or directory
```

Staging path for raw Block volumes with Block access mode is
as follows:
<stagingPath>/volumeDevices/staging/<pvName>

and it also requires the following csi volcaps:

AccessType: &csi.VolumeCapability_Block{
	Block: &csi.VolumeCapability_BlockVolume{},
	},

This commit adds the above two fixes.

Signed-off-by: Rakshith R <rar@redhat.com>


After fix
```
I0121 05:52:00.055279 1008555 utils.go:191] ID: 11 GRPC call: /reclaimspace.ReclaimSpaceNode/NodeReclaimSpace
I0121 05:52:00.055379 1008555 utils.go:195] ID: 11 GRPC request: {"secrets":"***stripped***","staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-e1ba208a-00e7-438c-9b98-ff9ea9ed981f","volume_capability":{"AccessType":{"Block":{}},"access_mode":{"mode":7}},"volume_id":"0001-0009-rook-ceph-0000000000000005-782366e2-7a76-11ec-946e-0242ac110003"}
I0121 05:52:00.674636 1008555 cephcmds.go:63] ID: 11 command succeeded: blkdiscard [/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-e1ba208a-00e7-438c-9b98-ff9ea9ed981f/0001-0009-rook-ceph-0000000000000005-782366e2-7a76-11ec-946e-0242ac110003]
I0121 05:52:00.674699 1008555 utils.go:202] ID: 11 GRPC response: {}
I0121 05:52:07.085750 1008555 utils.go:191] ID: 12 GRPC call: /reclaimspace.ReclaimSpaceNode/NodeReclaimSpace
I0121 05:52:07.086053 1008555 utils.go:195] ID: 12 GRPC request: {"secrets":"***stripped***","staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-8f9d9337-aaee-4eab-8261-af65b77094ec/globalmount","volume_capability":{"AccessType":{"Mount":{}},"access_mode":{"mode":7}},"volume_id":"0001-0009-rook-ceph-0000000000000005-abc386c5-79f8-11ec-8016-0242ac110003"}
I0121 05:52:07.088746 1008555 cephcmds.go:63] ID: 12 command succeeded: fstrim [/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-8f9d9337-aaee-4eab-8261-af65b77094ec/globalmount/0001-0009-rook-ceph-0000000000000005-abc386c5-79f8-11ec-8016-0242ac110003]
```