### PR TITLE
provide option to set MaxConcurrentReconciles

### DIFF
--- a/controllers/csiaddons/csiaddonsnode_controller.go
+++ b/controllers/csiaddons/csiaddonsnode_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -149,10 +150,11 @@ func (r *CSIAddonsNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *CSIAddonsNodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *CSIAddonsNodeReconciler) SetupWithManager(mgr ctrl.Manager, ctrlOptions controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&csiaddonsv1alpha1.CSIAddonsNode{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithOptions(ctrlOptions).
 		Complete(r)
 }
 

--- a/controllers/csiaddons/networkfence_controller.go
+++ b/controllers/csiaddons/networkfence_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -186,10 +187,11 @@ func (nf *NetworkFenceInstance) updateStatus(ctx context.Context,
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *NetworkFenceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *NetworkFenceReconciler) SetupWithManager(mgr ctrl.Manager, ctrlOptions controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&csiaddonsv1alpha1.NetworkFence{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithOptions(ctrlOptions).
 		Complete(r)
 }
 

--- a/controllers/csiaddons/persistentvolumeclaim_controller.go
+++ b/controllers/csiaddons/persistentvolumeclaim_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -168,7 +169,7 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *PersistentVolumeClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *PersistentVolumeClaimReconciler) SetupWithManager(mgr ctrl.Manager, ctrlOptions controller.Options) error {
 	err := mgr.GetFieldIndexer().IndexField(
 		context.Background(),
 		&csiaddonsv1alpha1.ReclaimSpaceCronJob{},
@@ -204,6 +205,7 @@ func (r *PersistentVolumeClaimReconciler) SetupWithManager(mgr ctrl.Manager) err
 		For(&corev1.PersistentVolumeClaim{}).
 		Owns(&csiaddonsv1alpha1.ReclaimSpaceCronJob{}).
 		WithEventFilter(pred).
+		WithOptions(ctrlOptions).
 		Complete(r)
 }
 

--- a/controllers/csiaddons/reclaimspacecronjob_controller.go
+++ b/controllers/csiaddons/reclaimspacecronjob_controller.go
@@ -32,6 +32,7 @@ import (
 	ref "k8s.io/client-go/tools/reference"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -190,7 +191,7 @@ func (r *ReclaimSpaceCronJobReconciler) Reconcile(ctx context.Context, req ctrl.
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ReclaimSpaceCronJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ReclaimSpaceCronJobReconciler) SetupWithManager(mgr ctrl.Manager, ctrlOptions controller.Options) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &csiaddonsv1alpha1.ReclaimSpaceJob{}, jobOwnerKey, func(rawObj client.Object) []string {
 		// extract the owner from job object.
 		job, ok := rawObj.(*csiaddonsv1alpha1.ReclaimSpaceJob)
@@ -213,6 +214,7 @@ func (r *ReclaimSpaceCronJobReconciler) SetupWithManager(mgr ctrl.Manager) error
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&csiaddonsv1alpha1.ReclaimSpaceCronJob{}).
 		Owns(&csiaddonsv1alpha1.ReclaimSpaceJob{}).
+		WithOptions(ctrlOptions).
 		Complete(r)
 }
 

--- a/controllers/csiaddons/reclaimspacejob_controller.go
+++ b/controllers/csiaddons/reclaimspacejob_controller.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -160,10 +161,11 @@ func (r *ReclaimSpaceJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ReclaimSpaceJobReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *ReclaimSpaceJobReconciler) SetupWithManager(mgr ctrl.Manager, ctrlOptions controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&csiaddonsv1alpha1.ReclaimSpaceJob{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithOptions(ctrlOptions).
 		Complete(r)
 }
 

--- a/docs/deploy-controller.md
+++ b/docs/deploy-controller.md
@@ -2,6 +2,18 @@
 
 The CSI-Addons Controller can be deployed by different ways:
 
+## Configuration
+
+**Available command line arguments:**
+
+| Option                        | Default value   | Description                 |
+| ----------------------------- | --------------- | --------------------------------------------- |
+| `--metrics-bind-address`      | `:8080`         | The address the metric endpoint binds to.     |
+| `--health-probe-bind-address` | `:8081`         | The address the probe endpoint binds to.      |
+| `--leader-elect`              | `false`         | Enable leader election for controller manager.|
+| `--reclaim-space-timeout`     | `3m`            | Timeout for reclaimspace operation            |
+| `--max-concurrent-reconciles` | 100             | Maximum number of concurrent reconciles       |
+
 ## Installation for versioned deployments
 
 The CSI-Addons Controller can also be installed  using the yaml files in `deploy/controller`.
@@ -21,7 +33,7 @@ customresourcedefinition.apiextensions.k8s.io/reclaimspacecronjobs.csiaddons.ope
 customresourcedefinition.apiextensions.k8s.io/reclaimspacejobs.csiaddons.openshift.io created
 
 $ kubectl create -f rbac.yaml
-... 
+...
 serviceaccount/csi-addons-controller-manager created
 role.rbac.authorization.k8s.io/csi-addons-leader-election-role created
 clusterrole.rbac.authorization.k8s.io/csi-addons-manager-role created


### PR DESCRIPTION
Current MaxConcurrentReconciles is 1, which is the default, meaning only one request will be processed at a time. This is not useful when we have 100/1000 CR to reconcile, which can affect the performance. This PR provides a way to set the MaxConcurrentReconciles to the user's desired value so that the user can tune the configuration based on the requirement.

Note:- Currently we have performance issue in DR VolRep because of this one, the failover and failback time are slightly affected because of the default value. with this, things will be better and same change need to be done when we add VolRep Reconciler also.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>