### PR TITLE
api: mark spec field of CRs as required

### DIFF
--- a/apis/csiaddons/v1alpha1/csiaddonsnode_types.go
+++ b/apis/csiaddons/v1alpha1/csiaddonsnode_types.go
@@ -85,7 +85,9 @@ type CSIAddonsNode struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   CSIAddonsNodeSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Required
+	Spec CSIAddonsNodeSpec `json:"spec"`
+
 	Status CSIAddonsNodeStatus `json:"status,omitempty"`
 }
 

--- a/apis/csiaddons/v1alpha1/networkfence_types.go
+++ b/apis/csiaddons/v1alpha1/networkfence_types.go
@@ -100,7 +100,9 @@ type NetworkFence struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   NetworkFenceSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Required
+	Spec NetworkFenceSpec `json:"spec"`
+
 	Status NetworkFenceStatus `json:"status,omitempty"`
 }
 

--- a/apis/csiaddons/v1alpha1/reclaimspacecronjob_types.go
+++ b/apis/csiaddons/v1alpha1/reclaimspacecronjob_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -123,7 +123,9 @@ type ReclaimSpaceCronJob struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ReclaimSpaceCronJobSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Required
+	Spec ReclaimSpaceCronJobSpec `json:"spec"`
+
 	Status ReclaimSpaceCronJobStatus `json:"status,omitempty"`
 }
 

--- a/apis/csiaddons/v1alpha1/reclaimspacejob_types.go
+++ b/apis/csiaddons/v1alpha1/reclaimspacejob_types.go
@@ -99,7 +99,9 @@ type ReclaimSpaceJob struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   ReclaimSpaceJobSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Required
+	Spec ReclaimSpaceJobSpec `json:"spec"`
+
 	Status ReclaimSpaceJobStatus `json:"status,omitempty"`
 }
 

--- a/apis/replication.storage/v1alpha1/volumereplication_types.go
+++ b/apis/replication.storage/v1alpha1/volumereplication_types.go
@@ -106,7 +106,9 @@ type VolumeReplication struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   VolumeReplicationSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Required
+	Spec VolumeReplicationSpec `json:"spec"`
+
 	Status VolumeReplicationStatus `json:"status,omitempty"`
 }
 

--- a/apis/replication.storage/v1alpha1/volumereplicationclass_types.go
+++ b/apis/replication.storage/v1alpha1/volumereplicationclass_types.go
@@ -46,7 +46,9 @@ type VolumeReplicationClass struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   VolumeReplicationClassSpec   `json:"spec,omitempty"`
+	// +kubebuilder:validation:Required
+	Spec VolumeReplicationClassSpec `json:"spec"`
+
 	Status VolumeReplicationClassStatus `json:"status,omitempty"`
 }
 

--- a/config/crd/bases/csiaddons.openshift.io_csiaddonsnodes.yaml
+++ b/config/crd/bases/csiaddons.openshift.io_csiaddonsnodes.yaml
@@ -95,6 +95,8 @@ spec:
                   CSI Driver.
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
+++ b/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
@@ -171,6 +171,8 @@ spec:
                   operation.
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/config/crd/bases/csiaddons.openshift.io_reclaimspacecronjobs.yaml
+++ b/config/crd/bases/csiaddons.openshift.io_reclaimspacecronjobs.yaml
@@ -197,6 +197,8 @@ spec:
                 format: date-time
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/config/crd/bases/csiaddons.openshift.io_reclaimspacejobs.yaml
+++ b/config/crd/bases/csiaddons.openshift.io_reclaimspacejobs.yaml
@@ -181,6 +181,8 @@ spec:
                 format: date-time
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/config/crd/bases/replication.storage.openshift.io_volumereplicationclasses.yaml
+++ b/config/crd/bases/replication.storage.openshift.io_volumereplicationclasses.yaml
@@ -60,6 +60,8 @@ spec:
             description: VolumeReplicationClassStatus defines the observed state of
               VolumeReplicationClass.
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml
+++ b/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml
@@ -193,6 +193,8 @@ spec:
                 description: State captures the latest state of the replication operation.
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -94,6 +94,8 @@ spec:
                   CSI Driver.
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -272,6 +274,8 @@ spec:
                   operation.
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -476,6 +480,8 @@ spec:
                 format: date-time
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -664,6 +670,8 @@ spec:
                 format: date-time
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -741,6 +749,8 @@ spec:
             description: VolumeReplicationClassStatus defines the observed state of
               VolumeReplicationClass.
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -941,6 +951,8 @@ spec:
                 description: State captures the latest state of the replication operation.
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true

--- a/deploy/controller/install-all-in-one.yaml
+++ b/deploy/controller/install-all-in-one.yaml
@@ -101,6 +101,8 @@ spec:
                   CSI Driver.
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -279,6 +281,8 @@ spec:
                   operation.
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -483,6 +487,8 @@ spec:
                 format: date-time
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -671,6 +677,8 @@ spec:
                 format: date-time
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -748,6 +756,8 @@ spec:
             description: VolumeReplicationClassStatus defines the observed state of
               VolumeReplicationClass.
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -948,6 +958,8 @@ spec:
                 description: State captures the latest state of the replication operation.
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true


### PR DESCRIPTION
All the CRs need to have valid spec field,
therefore this commit marks .spec field of all CRs as required using kubebuilder validation tag.

Signed-off-by: Rakshith R <rar@redhat.com>