### PR TITLE
ci: require `build_bundle` test to pass

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,6 +11,7 @@ queue_rules:
   - name: default
     conditions:
       - "status-success=codespell"
+      - "status-success=build_bundle"
       - "status-success=build_controller"
       - "status-success=build_sidecar"
       - "status-success=go_mod_verify"
@@ -31,6 +32,7 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - "status-success=codespell"
+      - "status-success=build_bundle"
       - "status-success=build_controller"
       - "status-success=build_sidecar"
       - "status-success=go_mod_verify"
@@ -49,6 +51,7 @@ pull_request_rules:
       - "approved-reviews-by=@csi-addons/kubernetes-csi-addons-contributors"
       - "approved-reviews-by=@csi-addons/kubernetes-csi-addons-reviewers"
       - "status-success=codespell"
+      - "status-success=build_bundle"
       - "status-success=build_controller"
       - "status-success=build_sidecar"
       - "status-success=go_mod_verify"


### PR DESCRIPTION
build_bundle is working well, and required to push the bundle so that
installing from Operator Hub is possible. Mergify should require passing
the build_bundle test as well.