### PR TITLE
controller/replication: fix bug in Unimplmented error check

### DIFF
--- a/controllers/replication.storage/volumereplication_controller.go
+++ b/controllers/replication.storage/volumereplication_controller.go
@@ -382,8 +382,7 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				instance.Status.LastSyncTime = &lastSyncTime
 			}
 			requeueForInfo = true
-		}
-		if !util.IsUnimplementedError(err) {
+		} else if !util.IsUnimplementedError(err) {
 			logger.Error(err, "Failed to get volume replication info")
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
A bug was introduced in 90f59d1f due to which
Volumereplication controller always gave error.
This commit fixes the same.

Signed-off-by: Rakshith R <rar@redhat.com>