### PR TITLE
controller/replication: add UnimplementedError for getVolRepInfo()

### DIFF
--- a/controllers/replication.storage/volumereplication_controller.go
+++ b/controllers/replication.storage/volumereplication_controller.go
@@ -371,20 +371,22 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	instance.Status.LastCompletionTime = getCurrentTime()
 
-	var requeueForInfo bool
+	requeueForInfo := false
 
 	if instance.Spec.ReplicationState == replicationv1alpha1.Primary {
 		info, err := r.getVolumeReplicationInfo(vr)
-		if err != nil {
+		if err == nil {
+			ts := info.GetLastSyncTime()
+			if ts != nil {
+				lastSyncTime := metav1.NewTime(ts.AsTime())
+				instance.Status.LastSyncTime = &lastSyncTime
+			}
+			requeueForInfo = true
+		}
+		if !util.IsUnimplementedError(err) {
 			logger.Error(err, "Failed to get volume replication info")
 			return ctrl.Result{}, err
 		}
-		ts := info.GetLastSyncTime()
-		if ts != nil {
-			lastSyncTime := metav1.NewTime(ts.AsTime())
-			instance.Status.LastSyncTime = &lastSyncTime
-		}
-		requeueForInfo = true
 	}
 	if instance.Spec.ReplicationState == replicationv1alpha1.Secondary {
 		instance.Status.LastSyncTime = nil

--- a/internal/util/error.go
+++ b/internal/util/error.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package util
 
-import "google.golang.org/grpc/status"
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
 
 // GetErrorMessage returns the message from the error if it is a grpc error,
 // else returns err.Error().
@@ -27,4 +30,14 @@ func GetErrorMessage(err error) string {
 	}
 
 	return s.Message()
+}
+
+// IsUnimplementedError returns true if the error is Unimplemented error.
+func IsUnimplementedError(err error) bool {
+	s, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+
+	return s.Code() == codes.Unimplemented
 }

--- a/internal/util/error_test.go
+++ b/internal/util/error_test.go
@@ -63,3 +63,48 @@ func TestGetErrorMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestIsUmplementedError(t *testing.T) {
+	type input struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args input
+		want bool
+	}{
+		{
+			name: "nil error",
+			args: input{
+				err: nil,
+			},
+			want: false,
+		},
+		{
+			name: "Unimplmented error",
+			args: input{
+				err: status.Error(codes.Unimplemented, "unimplemented"),
+			},
+			want: true,
+		},
+		{
+			name: "Non unimplmented error",
+			args: input{
+				err: status.Error(codes.NotFound, "not found"),
+			},
+			want: false,
+		},
+		{
+			name: "Non grpc status error",
+			args: input{
+				err: errors.New("new error"),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsUnimplementedError(tt.args.err))
+		})
+	}
+}


### PR DESCRIPTION
This commit adds code to handle UnimplmentedError from getVolumeReplicationInfo rpc. The controller wil now ignore this error and not requeue the request.

Fixes: #236

Signed-off-by: Rakshith R <rar@redhat.com>