### PR TITLE
Ensure only one VR per PVC

### DIFF
--- a/apis/replication.storage/v1alpha1/volumereplication_types.go
+++ b/apis/replication.storage/v1alpha1/volumereplication_types.go
@@ -21,6 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	VolumeReplicationNameAnnotation = "replication.storage.openshift.io/volume-replication-name"
+)
+
 // ReplicationState represents the replication operations to be performed on the volume.
 // +kubebuilder:validation:Enum=primary;secondary;resync
 type ReplicationState string

--- a/controllers/replication.storage/volumereplication_controller.go
+++ b/controllers/replication.storage/volumereplication_controller.go
@@ -172,6 +172,12 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		logger.Info("Replication handle", "ReplicationHandleName", replicationHandle)
 	}
 
+	err = r.annotatePVCWithOwner(ctx, logger, nameSpacedName, pvc)
+	if err != nil {
+		logger.Error(err, "Failed to annotate PVC owner")
+		return ctrl.Result{}, err
+	}
+
 	replicationClient, err := r.getReplicationClient(vrcObj.Spec.Provisioner)
 	if err != nil {
 		logger.Error(err, "Failed to get ReplicationClient")


### PR DESCRIPTION
VolumeReplication should ensure there is only one VR per PVC, as otherwise, it can lead to orchestrating the
PVC is based on multiple VRs to an inconsistent state. With this Patch only one VR will operate on a single PVC.


Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>