### PR TITLE
build: switch back to docker for golang:1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/projectquay/golang:1.20 as builder
+FROM golang:1.20 as builder
 
 # Copy the contents of the repository
 ADD . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons

--- a/build/Containerfile.sidecar
+++ b/build/Containerfile.sidecar
@@ -1,5 +1,5 @@
 # Build the sidecar binary
-FROM quay.io/projectquay/golang:1.20 as builder
+FROM golang:1.20 as builder
 
 # Copy the contents of the repository
 ADD . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons


### PR DESCRIPTION
This commit switches back to docker for
base image golang:1.20 since github actions
does not seem to be able to pull from quay
intermittently.

The actions seem to be failing from around the same time this change was introduced.

https://github.com/csi-addons/kubernetes-csi-addons/pull/383/files

https://github.com/csi-addons/kubernetes-csi-addons/actions/workflows/build-push.yaml

We can further investigate and revert this after the release.