### PR TITLE
ci: include `/tools` directory in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,15 @@ updates:
       prefix: "vendor"
     labels:
       - vendor
+  - package-ecosystem: "gomod"
+    directory: "/tools"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    commit-message:
+      prefix: "vendor"
+    labels:
+      - vendor
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
The `/tools` directory was added with commit 342d457093cccd. It is needed to update the dependencies of the tools separately.