### PR TITLE
use a unique label for csi-addons resources

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -4,18 +4,18 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: csi-addons
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        app.kubernetes.io/name: csi-addons
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: csi-addons

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons
   name: controller-manager-metrics-service
   namespace: system
 spec:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons

--- a/config/rbac/namespace.yaml
+++ b/config/rbac/namespace.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons
   name: system

--- a/deploy/controller/rbac.yaml
+++ b/deploy/controller/rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons
   name: csi-addons-system
 ---
 apiVersion: v1
@@ -271,7 +271,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons
   name: csi-addons-controller-manager-metrics-service
   namespace: csi-addons-system
 spec:
@@ -281,4 +281,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons

--- a/deploy/controller/setup-controller.yaml
+++ b/deploy/controller/setup-controller.yaml
@@ -21,20 +21,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: csi-addons
   name: csi-addons-controller-manager
   namespace: csi-addons-system
 spec:
   replicas: 1
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/name: csi-addons
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        app.kubernetes.io/name: csi-addons
     spec:
       containers:
       - args:


### PR DESCRIPTION
csi-addon operator is using the default label and labelSelector provided by operator-sdk `control-plane: controller-manager` for its resources, this is a generic label and it can cause problems when multiple resources use the same labels changing the label to unique one.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>