### PR TITLE
build: use Go 1.20 as Kubernetes packages require that too

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -15,10 +15,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Install Go 1.19
+      - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Generate the bundle contents
         run: make bundle

--- a/.github/workflows/kind-deploy.yaml
+++ b/.github/workflows/kind-deploy.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Build container container image
         uses: docker/build-push-action@v4

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -13,10 +13,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Install Go 1.19
+      - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Generate the bundle contents
         run: make bundle TAG=${{ github.ref_name }}
@@ -109,10 +109,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Install Go 1.19
+      - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Generate manifests for installation by kubectl
         run: make manifests TAG=${{ github.ref_name }}

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -14,10 +14,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Install Go 1.19
+      - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Generate the bundle contents
         run: make bundle

--- a/.github/workflows/test-golang.yaml
+++ b/.github/workflows/test-golang.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Verify Go modules
         run: go mod verify
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Vendor all dependencies
         run: go mod vendor

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csi-addons/kubernetes-csi-addons
 
-go 1.19
+go 1.20
 
 require (
 	github.com/container-storage-interface/spec v1.8.0


### PR DESCRIPTION
In preparation for updating the Kubernetes dependencies to v1.27 or newer, start using Go 1.20 now already.