### PR TITLE
ci: remove `rebase_fallback` from Mergify config

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,7 +4,6 @@ defaults:
     queue:
       name: default
       method: rebase
-      rebase_fallback: merge
       update_method: rebase
 
 queue_rules:


### PR DESCRIPTION
Mergify complains that the current configuration is invalid:

extra keys not allowed @ defaults → actions → queue → rebase_fallback

Dropping rebase_fallback because of this.