### PR TITLE
reclaimspace: add support for namespace annotation

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -136,8 +136,9 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.PersistentVolumeClaimReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		ConnPool: connPool,
 	}).SetupWithManager(mgr, ctrlOptions); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PersistentVolumeClaim")
 		os.Exit(1)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,6 +24,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - get

--- a/controllers/csiaddons/persistentvolumeclaim_controller.go
+++ b/controllers/csiaddons/persistentvolumeclaim_controller.go
@@ -18,11 +18,15 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/apis/csiaddons/v1alpha1"
+	"github.com/csi-addons/kubernetes-csi-addons/internal/connection"
+	"github.com/csi-addons/kubernetes-csi-addons/internal/util"
 
 	"github.com/go-logr/logr"
 	"github.com/robfig/cron/v3"
@@ -44,11 +48,17 @@ import (
 type PersistentVolumeClaimReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	// ConnectionPool consists of map of Connection objects.
+	ConnPool *connection.ConnectionPool
 }
 
 var (
 	rsCronJobScheduleTimeAnnotation = "reclaimspace." + csiaddonsv1alpha1.GroupVersion.Group + "/schedule"
 	rsCronJobNameAnnotation         = "reclaimspace." + csiaddonsv1alpha1.GroupVersion.Group + "/cronjob"
+	csiAddonsDriverAnnotation       = "reclaimspace." + csiaddonsv1alpha1.GroupVersion.Group + "/drivers"
+
+	// errDriverNotFound is returned when driver is not found in connection pool.
+	errDriverNotFound = errors.New("driver not found in connection pool")
 )
 
 const (
@@ -58,12 +68,14 @@ const (
 //+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims/finalizers,verbs=update
 //+kubebuilder:rbac:groups=csiaddons.openshift.io,resources=reclaimspacecronjobs,verbs=get;list;watch;create;delete;update
+//+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// This is triggered when `reclaimspace.csiaddons.openshift/schedule` annotation
-// is found on newly created PVC or if there is a change in value of the annotation.
-// It is also triggered by any changes to the child cronjob.
+// move the current state of the cluster closer to the desired state.  This is
+// triggered when `reclaimspace.csiaddons.openshift/schedule` annotation is
+// found on newly created PVC or its found on the namespace or if there is a
+// change in value of the annotation. It is also triggered by any changes to
+// the child cronjob.
 func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -81,6 +93,26 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
+	// Validate PVC in bound state
+	if pvc.Status.Phase != corev1.ClaimBound {
+		logger.Info("PVC is not in bound state", "PVCPhase", pvc.Status.Phase)
+		// requeue the request
+		return ctrl.Result{Requeue: true}, nil
+	}
+	// get the driver name from PV to check if it supports space reclamation.
+	pv := &corev1.PersistentVolume{}
+
+	err = r.Client.Get(ctx, types.NamespacedName{Name: pvc.Spec.VolumeName}, pv)
+	if err != nil {
+		logger.Error(err, "Failed to get PV", "PVName", pvc.Spec.VolumeName)
+		return ctrl.Result{}, err
+	}
+
+	if pv.Spec.CSI == nil {
+		logger.Info("PV is not a CSI volume", "PVName", pv.Name)
+		return ctrl.Result{}, nil
+	}
+
 	rsCronJob, err := r.findChildCronJob(ctx, &logger, &req)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -91,6 +123,35 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 
 	annotations := pvc.GetAnnotations()
 	schedule, scheduleFound := getScheduleFromAnnotation(&logger, annotations)
+	if !scheduleFound {
+		// check for namespace schedule annotation.
+		// We cannot have a generic solution for all CSI drivers to get the driver
+		// name from PV and check if driver supports space reclamation or not and
+		// requeue the request if the driver is not registered in the connection
+		// pool. This can put the controller in a requeue loop. Hence we are
+		// reading the driver name from the namespace annotation and checking if
+		// the driver is registered in the connection pool and if not we are not
+		// requeuing the request.
+		ns := &corev1.Namespace{}
+		err = r.Client.Get(ctx, types.NamespacedName{Name: pvc.Namespace}, ns)
+		if err != nil {
+			logger.Error(err, "Failed to get Namespace", "Namespace", pvc.Namespace)
+			return ctrl.Result{}, err
+		}
+		schedule, scheduleFound = getScheduleFromAnnotation(&logger, ns.Annotations)
+		// If the schedule is not found, check whether driver supports the
+		// space reclamation using annotation on namespace and registered driver
+		// capability for decision on requeue.
+		if !scheduleFound {
+			requeue, supportReclaimspace := r.checkDriverSupportReclaimsSpace(&logger, ns.Annotations, pv.Spec.CSI.Driver)
+			if !supportReclaimspace {
+				return ctrl.Result{
+					Requeue: requeue,
+				}, nil
+			}
+		}
+	}
+
 	if !scheduleFound {
 		// if schedule is not found,
 		// delete cron job.
@@ -140,8 +201,16 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 
 	rsCronJobName := generateCronJobName(req.Name)
 	logger = logger.WithValues("ReclaimSpaceCronJobName", rsCronJobName)
-	// add cronjob name in annotations.
-	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, rsCronJobNameAnnotation, rsCronJobName))
+	// add cronjob name and schedule in annotations.
+	// adding annotation is required for the case when pvc does not have
+	// have schedule annotation but namespace has.
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:%q,%q:%q}}}`,
+		rsCronJobNameAnnotation,
+		rsCronJobName,
+		rsCronJobScheduleTimeAnnotation,
+		schedule,
+	))
+	logger.Info("Adding annotation", "Annotation", string(patch))
 	err = r.Client.Patch(ctx, pvc, client.RawPatch(types.StrategicMergePatchType, patch))
 	if err != nil {
 		logger.Error(err, "Failed to update annotation")
@@ -166,6 +235,32 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 	logger.Info("Successfully created reclaimSpaceCronJob")
 
 	return ctrl.Result{}, nil
+}
+
+// checkDriverSupportReclaimsSpace checks if the driver supports space
+// reclamation or not. If the driver does not support space reclamation, it
+// returns false and if the driver supports space reclamation, it returns true.
+// If the driver name is not registered in the connection pool, it returns
+// false and requeues the request.
+func (r *PersistentVolumeClaimReconciler) checkDriverSupportReclaimsSpace(logger *logr.Logger, annotations map[string]string, driver string) (bool, bool) {
+	reclaimSpaceSupportedByDriver := false
+
+	if drivers, ok := annotations[csiAddonsDriverAnnotation]; ok && util.ContainsInSlice(strings.Split(drivers, ","), driver) {
+		reclaimSpaceSupportedByDriver = true
+	}
+
+	ok := r.supportsReclaimSpace(driver)
+	if reclaimSpaceSupportedByDriver && !ok {
+		logger.Info("Driver supports spacereclamation but driver is not registered in the connection pool, Reqeueing request", "DriverName", driver)
+		return true, false
+	}
+
+	if !ok {
+		logger.Info("Driver does not support spacereclamation, skip Requeue", "DriverName", driver)
+		return false, false
+	}
+
+	return false, true
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -322,4 +417,18 @@ func extractOwnerNameFromPVCObj(rawObj client.Object) []string {
 // with time hash.
 func generateCronJobName(parentName string) string {
 	return fmt.Sprintf("%s-%d", parentName, time.Now().Unix())
+}
+
+// supportsReclaimSpace checks if the CSI driver supports ReclaimSpace.
+func (r PersistentVolumeClaimReconciler) supportsReclaimSpace(driverName string) bool {
+	conns := r.ConnPool.GetByNodeID(driverName, "")
+	for _, v := range conns {
+		for _, cap := range v.Capabilities {
+			if cap.GetReclaimSpace() != nil {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/controllers/csiaddons/persistentvolumeclaim_controller.go
+++ b/controllers/csiaddons/persistentvolumeclaim_controller.go
@@ -180,15 +180,6 @@ func (r *PersistentVolumeClaimReconciler) SetupWithManager(mgr ctrl.Manager, ctr
 	}
 
 	pred := predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			if e.Object == nil {
-				return false
-			}
-			// reconcile only if schedule annotation is found.
-			_, ok := e.Object.GetAnnotations()[rsCronJobScheduleTimeAnnotation]
-
-			return ok
-		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if e.ObjectNew == nil || e.ObjectOld == nil {
 				return false

--- a/controllers/csiaddons/persistentvolumeclaim_controller_test.go
+++ b/controllers/csiaddons/persistentvolumeclaim_controller_test.go
@@ -22,66 +22,12 @@ import (
 	"testing"
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/apis/csiaddons/v1alpha1"
-
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-func TestGetScheduleFromAnnotation(t *testing.T) {
-	type args struct {
-		logger      *logr.Logger
-		annotations map[string]string
-	}
-	logger := log.FromContext(context.TODO())
-	tests := []struct {
-		name  string
-		args  args
-		want  string
-		want1 bool
-	}{
-		{
-			name: "no scheduling annotation set",
-			args: args{
-				logger:      &logger,
-				annotations: map[string]string{},
-			},
-			want:  "",
-			want1: false,
-		},
-		{
-			name: "valid scheduling annotation set",
-			args: args{
-				logger: &logger,
-				annotations: map[string]string{
-					rsCronJobScheduleTimeAnnotation: "@weekly",
-				},
-			},
-			want:  "@weekly",
-			want1: true,
-		},
-		{
-			name: "invalid scheduling annotation set",
-			args: args{
-				logger: &logger,
-				annotations: map[string]string{
-					rsCronJobScheduleTimeAnnotation: "@daytime",
-				},
-			},
-			want:  defaultSchedule,
-			want1: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := getScheduleFromAnnotation(tt.args.logger, tt.args.annotations)
-			assert.Equal(t, tt.want, got)
-			assert.Equal(t, tt.want1, got1)
-		})
-	}
-}
 
 func TestConstructRSCronJob(t *testing.T) {
 	type args struct {
@@ -246,6 +192,59 @@ func TestGenerateCronJobName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := generateCronJobName(tt.args.parentName)
 			assert.True(t, strings.HasPrefix(got, tt.want))
+		})
+	}
+}
+
+func TestGetScheduleFromAnnotation(t *testing.T) {
+	type args struct {
+		logger      *logr.Logger
+		annotations map[string]string
+	}
+	logger := log.FromContext(context.TODO())
+	tests := []struct {
+		name  string
+		args  args
+		want  string
+		want1 bool
+	}{
+		{
+			name: "no scheduling annotation set",
+			args: args{
+				logger:      &logger,
+				annotations: map[string]string{},
+			},
+			want:  "",
+			want1: false,
+		},
+		{
+			name: "valid scheduling annotation set",
+			args: args{
+				logger: &logger,
+				annotations: map[string]string{
+					rsCronJobScheduleTimeAnnotation: "@weekly",
+				},
+			},
+			want:  "@weekly",
+			want1: true,
+		},
+		{
+			name: "invalid scheduling annotation set",
+			args: args{
+				logger: &logger,
+				annotations: map[string]string{
+					rsCronJobScheduleTimeAnnotation: "@daytime",
+				},
+			},
+			want:  defaultSchedule,
+			want1: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := getScheduleFromAnnotation(tt.args.logger, tt.args.annotations)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want1, got1)
 		})
 	}
 }

--- a/deploy/controller/install-all-in-one.yaml
+++ b/deploy/controller/install-all-in-one.yaml
@@ -1020,6 +1020,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - get

--- a/deploy/controller/rbac.yaml
+++ b/deploy/controller/rbac.yaml
@@ -74,6 +74,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - get

--- a/docs/reclaimspace.md
+++ b/docs/reclaimspace.md
@@ -14,9 +14,8 @@ spec:
   retryDeadlineSeconds: 900
 ```
 
