### PR TITLE
fix: fix markdown failures

### DIFF
--- a/.github/workflows/lint-extras.yaml
+++ b/.github/workflows/lint-extras.yaml
@@ -26,6 +26,5 @@ jobs:
           VALIDATE_GO: false
           VALIDATE_JSCPD: false
           VALIDATE_KUBERNETES_KUBECONFORM: false
-          VALIDATE_MARKDOWN: false
           VALIDATE_PROTOBUF: false
           VALIDATE_YAML: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,9 @@ All Pull-Requests are required to be reviewed by at least two others that
 regularly participate in the project. There are two GitHub teams that contain
 members who can approve changes:
 
- - @csi-addons/kubernetes-csi-addons-contributors: regular contributors,
+- @csi-addons/kubernetes-csi-addons-contributors: regular contributors,
    sending Pull-Requests, designing new features
- - @csi-addons/kubernetes-csi-addons-reviewers: contributors to the general
+- @csi-addons/kubernetes-csi-addons-reviewers: contributors to the general
    CSI-Addons project, sharing expertise and domain knowledge
 
 For changes that are related to the integration with other components or affect

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the interface, a new CSI-Addons Controller is needed. The CSI-Addons Controller
 will watch for Kubernetes events (CRs) and relay operation initiated by the
 user to the CSI-driver.
 
-```
+```plaintext
 .------.   CR  .------------.
 | User |-------| CSI-Addons |
 '------'       | Controller |
@@ -83,6 +83,5 @@ Subscribing can be done through the [mailman web interface][mailman] or by
 [csi_addons_spec]: https://github.com/csi-addons/spec/
 [csi_addons]: https://csi-addons.github.io/
 [csi]: https://kubernetes-csi.github.io/docs/
-[operatorhub]: https://operatorhub.io/
 [mailman]: https://listman.redhat.com/mailman/listinfo/csi-addons
 [subscribe]: mailto:csi-addons-request@redhat.com?subject=subscribe

--- a/cmd/csi-addons/README.md
+++ b/cmd/csi-addons/README.md
@@ -10,17 +10,17 @@ similar to:
 ```console
 $ kubectl exec -c csi-addons csi-backend-nodeplugin -- csi-addons -h
   -drivername string
-    	name of the CSI driver
+    name of the CSI driver
   -endpoint string
-    	CSI-Addons endpoint (default "unix:///tmp/csi-addons.sock")
+    CSI-Addons endpoint (default "unix:///tmp/csi-addons.sock")
   -legacy
-    	use legacy format for old Kubernetes versions
+    use legacy format for old Kubernetes versions
   -operation string
-    	csi-addons operation
+    csi-addons operation
   -persistentvolume string
-    	name of the PersistentVolume
+    name of the PersistentVolume
   -stagingpath string
-    	staging path (default "/var/lib/kubelet/plugins/kubernetes.io/csi/")
+    staging path (default "/var/lib/kubelet/plugins/kubernetes.io/csi/")
 
 The following operations are supported:
  - NodeReclaimSpace

--- a/docs/csiaddonsnode.md
+++ b/docs/csiaddonsnode.md
@@ -14,6 +14,6 @@ spec:
         nodeID: node-1
 ```
 + `driver` contains the required information about the CSI driver.
-    + `name` contains the name of the driver. The name of the driver is in the format: `driver.csi.example.io`
-    + `endpoint` contains the URL that contains the name of the Pod and its Namespace that can be used by the controller to connect to.
-    + `nodeID` contains the ID of node to identify on which node the side-car is running.
+  + `name` contains the name of the driver. The name of the driver is in the format: `driver.csi.example.io`
+  + `endpoint` contains the URL that contains the name of the Pod and its Namespace that can be used by the controller to connect to.
+  + `nodeID` contains the ID of node to identify on which node the side-car is running.

--- a/docs/networkfence.md
+++ b/docs/networkfence.md
@@ -5,7 +5,7 @@ NetworkFence is a cluster-scoped custom resource that allows Kubernetes to invok
 The user needs to specify the list of CIDR blocks on which network fencing operation will be performed; alongside the csi driver name.
 The creation of NetworkFence CR will add a network fence, and its deletion will undo the operation.
 
-### Fence Operation
+## Fence Operation
 
 ```yaml
 apiVersion: csiaddons.openshift.io/v1alpha1

--- a/docs/reclaimspace.md
+++ b/docs/reclaimspace.md
@@ -68,7 +68,7 @@ spec:
 `reclaimspace.csiaddons.openshift.io/schedule: "@midnight"` annotation
 to PersistentVolumeClaim object.
 
-```
+```console
 $ kubectl get pvc data-pvc
 NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
 data-pvc  Bound    pvc-f37b8582-4b04-4676-88dd-e1b95c6abf74   1Gi        RWO            default           20h
@@ -112,7 +112,7 @@ want kubernetes-csi-addons to consider existing PersistentVolumeClaims.
 
 `drivernames` can be `,` separated driver names that supports reclaimspace operations.
 
-```
+```console
 $ kubectl get namespace default
 NAME      STATUS   AGE
 default   Active   5d2h


### PR DESCRIPTION
This PR involves enabling of Markdown linter and fixing the failures.

Updates: https://github.com/csi-addons/kubernetes-csi-addons/issues/405, https://github.com/csi-addons/kubernetes-csi-addons/issues/12

 
 