### PR TITLE
build: use Go 1.20 while building in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM quay.io/projectquay/golang:1.20 as builder
 
 # Copy the contents of the repository
 ADD . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons

--- a/build/Containerfile.sidecar
+++ b/build/Containerfile.sidecar
@@ -1,5 +1,5 @@
 # Build the sidecar binary
-FROM golang:1.19 as builder
+FROM quay.io/projectquay/golang:1.20 as builder
 
 # Copy the contents of the repository
 ADD . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons


### PR DESCRIPTION
This also moves to use the quay.io mirror of the Golang container-image from docker.io. Docker Hub has pull restrictions, that can prevent pulling the image if it is done too often. Quay.io does not enforce restrictions like that.