### PR TITLE
build: include `-version` option for csi-addons executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ ENV GOPATH=/workspace/go
 WORKDIR /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -o /workspace/manager cmd/manager/main.go
+RUN make build
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons/bin/csi-addons-manager .
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/csi-addons-manager"]

--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,8 @@ bundle-validate: container-cmd operator-sdk
 
 .PHONY: build
 build: generate fmt vet ## Build manager binary.
-	go build -ldflags '$(LDFLAGS)' -o bin/manager cmd/manager/main.go
-	go build -ldflags '$(LDFLAGS)' -o bin/sidecar sidecar/main.go
+	go build -ldflags '$(LDFLAGS)' -o bin/csi-addons-manager cmd/manager/main.go
+	go build -ldflags '$(LDFLAGS)' -o bin/csi-addons-sidecar sidecar/main.go
 	go build -o bin/csi-addons ./cmd/csi-addons
 
 .PHONY: run

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ bundle-validate: container-cmd operator-sdk
 build: generate fmt vet ## Build manager binary.
 	go build -ldflags '$(LDFLAGS)' -o bin/csi-addons-manager cmd/manager/main.go
 	go build -ldflags '$(LDFLAGS)' -o bin/csi-addons-sidecar sidecar/main.go
-	go build -o bin/csi-addons ./cmd/csi-addons
+	go build -ldflags '$(LDFLAGS)' -o bin/csi-addons ./cmd/csi-addons
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/build/Containerfile.sidecar
+++ b/build/Containerfile.sidecar
@@ -7,16 +7,14 @@ ADD . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons
 ENV GOPATH=/workspace/go
 WORKDIR /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons
 
-# Build
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -o /workspace/csi-addons-sidecar ./sidecar
-
-# Build the csi-addons tool for admin usage and testing
-RUN CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -o /workspace/csi-addons ./cmd/csi-addons
+# Build the sidecar and csi-addons tool for admin usage and testing
+RUN make build
 
 # Use distroless as minimal base image to package the sidecar binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:latest
 WORKDIR /
-COPY --from=builder /workspace /usr/bin/
+COPY --from=builder /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons/bin/csi-addons-sidecar /usr/sbin/
+COPY --from=builder /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons/bin/csi-addons /usr/bin/
 
-ENTRYPOINT ["/usr/bin/csi-addons-sidecar"]
+ENTRYPOINT ["/usr/sbin/csi-addons-sidecar"]

--- a/cmd/csi-addons/main.go
+++ b/cmd/csi-addons/main.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/csi-addons/kubernetes-csi-addons/internal/version"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/client-go/kubernetes"
@@ -47,12 +49,15 @@ type command struct {
 var cmd = &command{}
 
 func init() {
+	var showVersion bool
+
 	flag.StringVar(&cmd.endpoint, "endpoint", endpoint, "CSI-Addons endpoint")
 	flag.StringVar(&cmd.stagingPath, "stagingpath", stagingPath, "staging path")
 	flag.StringVar(&cmd.operation, "operation", "", "csi-addons operation")
 	flag.StringVar(&cmd.persistentVolume, "persistentvolume", "", "name of the PersistentVolume")
 	flag.StringVar(&cmd.drivername, "drivername", "", "name of the CSI driver")
 	flag.BoolVar(&cmd.legacy, "legacy", false, "use legacy format for old Kubernetes versions")
+	flag.BoolVar(&showVersion, "version", false, "print Version details")
 
 	// output to show when --help is passed
 	flag.Usage = func() {
@@ -66,6 +71,11 @@ func init() {
 	}
 
 	flag.Parse()
+
+	if showVersion {
+		version.PrintVersion()
+		os.Exit(0)
+	}
 }
 
 func main() {

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,7 +22,7 @@ spec:
         runAsNonRoot: true
       containers:
         - command:
-            - /manager
+            - /csi-addons-manager
           args:
             - --leader-elect
           image: controller:latest

--- a/deploy/controller/install-all-in-one.yaml
+++ b/deploy/controller/install-all-in-one.yaml
@@ -1354,7 +1354,7 @@ spec:
         - --leader-elect
         - --enable-admission-webhooks=true
         command:
-        - /manager
+        - /csi-addons-manager
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/deploy/controller/setup-controller.yaml
+++ b/deploy/controller/setup-controller.yaml
@@ -63,7 +63,7 @@ spec:
         - --leader-elect
         - --enable-admission-webhooks=false
         command:
-        - /manager
+        - /csi-addons-manager
         env:
         - name: POD_NAMESPACE
           valueFrom:


### PR DESCRIPTION
The `Makefile` now contains logic to provide a version (git tag) and the
current git commit hash in a `-version` argument to executables. However
the container-images did not use `make`, and therefor the executables
would not have the version information set.

While updating the building of the executables in the container, the
names of the executables has been prefixed with `csi-addons-`, so that a
listing of running processes on a Kubernetes node does not show
`manager` for the CSI-Addons Operator, but `csi-addons-manager`.

Just like for the manager and sidecar executables, add `-version` as an
option to the `csi-addons` tool.

Updates: #385