### PR TITLE
reclaimspace: consider VA object only it is attached & not being deleted

### DIFF
--- a/controllers/csiaddons/reclaimspacejob_controller.go
+++ b/controllers/csiaddons/reclaimspacejob_controller.go
@@ -324,7 +324,7 @@ func (r *ReclaimSpaceJobReconciler) getTargetDetails(
 		pvName:     pv.Name,
 	}
 	for _, v := range volumeAttachments.Items {
-		if *v.Spec.Source.PersistentVolumeName == pv.Name {
+		if v.DeletionTimestamp.IsZero() && v.Status.Attached && *v.Spec.Source.PersistentVolumeName == pv.Name {
 			*logger = logger.WithValues("NodeID", v.Spec.NodeName)
 			details.nodeID = v.Spec.NodeName
 			break


### PR DESCRIPTION
This commit makes modification to ignore Volume Attachment objects which are being deleted or not attached.

Signed-off-by: Rakshith R <rar@redhat.com>