### PR TITLE
rebase: use go 1.18 in tag-release workflow

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -109,10 +109,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Install Go 1.17
+      - name: Install Go 1.18
         uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: '1.18'
 
       - name: Generate manifests for installation by kubectl
         run: make manifests TAG=${{ github.ref_name }}


### PR DESCRIPTION
failed workflow https://github.com/csi-addons/kubernetes-csi-addons/runs/8089285012?check_suite_focus=true

Signed-off-by: Rakshith R <rar@redhat.com>