### PR TITLE
ci: update GitHub Actions with Depandabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,12 @@ updates:
       prefix: "vendor"
     labels:
       - vendor
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - testing


### PR DESCRIPTION
Dependabot can update GitHub Actions in the workflows. It is useful to have them updated regularly so that enhancements and bugfixes get included.