-
 + `target` represents volume target on which the operation will be performed.
-    + `persistentVolumeClaim` contains a string indicating the name of `PersistentVolumeClaim`.
+  + `persistentVolumeClaim` contains a string indicating the name of `PersistentVolumeClaim`.
 + `backOfflimit` specifies the number of retries before marking reclaim space operation as failed. If not specified, defaults to 6. Maximum allowed value is 60 and minimum allowed value is 0.
 + `retryDeadlineSeconds` specifies the duration in seconds relative to the start time that the operation may be retried; value must be positive integer. If not specified, defaults to 600 seconds. Maximum allowed value is 1800.
 
@@ -63,7 +62,7 @@ spec:
 
 ## Annotating PerstentVolumeClaims
 
-`ReclaimSpaceCronJob` CR can also be automatically created by adding 
+`ReclaimSpaceCronJob` CR can also be automatically created by adding
 `reclaimspace.csiaddons.openshift.io/schedule: "@midnight"` annotation
 to PersistentVolumeClaim object.
 
@@ -75,7 +74,7 @@ data-pvc  Bound    pvc-f37b8582-4b04-4676-88dd-e1b95c6abf74   1Gi        RWO    
 $ kubectl annotate pvc data-pvc "reclaimspace.csiaddons.openshift.io/schedule=@midnight"
 persistentvolumeclaim/data-pvc annotated
 
