### PR TITLE
ci: only build container for Kind GitHub Action on current platform

### DIFF
--- a/.github/workflows/kind-deploy.yaml
+++ b/.github/workflows/kind-deploy.yaml
@@ -29,7 +29,6 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: ${{ secrets.BUILD_PLATFORMS }}
           push: false
           tags: quay.io/csiaddons/k8s-controller:${{ env.TAG }}
 


### PR DESCRIPTION
When passing `platforms:` to the docker-build-push GitHub Action, QEMU needs to be configured and the `docker-buildx` action needs to be used. For the Kind deployment test, there is no need to run it on different platforms.