### PR TITLE
controllers: Use ISO 8601 timestamp format in logs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -25,6 +25,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -72,6 +73,7 @@ func main() {
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 100, "Maximum number of concurrent reconciles")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/operator-framework/operator-sdk v1.22.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.8.0
+	go.uber.org/zap v1.19.1
 	google.golang.org/grpc v1.48.0
 	google.golang.org/protobuf v1.28.1
 	k8s.io/api v0.24.4
@@ -207,7 +208,6 @@ require (
 	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220408190544-5352b0902921 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect


### PR DESCRIPTION
Use ISO 8601 for better timestamp readability from logs.

we can also use kubectl logs --timestamps=true options for the timestamp.

Ref: https://github.com/RamenDR/ramen/pull/499

fixes #198 

## without fix

```
./bin/manager
1.6612317914296057e+09	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": ":8080"}
I0823 10:46:32.570418 1458419 request.go:601] Waited for 1.049527477s due to client-side throttling, not priority and fairness, request: GET:https://192.168.39.26:8443/apis/policy/v1?timeout=32s
1.661231793128033e+09	ERROR	setup	unable to create controller	{"controller": "ReclaimSpaceCronJob", "error": "no matches for kind \"ReclaimSpaceJob\" in version \"csiaddons.openshift.io/v1alpha1\""}
main.main
	/home/mrajanna/workspace/src/github.com/csi-addons/kubernetes-csi-addons/cmd/manager/main.go:130
runtime.main
	/usr/local/go/src/runtime/proc.go:250

```

## with this Fix

```
./bin/manager
2022-08-23T10:48:39.306+0530	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": ":8080"}
I0823 10:48:40.454459 1460747 request.go:601] Waited for 1.04569822s due to client-side throttling, not priority and fairness, request: GET:https://192.168.39.26:8443/apis/autoscaling/v2beta2?timeout=32s
2022-08-23T10:48:41.006+0530	ERROR	setup	unable to create controller	{"controller": "ReclaimSpaceCronJob", "error": "no matches for kind \"ReclaimSpaceJob\" in version \"csiaddons.openshift.io/v1alpha1\""}
main.main
	/home/mrajanna/workspace/src/github.com/csi-addons/kubernetes-csi-addons/cmd/manager/main.go:132
runtime.main
	/usr/local/go/src/runtime/proc.go:250

```
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>