### PR TITLE
replication: reduce the reqeue time for GetReplicationInfo

### DIFF
--- a/controllers/replication.storage/volumereplication_test.go
+++ b/controllers/replication.storage/volumereplication_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestGetScheduledTime(t *testing.T) {
 	t.Parallel()
-	td, _ := time.ParseDuration("1m")
 	const defaultScheduleTime = time.Hour
 	logger := testr.New(t)
 	testcases := []struct {
@@ -37,7 +36,7 @@ func TestGetScheduledTime(t *testing.T) {
 				"replication.storage.openshift.io/replication-secret-name": "rook-csi-rbd-provisioner",
 				"schedulingInterval": "1m",
 			},
-			time: td,
+			time: time.Minute,
 		},
 		{
 			parameters: map[string]string{
@@ -61,12 +60,30 @@ func TestGetScheduledTime(t *testing.T) {
 			},
 			time: defaultScheduleTime,
 		},
+		{
+			parameters: map[string]string{
+				"schedulingInterval": "10s",
+			},
+			time: 10 * time.Second,
+		},
+		{
+			parameters: map[string]string{
+				"schedulingInterval": "4m",
+			},
+			time: 2 * time.Minute,
+		},
+		{
+			parameters: map[string]string{
+				"schedulingInterval": "1h",
+			},
+			time: 30 * time.Minute,
+		},
 	}
 	for _, tt := range testcases {
 		newtt := tt
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
-			if got := getScheduleTime(newtt.parameters, logger); got != newtt.time {
+			if got := getInfoReconcileInterval(newtt.parameters, logger); got != newtt.time {
 				t.Errorf("GetSchedluedTime() = %v, want %v", got, newtt.time)
 			}
 		})

--- a/docs/volumereplicationclass.md
+++ b/docs/volumereplicationclass.md
@@ -10,8 +10,8 @@
 
 + `replication.storage.openshift.io/replication-secret-name`
 + `replication.storage.openshift.io/replication-secret-namespace`
-  
-``` yaml  
+
+``` yaml
 apiVersion: replication.storage.openshift.io/v1alpha1
 kind: VolumeReplicationClass
 metadata:
@@ -21,5 +21,8 @@ spec:
   parameters:
     replication.storage.openshift.io/replication-secret-name: secret-name
     replication.storage.openshift.io/replication-secret-namespace: secret-namespace
+    # schedulingInterval is a vendor specific parameter. It is used to set the
+    # replication scheduling interval for storage volumes that are replication
+    # enabled using related VolumeReplication resource
     schedulingInterval: 1m
 ```


### PR DESCRIPTION
Reduce the schedule time by half to get the latest update and also to avoid the inconsistency between the last sync time in
the VR and the Storage system.
 
The user can see updates for RPO that are not stuck in a bad schedule race, i.e, VolumeReplication checks and finds sync time as t-5m, and just after that storage system updates it to t+x. If we checked every 1/2 of the schedule we will update it to t+x in t+s/2

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>