### PR TITLE
deploy: fix setting rbac-proxy image in kustomize files

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,10 +12,7 @@ namePrefix: csi-addons-
 #commonLabels:
 #  someName: someValue
 
-bases:
-- ../crd
-- ../rbac
-- ../manager
+# bases:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
@@ -24,10 +21,10 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
+patchesStrategicMerge:
 - manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
@@ -44,7 +41,7 @@ patchesStrategicMerge:
 #- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
-vars:
+# vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 #- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
 #  objref:
@@ -77,3 +74,9 @@ images:
 - name: rbac-proxy
   newName: gcr.io/kubebuilder/kube-rbac-proxy
   newTag: v0.8.0
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../crd
+- ../rbac
+- ../manager


### PR DESCRIPTION
` cd config/manager && $(KUSTOMIZE) edit set image
 controller=${CONTROLLER_IMG} $(KUSTOMIZE_RBAC_PROXY)`
The above command did not set rbax-proxy image since this
image variable was part of config/default/kustomization.yaml.
This commit fixes this issue and does some cleanup in the Makefile
and config/default/kustomization.yaml(running the cmd moved
/removed some default parameters).

Signed-off-by: Rakshith R <rar@redhat.com>

Currently 
```
[rakshith@fedora kubernetes-csi-addons]$ RBAC_PROXY_IMG=gcr.io/kubebuilder/kube-rbac-proxy:v0.9.0 make manifests 
make: go: Permission denied
go build -o /home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/bin/controller-gen ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
go build -o /home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/bin/kustomize ./vendor/sigs.k8s.io/kustomize/kustomize/v4
/home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/bin/controller-gen rbac:roleName=manager-role crd webhook paths="{./api/...,./cmd/...,./controllers/...,./sidecar/...}" output:crd:artifacts:config=config/crd/bases
cd config/manager && /home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/bin/kustomize edit set image controller=quay.io/csiaddons/k8s-controller:latest rbac-proxy=gcr.io/kubebuilder/kube-rbac-proxy:v0.9.0
/home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/bin/kustomize build config/default > deploy/controller/setup-controller.yaml
[rakshith@fedora kubernetes-csi-addons]$ git diff
diff --git a/config/manager/kustomization.yaml b/config/manager/kustomization.yaml
index 98ef21b..7956db1 100644
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,3 +14,6 @@ images:
 - name: controller
   newName: quay.io/csiaddons/k8s-controller
   newTag: latest
+- name: rbac-proxy
+  newName: gcr.io/kubebuilder/kube-rbac-proxy
+  newTag: v0.9.0
```

After fix
```
[rakshith@fedora kubernetes-csi-addons]$ RBAC_PROXY_IMG=gcr.io/kubebuilder/kube-rbac-proxy:v0.9.0 make manifests 
make: go: Permission denied
go build -o /home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/bin/controller-gen ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
go build -o /home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/bin/kustomize ./vendor/sigs.k8s.io/kustomize/kustomize/v4
/home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/bin/controller-gen rbac:roleName=manager-role crd webhook paths="{./api/...,./cmd/...,./controllers/...,./sidecar/...}" output:crd:artifacts:config=config/crd/bases
cd config/default && /home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/bin/kustomize edit set image rbac-proxy=gcr.io/kubebuilder/kube-rbac-proxy:v0.9.0
cd config/manager && /home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/bin/kustomize edit set image controller=quay.io/csiaddons/k8s-controller:latest
/home/rakshith/workspace/src/github.com/csi-addons/kubernetes-csi-addons/bin/kustomize build config/default > deploy/controller/setup-controller.yaml
[rakshith@fedora kubernetes-csi-addons]$ git diff
diff --git a/config/default/kustomization.yaml b/config/default/kustomization.yaml
index 8250834..62b9329 100644
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -73,7 +73,7 @@ patchesStrategicMerge:
 images:
 - name: rbac-proxy
   newName: gcr.io/kubebuilder/kube-rbac-proxy
-  newTag: v0.8.0
+  newTag: v0.9.0
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
diff --git a/deploy/controller/setup-controller.yaml b/deploy/controller/setup-controller.yaml
index 490d38f..a628c18 100644
--- a/deploy/controller/setup-controller.yaml
+++ b/deploy/controller/setup-controller.yaml
@@ -1009,7 +1009,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.9.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
```