-$ kubectl get reclaimspacecronjobs.csiaddons.openshift.io 
+$ kubectl get reclaimspacecronjobs.csiaddons.openshift.io
 NAME                    SCHEDULE    SUSPEND   ACTIVE   LASTSCHEDULE   AGE
 data-pvc-1642663516   @midnight                                     3s
 
@@ -87,14 +86,41 @@ NAME                  SCHEDULE    SUSPEND   ACTIVE   LASTSCHEDULE   AGE
 data-pvc-1642664617   */1 * * * *                                   3s
 ```
 
-- Upon adding annotation as shown above, a `ReclaimSpaceCronJob` with name
-  `"<pvc-name>-xxxxxxx"` is created (pvc name suffixed with current time hash when 
-  the job was created). 
-- `schedule` value is in the same [format as Kubernetes CronJobs][batch_cronjob]
++ Upon adding annotation as shown above, a `ReclaimSpaceCronJob` with name
+  `"<pvc-name>-xxxxxxx"` is created (pvc name suffixed with current time hash when
+  the job was created).
++ `schedule` value is in the same [format as Kubernetes CronJobs][batch_cronjob]
   that sets the and/or interval of the recurring operation request.
-- Default schedule value `"@weekly"` is used if `schedule` value is empty or in invalid format. 
-- `ReclaimSpaceCronJob` is recreated when `schedule` is modified and deleted when
++ Default schedule value `"@weekly"` is used if `schedule` value is empty or in invalid format.
++ `ReclaimSpaceCronJob` is recreated when `schedule` is modified and deleted when
   the annotation is removed.
 
 [batch_cronjob]: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/
-[go_cron]: https://pkg.go.dev/github.com/robfig/cron/v3#hdr-CRON_Expression_Format
+[go_cron]:
+    https://pkg.go.dev/github.com/robfig/cron/v3#hdr-CRON_Expression_Format
+
+## Annotating Namespace
+
+You can create `ReclaimSpaceCronJob` CR automatically by adding the
+`reclaimspace.csiaddons.openshift.io/schedule: "@midnight"` and (optional)
+`reclaimspace.csiaddons.openshift.io/drivers: drivernames` annotations to the
+Namespace object. This will only inspect new PersistentVolumeClaims in the
+Namespace for ReclaimSpace operations. You must restart the controller if you
+want kubernetes-csi-addons to consider existing PersistentVolumeClaims.
+
+`drivernames` can be `,` separated driver names that supports reclaimspace operations.
+
+```
+$ kubectl get namespace default
+NAME      STATUS   AGE
+default   Active   5d2h
+
+$ kubectl annotate namespace default "reclaimspace.csiaddons.openshift.io/schedule=@midnight"
+namespace/default annotated
+```
+
+**Note** Please note that the PersistentVolumeClaim annotation takes priority
+over Namespace annotation. The kubernetes-csi-addons only generate a
+`ReclaimSpaceCronJob` if the annotation exists on the Namespace. If an admin
+needs to modify or delete the annotation on the Namespace, they must perform
+the same action on all the PersistentVolumeClaims within that Namespace.


### PR DESCRIPTION
Currently, we only support the reclaimspace feature on the PVC annotation. However, this adds support for namespace annotations as well. If the required PVC annotation is missing, our controller will check if the necessary annotation is present on the namespace. If it is, the scheduling details will be retrieved from the namespace annotation and used to create the ReclaimspaceCronJob.
    
It's important to note that the PVC annotation will take precedence over namespace annotations.
    
Please be aware that we can only create a reclaimspaceCronJob if the annotation exists on the namespace. If an admin wants to update or remove the annotation on the namespace, the same action must be taken on all the PVCs within that namespace.
    
Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>