### PR TITLE
controller: adds yaml to install and deploy controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,10 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: controller-gen kustomize ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="{./api/...,./cmd/...,./controllers/...,./sidecar/...}" output:crd:artifacts:config=config/crd/bases
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${CONTROLLER_IMG} $(KUSTOMIZE_RBAC_PROXY)
+	$(KUSTOMIZE) build config/default > deploy/controller/setup-controller.yaml
 
 # generate the <package-name>.clusterserviceversion.yaml
 config/manifests/bases/$(PACKAGE_NAME).clusterserviceversion.yaml: config/manifests/bases/clusterserviceversion.yaml.in

--- a/deploy/controller/setup-controller.yaml
+++ b/deploy/controller/setup-controller.yaml
@@ -1,0 +1,1050 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: csi-addons-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: csiaddonsnodes.csiaddons.openshift.io
+spec:
+  group: csiaddons.openshift.io
+  names:
+    kind: CSIAddonsNode
+    listKind: CSIAddonsNodeList
+    plural: csiaddonsnodes
+    singular: csiaddonsnode
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.namespace
+      name: namespace
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.driver.name
+      name: DriverName
+      type: string
+    - jsonPath: .spec.driver.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .spec.driver.nodeID
+      name: NodeID
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CSIAddonsNode is the Schema for the csiaddonsnode API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CSIAddonsNodeSpec defines the desired state of CSIAddonsNode
+            properties:
+              driver:
+                description: Driver is the information of the CSI Driver existing
+                  on a node. If the driver is uninstalled, this can become empty.
+                properties:
+                  endpoint:
+                    description: EndPoint is url that contains the ip-address to which
+                      the CSI-Addons side-car listens to.
+                    type: string
+                  name:
+                    description: 'Name is the name of the CSI driver that this object
+                      refers to. This must be the same name returned by the CSI-Addons
+                      GetIdentity() call for that driver. The name of the driver is
+                      in the format: `example.csi.ceph.com`'
+                    type: string
+                  nodeID:
+                    description: NodeID is the ID of the node to identify on which
+                      node the side-car is running.
+                    type: string
+                required:
+                - endpoint
+                - name
+                - nodeID
+                type: object
+            required:
+            - driver
+            type: object
+          status:
+            description: CSIAddonsNodeStatus defines the observed state of CSIAddonsNode
+            properties:
+              message:
+                description: Messgae is a human-readable message indicating details
+                  about why the CSIAddonsNode is in this state.
+                type: string
+              reason:
+                description: Reason is a brief CamelCase string that describes any
+                  failure and is meant for machine parsing and tidy display in the
+                  CLI.
+                type: string
+              state:
+                description: State represents the state of the CSIAddonsNode object.
+                  It informs whether or not the CSIAddonsNode is Connected to the
+                  CSI Driver.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: networkfences.csiaddons.openshift.io
+spec:
+  group: csiaddons.openshift.io
+  names:
+    kind: NetworkFence
+    listKind: NetworkFenceList
+    plural: networkfences
+    singular: networkfence
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.driver
+      name: Driver
+      type: string
+    - jsonPath: .spec.cidrs
+      name: Cidrs
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.result
+      name: Result
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NetworkFence is the Schema for the networkfences API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NetworkFenceSpec defines the desired state of NetworkFence
+            properties:
+              cidrs:
+                description: Cidrs contains a list of CIDR blocks, which are required
+                  to be fenced.
+                items:
+                  type: string
+                type: array
+              driver:
+                description: Driver contains  the name of CSI driver.
+                type: string
+              parameters:
+                additionalProperties:
+                  type: string
+                description: Parameters is used to pass additional parameters to the
+                  CSI driver.
+                type: object
+              secret:
+                description: Secret is a kubernetes secret, which is required to perform
+                  the fence/unfence operation.
+                properties:
+                  name:
+                    description: Name specifies the name of the secret.
+                    type: string
+                  namespace:
+                    description: Namespace specifies the namespace in which the secret
+                      is located.
+                    type: string
+                type: object
+            required:
+            - cidrs
+            - driver
+            type: object
+          status:
+            description: NetworkFenceStatus defines the observed state of NetworkFence
+            properties:
+              conditions:
+                description: Conditions are the list of conditions and their status.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                description: Message contains any message from the NetworkFence operation.
+                type: string
+              result:
+                description: Result indicates the result of NetworkFence operation.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: reclaimspacecronjobs.csiaddons.openshift.io
+spec:
+  group: csiaddons.openshift.io
+  names:
+    kind: ReclaimSpaceCronJob
+    listKind: ReclaimSpaceCronJobList
+    plural: reclaimspacecronjobs
+    singular: reclaimspacecronjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - jsonPath: .spec.suspend
+      name: Suspend
+      type: boolean
+    - jsonPath: .status.active.name
+      name: Active
+      type: string
+    - jsonPath: .status.lastScheduleTime
+      name: Lastschedule
+      type: date
+    - jsonPath: .status.lastSuccessfulTime
+      name: Lastsuccessfultime
+      priority: 1
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ReclaimSpaceCronJob is the Schema for the reclaimspacecronjobs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ReclaimSpaceCronJobSpec defines the desired state of ReclaimSpaceJob
+            properties:
+              concurrencyPolicy:
+                default: Forbid
+                description: 'Specifies how to treat concurrent executions of a Job.
+                  Valid values are: - "Forbid" (default): forbids concurrent runs,
+                  skipping next run if previous run hasn''t finished yet; - "Replace":
+                  cancels currently running job and replaces it with a new one'
+                enum:
+                - Forbid
+                - Replace
+                type: string
+              failedJobsHistoryLimit:
+                default: 1
+                description: The number of failed finished jobs to retain. Value must
+                  be non-negative integer. Defaults to 1.
+                format: int32
+                maximum: 60
+                minimum: 0
+                type: integer
+              jobTemplate:
+                description: Specifies the job that will be created when executing
+                  a CronJob.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata of the jobs created
+                      from this template. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the job.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                    properties:
+                      backOffLimit:
+                        default: 6
+                        description: BackOffLimit specifies the number of retries
+                          allowed before marking reclaim space operation as failed.
+                          If not specified, defaults to 6. Maximum allowed value is
+                          60 and minimum allowed value is 0.
+                        format: int32
+                        maximum: 60
+                        minimum: 0
+                        type: integer
+                      retryDeadlineSeconds:
+                        default: 600
+                        description: RetryDeadlineSeconds specifies the duration in
+                          seconds relative to the start time that the operation may
+                          be retried; value MUST be positive integer. If not specified,
+                          defaults to 600 seconds. Maximum allowed value is 1800.
+                        format: int64
+                        maximum: 1800
+                        minimum: 0
+                        type: integer
+                      target:
+                        description: Target represents volume target on which the
+                          operation will be performed.
+                        properties:
+                          persistentVolumeClaim:
+                            description: PersistentVolumeClaim specifies the target
+                              PersistentVolumeClaim name.
+                            type: string
+                        type: object
+                    required:
+                    - target
+                    type: object
+                type: object
+              schedule:
+                description: The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+                pattern: .+
+                type: string
+              startingDeadlineSeconds:
+                description: Optional deadline in seconds for starting the job if
+                  it misses scheduled time for any reason.  Missed jobs executions
+                  will be counted as failed ones.
+                format: int64
+                type: integer
+              successfulJobsHistoryLimit:
+                default: 3
+                description: The number of successful finished jobs to retain. Value
+                  must be non-negative integer. Defaults to 3.
+                format: int32
+                maximum: 60
+                minimum: 0
+                type: integer
+              suspend:
+                description: This flag tells the controller to suspend subsequent
+                  executions, it does not apply to already started executions.  Defaults
+                  to false.
+                type: boolean
+            required:
+            - jobTemplate
+            - schedule
+            type: object
+          status:
+            description: ReclaimSpaceCronJobStatus defines the observed state of ReclaimSpaceJob
+            properties:
+              active:
+                description: A pointer to currently running job.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+              lastScheduleTime:
+                description: Information when was the last time the job was successfully
+                  scheduled.
+                format: date-time
+                type: string
+              lastSuccessfulTime:
+                description: Information when was the last time the job successfully
+                  completed.
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: reclaimspacejobs.csiaddons.openshift.io
+spec:
+  group: csiaddons.openshift.io
+  names:
+    kind: ReclaimSpaceJob
+    listKind: ReclaimSpaceJobList
+    plural: reclaimspacejobs
+    singular: reclaimspacejob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.namespace
+      name: Namespace
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.retries
+      name: Retries
+      type: integer
+    - jsonPath: .status.result
+      name: Result
+      type: string
+    - jsonPath: .status.reclaimedSpace
+      name: ReclaimedSpace
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ReclaimSpaceJob is the Schema for the reclaimspacejobs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ReclaimSpaceJobSpec defines the desired state of ReclaimSpaceJob
+            properties:
+              backOffLimit:
+                default: 6
+                description: BackOffLimit specifies the number of retries allowed
+                  before marking reclaim space operation as failed. If not specified,
+                  defaults to 6. Maximum allowed value is 60 and minimum allowed value
+                  is 0.
+                format: int32
+                maximum: 60
+                minimum: 0
+                type: integer
+              retryDeadlineSeconds:
+                default: 600
+                description: RetryDeadlineSeconds specifies the duration in seconds
+                  relative to the start time that the operation may be retried; value
+                  MUST be positive integer. If not specified, defaults to 600 seconds.
+                  Maximum allowed value is 1800.
+                format: int64
+                maximum: 1800
+                minimum: 0
+                type: integer
+              target:
+                description: Target represents volume target on which the operation
+                  will be performed.
+                properties:
+                  persistentVolumeClaim:
+                    description: PersistentVolumeClaim specifies the target PersistentVolumeClaim
+                      name.
+                    type: string
+                type: object
+            required:
+            - target
+            type: object
+          status:
+            description: ReclaimSpaceJobStatus defines the observed state of ReclaimSpaceJob
+            properties:
+              completionTime:
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions are the list of conditions and their status.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                description: Message contains any message from the ReclaimSpaceJob.
+                type: string
+              reclaimedSpace:
+                anyOf:
+                - type: integer
+                - type: string
+                description: ReclaimedSpace indicates the amount of space reclaimed.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              result:
+                description: Result indicates the result of ReclaimSpaceJob.
+                type: string
+              retries:
+                description: Retries indicates the number of times the operation is
+                  retried.
+                format: int32
+                type: integer
+              startTime:
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-addons-controller-manager
+  namespace: csi-addons-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: csi-addons-leader-election-role
+  namespace: csi-addons-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: csi-addons-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - csiaddonsnodes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - networkfences
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - networkfences/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - networkfences/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - reclaimspacecronjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - reclaimspacecronjobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - reclaimspacecronjobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - reclaimspacejobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - reclaimspacejobs/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
+  - reclaimspacejobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-addons-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-addons-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: csi-addons-leader-election-rolebinding
+  namespace: csi-addons-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: csi-addons-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: csi-addons-controller-manager
+  namespace: csi-addons-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-addons-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-addons-manager-role
+subjects:
+- kind: ServiceAccount
+  name: csi-addons-controller-manager
+  namespace: csi-addons-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-addons-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-addons-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: csi-addons-controller-manager
+  namespace: csi-addons-system
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: e8cd140a.openshift.io
+kind: ConfigMap
+metadata:
+  name: csi-addons-manager-config
+  namespace: csi-addons-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: csi-addons-controller-manager-metrics-service
+  namespace: csi-addons-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: csi-addons-controller-manager
+  namespace: csi-addons-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /manager
+        image: quay.io/csiaddons/k8s-controller:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: csi-addons-controller-manager
+      terminationGracePeriodSeconds: 10


### PR DESCRIPTION
this commit adds raw yaml generated using kustomize
in deploy/crds.yaml which can be used by others to
directly deploy the controller

Fixes: #105

Signed-off-by: yati1998 <ypadia@redhat.com>