### PR TITLE
ci: use Go 1.19 for testing and building

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -15,10 +15,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Install Go 1.18
+      - name: Install Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - name: Generate the bundle contents
         run: make bundle

--- a/.github/workflows/kind-deploy.yaml
+++ b/.github/workflows/kind-deploy.yaml
@@ -17,10 +17,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Install Go 1.18
+      - name: Install Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - name: Deploy the controller and CRDs
         run: make deploy

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -13,10 +13,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Install Go 1.18
+      - name: Install Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - name: Generate the bundle contents
         run: make bundle TAG=${{ github.ref_name }}
@@ -109,10 +109,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Install Go 1.18
+      - name: Install Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - name: Generate manifests for installation by kubectl
         run: make manifests TAG=${{ github.ref_name }}

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -14,10 +14,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Install Go 1.18
+      - name: Install Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.19
 
       - name: Generate the bundle contents
         run: make bundle

--- a/.github/workflows/test-golang.yaml
+++ b/.github/workflows/test-golang.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Run "make test"
         run: make test
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Verify Go modules
         run: go mod verify
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - name: Vendor all dependencies
         run: go mod vendor


### PR DESCRIPTION
Kubernetes 1.25 requires Go 1.19 or newer. In order to update the
vendored dependencies, we'll need to use it too.