### PR TITLE
add default value to autoResync

### DIFF
--- a/apis/replication.storage/v1alpha1/volumereplication_types.go
+++ b/apis/replication.storage/v1alpha1/volumereplication_types.go
@@ -71,6 +71,7 @@ type VolumeReplicationSpec struct {
 
 	// AutoResync represents the volume to be auto resynced when
 	// ReplicationState is "secondary"
+	// +kubebuilder:default:=false
 	AutoResync bool `json:"autoResync"`
 
 	// replicationHandle represents an existing (but new) replication id

--- a/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml
+++ b/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml
@@ -54,6 +54,7 @@ spec:
             description: VolumeReplicationSpec defines the desired state of VolumeReplication.
             properties:
               autoResync:
+                default: false
                 description: AutoResync represents the volume to be auto resynced
                   when ReplicationState is "secondary"
                 type: boolean

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -802,6 +802,7 @@ spec:
             description: VolumeReplicationSpec defines the desired state of VolumeReplication.
             properties:
               autoResync:
+                default: false
                 description: AutoResync represents the volume to be auto resynced
                   when ReplicationState is "secondary"
                 type: boolean

--- a/deploy/controller/install-all-in-one.yaml
+++ b/deploy/controller/install-all-in-one.yaml
@@ -809,6 +809,7 @@ spec:
             description: VolumeReplicationSpec defines the desired state of VolumeReplication.
             properties:
               autoResync:
+                default: false
                 description: AutoResync represents the volume to be auto resynced
                   when ReplicationState is "secondary"
                 type: boolean


### PR DESCRIPTION
Currently, if a user will want to create `VolumeReplication` without the `autoResync` field it will fail because it’s a required field. After this PR it will have a default in the CRD and it won’t fail and will create the object with the default value