### PR TITLE
ci: add ability to have replaces,skips in CSV

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,16 @@ endif
 # bundle should use a different PACKAGE_NAME to prevent conflicts.
 PACKAGE_NAME ?= csi-addons
 
+# Each CSV has a replaces parameter that indicates which Operator it replaces.
+# This builds a graph of CSVs that can be queried by OLM, and updates can be
+# shared between channels. Channels can be thought of as entry points into
+# the graph of updates:
+REPLACES ?= ""
+
+# Creating the New CatalogSource requires publishing CSVs that replace one Operator,
+# but can skip several. This can be accomplished using the skipRange annotation:
+SKIP_RANGE ?= ""
+
 # By setting RBAC_PROXY_IMG to a different container-image, new versions of
 # the kube-rbac-proxy can easily be tested. Products that include CSI-Addons
 # may want to provide a different location of the container-image.
@@ -87,12 +97,13 @@ manifests: controller-gen kustomize ## Generate WebhookConfiguration, ClusterRol
 	$(KUSTOMIZE) build config/rbac > deploy/controller/rbac.yaml
 	$(KUSTOMIZE) build config/manager > deploy/controller/setup-controller.yaml
 
-# generate the <package-name>.clusterserviceversion.yaml
-config/manifests/bases/$(PACKAGE_NAME).clusterserviceversion.yaml: config/manifests/bases/clusterserviceversion.yaml.in
-	sed 's/@PACKAGE_NAME@/$(PACKAGE_NAME)/g' < $^ > $@
+# generate the <package-name>.clusterserviceversion.yaml base
+gen-csv-base:
+	sed 's/@PACKAGE_NAME@/$(PACKAGE_NAME)/g;s/@SKIP_RANGE@/$(SKIP_RANGE)/g;s/@REPLACES@/$(REPLACES)/g' \
+	< config/manifests/bases/clusterserviceversion.yaml.in > config/manifests/bases/$(PACKAGE_NAME).clusterserviceversion.yaml
 
 .PHONY: bundle
-bundle: config/manifests/bases/$(PACKAGE_NAME).clusterserviceversion.yaml manifests operator-sdk
+bundle: gen-csv-base manifests operator-sdk
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle --manifests --metadata --package=$(PACKAGE_NAME) $(BUNDLE_VERSION)
 
 .PHONY: generate

--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    olm.skipRange: @SKIP_RANGE@
   name: @PACKAGE_NAME@.v0.1.1
   namespace: placeholder
 spec:
@@ -62,3 +63,4 @@ spec:
   provider:
     name: CSI Addons Community
   version: 0.1.1
+  replaces: @REPLACES@


### PR DESCRIPTION
Each CSV has a replaces parameter that indicates
which Operator it replaces. This builds a graph of
CSVs that can be queried by OLM, and updates can be
shared between channels. Channels can be thought of
as entry points into the graph of updates:
REPLACES ?= ""

Creating the New CatalogSource requires publishing CSVs
that replace one Operator, but can skip several. This can
be accomplished using the skipRange annotation:
SKIP_RANGE ?= ""

Signed-off-by: Rakshith R <rar@redhat.com>

Refer: https://github.com/red-hat-storage/odf-operator/commit/e1c41bee0b26731a923eb06f5fc3e047539bfd6a

cc @nixpanic @Madhu-1 @iamniting