### PR TITLE
build: support OwnNamespace installMode type

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -16,7 +16,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_csiaddonsnodes.yaml
 #- patches/webhook_in_reclaimspacejobs.yaml
 #- patches/webhook_in_volumereplications.yaml
-- patches/webhook_in_volumereplicationclasses.yaml
+#- patches/webhook_in_volumereplicationclasses.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
@@ -24,7 +24,7 @@ patchesStrategicMerge:
 #- patches/cainjection_in_csiaddonsnodes.yaml
 #- patches/cainjection_in_reclaimspacejobs.yaml
 #- patches/cainjection_in_volumereplications.yaml
-- patches/cainjection_in_volumereplicationclasses.yaml
+#- patches/cainjection_in_volumereplicationclasses.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/manifests/bases/clusterserviceversion.yaml.in
+++ b/config/manifests/bases/clusterserviceversion.yaml.in
@@ -52,8 +52,7 @@ spec:
       deployments: null
     strategy: ""
   installModes:
-  # CSVs featuring a conversion webhook can only support the AllNamespaces install mode
-  - supported: false
+  - supported: true
     type: OwnNamespace
   - supported: false
     type: SingleNamespace

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -682,20 +682,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
     controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
   name: volumereplicationclasses.replication.storage.openshift.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: webhook-service
-          namespace: system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: replication.storage.openshift.io
   names:
     kind: VolumeReplicationClass

--- a/deploy/controller/install-all-in-one.yaml
+++ b/deploy/controller/install-all-in-one.yaml
@@ -689,20 +689,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: csi-addons-system/csi-addons-serving-cert
     controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
   name: volumereplicationclasses.replication.storage.openshift.io
 spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: csi-addons-webhook-service
-          namespace: system
-          path: /convert
-      conversionReviewVersions:
-      - v1
   group: replication.storage.openshift.io
   names:
     kind: VolumeReplicationClass


### PR DESCRIPTION
We currently don't have a conversion webhook,
therefore can support the OwnNamespace installMode type too.
This change was done by default when webhook support was added.

Signed-off-by: Rakshith R <rar@redhat.com>