### PR TITLE
NetworkFence: correct check in validating webhook

### DIFF
--- a/apis/csiaddons/v1alpha1/networkfence_webhook.go
+++ b/apis/csiaddons/v1alpha1/networkfence_webhook.go
@@ -61,7 +61,7 @@ func (n *NetworkFence) ValidateUpdate(old runtime.Object) error {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("driver"), n.Spec.Driver, "driver cannot be changed"))
 	}
 
-	if reflect.DeepEqual(n.Spec.Parameters, oldNetworkFence.Spec.Parameters) {
+	if !reflect.DeepEqual(n.Spec.Parameters, oldNetworkFence.Spec.Parameters) {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("parameters"), n.Spec.Parameters, "parameters cannot be changed"))
 	}
 


### PR DESCRIPTION
When a NetworkFence CR is validated, an incorrect comparison is done. `DeepEqual()` returns `true` when the there are no changes, this is valid and not an error. Adding `!` to inverse the check corrects the comparison and only reports an error when the parameters are modified.

See-also: https://bugzilla.redhat.com/2182375