### PR TITLE
replication: remove annotation from pvc

### DIFF
--- a/controllers/replication.storage/pvc.go
+++ b/controllers/replication.storage/pvc.go
@@ -91,3 +91,18 @@ func (r *VolumeReplicationReconciler) annotatePVCWithOwner(ctx context.Context, 
 
 	return nil
 }
+
+// removeOwnerFromPVCAnnotation removes the VolumeReplication owner from the PVC annotations.
+func (r *VolumeReplicationReconciler) removeOwnerFromPVCAnnotation(ctx context.Context, logger logr.Logger, pvc *corev1.PersistentVolumeClaim) error {
+	if _, ok := pvc.ObjectMeta.Annotations[replicationv1alpha1.VolumeReplicationNameAnnotation]; ok {
+		logger.Info("removing owner annotation from PersistentVolumeClaim object", "Annotation", replicationv1alpha1.VolumeReplicationNameAnnotation)
+		delete(pvc.ObjectMeta.Annotations, replicationv1alpha1.VolumeReplicationNameAnnotation)
+		if err := r.Client.Update(ctx, pvc); err != nil {
+			return fmt.Errorf("failed to remove annotation %q from PersistentVolumeClaim "+
+				"%q %w",
+				replicationv1alpha1.VolumeReplicationNameAnnotation, pvc.Name, err)
+		}
+	}
+
+	return nil
+}

--- a/controllers/replication.storage/pvc_test.go
+++ b/controllers/replication.storage/pvc_test.go
@@ -236,5 +236,25 @@ func TestVolumeReplicationReconciler_annotatePVCWithOwner(t *testing.T) {
 		} else {
 			assert.NoError(t, err)
 		}
+
+		err = reconciler.removeOwnerFromPVCAnnotation(context.TODO(), log.FromContext(context.TODO()), testPVC)
+		assert.NoError(t, err)
+
+		// try calling delete again, it should not fail
+		err = reconciler.removeOwnerFromPVCAnnotation(context.TODO(), log.FromContext(context.TODO()), testPVC)
+		assert.NoError(t, err)
+
 	}
+
+	// try removeOwnerFromPVCAnnotation for empty map
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pvc-name",
+			Namespace: mockNamespace,
+		},
+	}
+	volumeReplication := &replicationv1alpha1.VolumeReplication{}
+	reconciler := createFakeVolumeReplicationReconciler(t, pvc, volumeReplication)
+	err := reconciler.removeOwnerFromPVCAnnotation(context.TODO(), log.FromContext(context.TODO()), pvc)
+	assert.NoError(t, err)
 }

--- a/controllers/replication.storage/volumereplication_controller.go
+++ b/controllers/replication.storage/volumereplication_controller.go
@@ -172,12 +172,6 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		logger.Info("Replication handle", "ReplicationHandleName", replicationHandle)
 	}
 
-	err = r.annotatePVCWithOwner(ctx, logger, nameSpacedName, pvc)
-	if err != nil {
-		logger.Error(err, "Failed to annotate PVC owner")
-		return ctrl.Result{}, err
-	}
-
 	replicationClient, err := r.getReplicationClient(vrcObj.Spec.Provisioner)
 	if err != nil {
 		logger.Error(err, "Failed to get ReplicationClient")
@@ -206,6 +200,13 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 			return reconcile.Result{}, err
 		}
+
+		err = r.annotatePVCWithOwner(ctx, logger, req.Name, pvc)
+		if err != nil {
+			logger.Error(err, "Failed to annotate PVC owner")
+			return ctrl.Result{}, err
+		}
+
 		if err = r.addFinalizerToPVC(logger, pvc); err != nil {
 			logger.Error(err, "Failed to add PersistentVolumeClaim finalizer")
 

--- a/controllers/replication.storage/volumereplication_controller.go
+++ b/controllers/replication.storage/volumereplication_controller.go
@@ -219,6 +219,13 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 				return ctrl.Result{}, err
 			}
+
+			if err = r.removeOwnerFromPVCAnnotation(ctx, logger, pvc); err != nil {
+				logger.Error(err, "Failed to remove VolumeReplication annotation from PersistentVolumeClaim")
+
+				return reconcile.Result{}, err
+			}
+
 			if err = r.removeFinalizerFromPVC(logger, pvc); err != nil {
 				logger.Error(err, "Failed to remove PersistentVolumeClaim finalizer")
 


### PR DESCRIPTION
As part of #213, support was added to have one VR per PVC. Once the VR is deleted, we need to remove the annotation so a new VR can be created for the same PVC. This PR adds the missing piece.

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>