### PR TITLE
csv: use "csi-addons.github.io" for main website

### DIFF
--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -54,7 +54,7 @@ spec:
   - csi
   links:
   - name: CSI Addons
-    url: https://github.com/csi-addons
+    url: https://csi-addons.github.io
   maintainers:
   - email: csi-addons@redhat.com
     name: CSI Addons Community


### PR DESCRIPTION
Currently the CSV points to the GitHub organization, but there is a
(minimal) website at https://csi-addons.github.io which should be the
main entry point for users.