### PR TITLE
Use `pod://` URL formatting for CSIAddonsNode endpoints

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -37,6 +37,14 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - csiaddons.openshift.io
   resources:
   - csiaddonsnodes

--- a/controllers/csiaddons/csiaddonsnode_controller_test.go
+++ b/controllers/csiaddons/csiaddonsnode_controller_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2022 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseEndpoint(t *testing.T) {
+	_, _, _, err := parseEndpoint("1.2.3.4:5678")
+	assert.True(t, errors.Is(err, errLegacyEndpoint))
+
+	namespace, podname, port, err := parseEndpoint("pod://pod-name:5678")
+	assert.NoError(t, err)
+	assert.Equal(t, namespace, "")
+	assert.Equal(t, podname, "pod-name")
+	assert.Equal(t, port, "5678")
+
+	namespace, podname, port, err = parseEndpoint("pod://pod-name.csi-addons:5678")
+	assert.NoError(t, err)
+	assert.Equal(t, namespace, "csi-addons")
+	assert.Equal(t, podname, "pod-name")
+	assert.Equal(t, port, "5678")
+
+	_, _, _, err = parseEndpoint("pod://pod.ns.cluster.local:5678")
+	assert.Error(t, err)
+}

--- a/deploy/controller/rbac.yaml
+++ b/deploy/controller/rbac.yaml
@@ -87,6 +87,14 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - csiaddons.openshift.io
   resources:
   - csiaddonsnodes

--- a/docs/csiaddonsnode.md
+++ b/docs/csiaddonsnode.md
@@ -9,11 +9,11 @@ metadata:
   name: csiaddonsnode-sample
 spec:
     driver:
-        name: example.csi.ceph.com
-        endpoint: <url>
+        name: driver.csi.example.io
+        endpoint: pod://csiaddonsnode-sample.csi-addons-system:9070
         nodeID: node-1
 ```
 + `driver` contains the required information about the CSI driver.
-    + `name` contains the name of the driver. The name of the driver is in the format: `rbd/cephfs.csi.ceph.com`
-    + `endpoint` contains the url that contains the ip-address to which the CSI-Addons side-car listens to.
+    + `name` contains the name of the driver. The name of the driver is in the format: `driver.csi.example.io`
+    + `endpoint` contains the URL that contains the name of the Pod and its Namespace that can be used by the controller to connect to.
     + `nodeID` contains the ID of node to identify on which node the side-car is running.

--- a/sidecar/internal/server/server.go
+++ b/sidecar/internal/server/server.go
@@ -77,7 +77,7 @@ func (ss *SidecarServer) Start() {
 
 	listener, err := net.Listen(ss.scheme, ss.endpoint)
 	if err != nil {
-		klog.Fatalf("failed to listen on %q: %w", listener.Addr(), err)
+		klog.Fatalf("failed to listen on %s (%s): %v", ss.endpoint, ss.scheme, err)
 	}
 
 	ss.serve(listener)

--- a/sidecar/internal/server/server.go
+++ b/sidecar/internal/server/server.go
@@ -43,9 +43,10 @@ type SidecarServer struct {
 	services []SidecarService
 }
 
-// NewSidecarServer create a new SidecarServer on the given endpoint. The
-// endpoint should be an ip address. Only tcp ports are supported.
-func NewSidecarServer(endpoint string) *SidecarServer {
+// NewSidecarServer create a new SidecarServer on the given IP-address and
+// port. If the IP-address is an empty string, the server will listen on all
+// available IP-addresses. Only tcp ports are supported.
+func NewSidecarServer(ip, port string) *SidecarServer {
 	ss := &SidecarServer{}
 
 	if ss.services == nil {
@@ -53,7 +54,7 @@ func NewSidecarServer(endpoint string) *SidecarServer {
 	}
 
 	ss.scheme = "tcp"
-	ss.endpoint = endpoint
+	ss.endpoint = ip + ":" + port
 
 	return ss
 }

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 	flag.Parse()
 
-	controllerEndpoint, err := util.ValidateControllerEndpoint(*controllerIP, *controllerPort)
+	controllerEndpoint, err := util.BuildEndpointURL(*controllerIP, *controllerPort, *podName, *podNamespace)
 	if err != nil {
 		klog.Fatalf("Failed to validate controller endpoint: %w", err)
 	}

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -92,7 +92,7 @@ func main() {
 		klog.Fatalf("Failed to create csiaddonsnode: %v", err)
 	}
 
-	sidecarServer := server.NewSidecarServer(controllerEndpoint)
+	sidecarServer := server.NewSidecarServer(*controllerIP, *controllerPort)
 	sidecarServer.RegisterService(service.NewIdentityServer(csiClient.GetGRPCClient()))
 	sidecarServer.RegisterService(service.NewReclaimSpaceServer(csiClient.GetGRPCClient(), kubeClient, *stagingPath))
 	sidecarServer.RegisterService(service.NewNetworkFenceServer(csiClient.GetGRPCClient(), kubeClient))


### PR DESCRIPTION
When there is no `controller-ip` parameter set, the endpoint in the
CSIAddonsNode CR will be set to `pod://<name>.<namespace>:<port>`. The
Controller can then get the PodIP through the Kubernetes API. This makes
sure that the CSIAddonsNode does not need to be updated when the
IP-address of the Pod hosting the sidecar changes.

Closes: #186