### PR TITLE
webhook: add webhooks for volumereplication

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -49,6 +49,9 @@ resources:
   kind: VolumeReplication
   path: github.com/csi-addons/kubernetes-csi-addons/apis/replication.storage/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/apis/replication.storage/v1alpha1/volumereplication_webhook.go
+++ b/apis/replication.storage/v1alpha1/volumereplication_webhook.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2022 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"errors"
+	"reflect"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var vrLog = logf.Log.WithName("volumereplication-webhook")
+
+func (v *VolumeReplication) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(v).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-replication-storage-openshift-io-v1alpha1-volumereplication,mutating=false,failurePolicy=fail,sideEffects=None,groups=replication.storage.openshift.io,resources=volumereplications,verbs=update,versions=v1alpha1,name=vvolumereplication.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &VolumeReplication{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (v *VolumeReplication) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (v *VolumeReplication) ValidateUpdate(old runtime.Object) error {
+	vrLog.Info("validate update", "name", v.Name)
+
+	oldReplication, ok := old.(*VolumeReplication)
+	if !ok {
+		return errors.New("error casting old VolumeReplication object")
+	}
+
+	var allErrs field.ErrorList
+
+	if !reflect.DeepEqual(oldReplication.Spec.DataSource, v.Spec.DataSource) {
+		vrLog.Info("invalid request to change the DataSource", "exiting dataSource", oldReplication.Spec.DataSource, "new dataSource", v.Spec.DataSource)
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("dataSource"), v.Spec.DataSource, "dataSource cannot be changed"))
+	}
+
+	if oldReplication.Spec.VolumeReplicationClass != v.Spec.VolumeReplicationClass {
+		vrLog.Info("invalid request to change the volumeReplicationClass", "exiting volumeReplicationClass", oldReplication.Spec.VolumeReplicationClass, "new volumeReplicationClass", v.Spec.VolumeReplicationClass)
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("volumeReplicationClass"), v.Spec.VolumeReplicationClass, "volumeReplicationClass cannot be changed"))
+	}
+
+	if len(allErrs) != 0 {
+		return apierrors.NewInvalid(
+			schema.GroupKind{Group: "replication.storage.openshift.io", Kind: "VolumeReplication"},
+			v.Name, allErrs)
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (v *VolumeReplication) ValidateDelete() error {
+	return nil
+}

--- a/apis/replication.storage/v1alpha1/webhook_suite_test.go
+++ b/apis/replication.storage/v1alpha1/webhook_suite_test.go
@@ -105,6 +105,9 @@ var _ = BeforeSuite(func() {
 	err = (&VolumeReplicationClass{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&VolumeReplication{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	//+kubebuilder:scaffold:webhook
 
 	go func() {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -157,6 +157,11 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "VolumeReplicationClass")
 			os.Exit(1)
 		}
+
+		if err = (&replicationstoragev1alpha1.VolumeReplication{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "VolumeReplication")
+			os.Exit(1)
+		}
 	}
 	//+kubebuilder:scaffold:builder
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -11,6 +11,25 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-replication-storage-openshift-io-v1alpha1-volumereplication
+  failurePolicy: Fail
+  name: vvolumereplication.kb.io
+  rules:
+  - apiGroups:
+    - replication.storage.openshift.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - UPDATE
+    resources:
+    - volumereplications
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-replication-storage-openshift-io-v1alpha1-volumereplicationclass
   failurePolicy: Fail
   name: vvolumereplicationclass.kb.io

--- a/deploy/controller/install-all-in-one.yaml
+++ b/deploy/controller/install-all-in-one.yaml
@@ -1423,6 +1423,25 @@ webhooks:
     service:
       name: csi-addons-webhook-service
       namespace: csi-addons-system
+      path: /validate-replication-storage-openshift-io-v1alpha1-volumereplication
+  failurePolicy: Fail
+  name: vvolumereplication.kb.io
+  rules:
+  - apiGroups:
+    - replication.storage.openshift.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - UPDATE
+    resources:
+    - volumereplications
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: csi-addons-webhook-service
+      namespace: csi-addons-system
       path: /validate-replication-storage-openshift-io-v1alpha1-volumereplicationclass
   failurePolicy: Fail
   name: vvolumereplicationclass.kb.io


### PR DESCRIPTION
Add webhook for volume replication object to prevent users from changing the dataSource or the volumeReplicationClass once created. Below is the command to generate a webhook for VolumeReplication object

```bash
$ operator-sdk create webhook --group replication.storage --version v1alpha1 --kind VolumeReplication --programmatic-validation
```

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>