### PR TITLE
ci: wait for images to be pushed before creating the release

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -115,6 +115,10 @@ jobs:
       github.repository == 'csi-addons/kubernetes-csi-addons'
       &&
       github.ref_type  == 'tag'
+    needs:
+      - tag_bundle
+      - tag_controller
+      - tag_sidecar
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
The release is created a little before images are pushed. This caused some confusion by consumers who were very eager to adopt the new version. By having the release job depend on the image building and pushing, this should not happen anymore.