### PR TITLE
build: increase default resource cpu & memory limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,54 +64,9 @@ By listing the `CSIAddonsNode` CRs, the CSI-Addons Controller knows how to
 connect to the side-cars. By checking the supported capabilities of the
 side-cars, it can decide where to execute operations that the user requested.
 
-The preferred way to install the controllers is to use yaml files that are
-made available with the
-[latest release](https://github.com/csi-addons/kubernetes-csi-addons/releases/latest).
-The detailed documentation for the installation of the CSI-Addons Controller using
-the yaml file is present
-[here](docs/deploy-controller.md). This also includes other methods to deploy the
-controller.
+### Installation
 
-### Installation for versioned deployments
-
-The CSI-Addons Controller can also be installed  using the yaml files in `deploy/controller`.
-The versioned deployment is possible with the yaml files that get generated for a release,
-like [release-v0.3.0](https://github.com/csi-addons/kubernetes-csi-addons/releases/tag/v0.3.0).
-You can download the yaml files from there, or use them directly with kubectl.
-
-```console
-$ cd deploy/controller
-
-$ kubectl create -f crds.yaml
-...
-customresourcedefinition.apiextensions.k8s.io/csiaddonsnodes.csiaddons.openshift.io created
-customresourcedefinition.apiextensions.k8s.io/networkfences.csiaddons.openshift.io created
-customresourcedefinition.apiextensions.k8s.io/reclaimspacecronjobs.csiaddons.openshift.io created
-customresourcedefinition.apiextensions.k8s.io/reclaimspacejobs.csiaddons.openshift.io created
-
-$ kubectl create -f rbac.yaml
-... 
-serviceaccount/csi-addons-controller-manager created
-role.rbac.authorization.k8s.io/csi-addons-leader-election-role created
-clusterrole.rbac.authorization.k8s.io/csi-addons-manager-role created
-clusterrole.rbac.authorization.k8s.io/csi-addons-metrics-reader created
-clusterrole.rbac.authorization.k8s.io/csi-addons-proxy-role created
-rolebinding.rbac.authorization.k8s.io/csi-addons-leader-election-rolebinding created
-clusterrolebinding.rbac.authorization.k8s.io/csi-addons-manager-rolebinding created
-clusterrolebinding.rbac.authorization.k8s.io/csi-addons-proxy-rolebinding created
-configmap/csi-addons-manager-config created
-service/csi-addons-controller-manager-metrics-service created
-
-$ kubectl create -f setup-controller.yaml
-...
-deployment.apps/csi-addons-controller-manager created
-```
-
-* The crds.yaml create the required crds for reclaimspace operation.
-
-* The rbac.yaml creates the required rbac.
-
-* The setup-controller creates the csi-addons-controller-manager.
+Refer to the [installation guide](docs/deploy-controller.md) for more details.
 
 ## Contributing
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,8 +44,8 @@ spec:
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:
-            cpu: 500m
-            memory: 128Mi
+            cpu: 1000m
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/deploy/controller/install-all-in-one.yaml
+++ b/deploy/controller/install-all-in-one.yaml
@@ -1352,8 +1352,8 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 500m
-            memory: 128Mi
+            cpu: 1000m
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/deploy/controller/setup-controller.yaml
+++ b/deploy/controller/setup-controller.yaml
@@ -78,8 +78,8 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 500m
-            memory: 128Mi
+            cpu: 1000m
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/docs/deploy-controller.md
+++ b/docs/deploy-controller.md
@@ -153,3 +153,21 @@ deployment.apps/csi-addons-controller-manager   1/1     1            1          
 NAME                                                       DESIRED   CURRENT   READY   AGE
 replicaset.apps/csi-addons-controller-manager-687d47b8c7   1         1         1       49s
 ```
+
+## Resource Requirements
+
+The resource requirements for the CSI-Addons Controller depends on the number of
+PersistentVolumeClaims, Pods, Nodes and CSI-Addons CRs that are deployed in the
+cluster. The resource requirements can be adjusted by the user depending on the
+requirements of the cluster after observation. The default resource requirements
+for the CSI-Addons Controller are as follows:
+
+```yaml
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+```


### PR DESCRIPTION
We now have 100 workers by default and watch a lot of resources such as PVCs,  VolumeAttachments and owned CRs. This leads to Out-Of-Memory kills(OOMKILLs) with just limit of 128Mi.
Therefore, raising limit to 512Mi memory and 1000m cpu./


> Note: I am noticing increase of 50Mi usage with 1000 PVC with reclaimspace annotation. This new limit should give us headroom, while the requested resource is still the same.