### PR TITLE
Fix corner cases bugs found in CEL validation

### DIFF
--- a/apis/csiaddons/v1alpha1/networkfence_types.go
+++ b/apis/csiaddons/v1alpha1/networkfence_types.go
@@ -56,6 +56,7 @@ type SecretSpec struct {
 }
 
 // NetworkFenceSpec defines the desired state of NetworkFence
+// +kubebuilder:validation:XValidation:rule="has(self.parameters) == has(oldSelf.parameters)",message="parameters are immutable"
 type NetworkFenceSpec struct {
 	// Driver contains  the name of CSI driver.
 	// +kubebuilder:validation:Required

--- a/apis/csiaddons/v1alpha1/networkfence_types.go
+++ b/apis/csiaddons/v1alpha1/networkfence_types.go
@@ -57,6 +57,7 @@ type SecretSpec struct {
 
 // NetworkFenceSpec defines the desired state of NetworkFence
 // +kubebuilder:validation:XValidation:rule="has(self.parameters) == has(oldSelf.parameters)",message="parameters are immutable"
+// +kubebuilder:validation:XValidation:rule="has(self.secret) == has(oldSelf.secret)",message="secret is immutable"
 type NetworkFenceSpec struct {
 	// Driver contains  the name of CSI driver.
 	// +kubebuilder:validation:Required

--- a/apis/replication.storage/v1alpha1/volumereplicationclass_types.go
+++ b/apis/replication.storage/v1alpha1/volumereplicationclass_types.go
@@ -23,6 +23,7 @@ import (
 // VolumeReplicationClassSpec specifies parameters that an underlying storage system uses
 // when creating a volume replica. A specific VolumeReplicationClass is used by specifying
 // its name in a VolumeReplication object.
+// +kubebuilder:validation:XValidation:rule="has(self.parameters) == has(oldSelf.parameters)",message="parameters are immutable"
 type VolumeReplicationClassSpec struct {
 	// Provisioner is the name of storage provisioner
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
+++ b/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
@@ -105,6 +105,9 @@ spec:
             - driver
             - fenceState
             type: object
+            x-kubernetes-validations:
+            - message: parameters are immutable
+              rule: has(self.parameters) == has(oldSelf.parameters)
           status:
             description: NetworkFenceStatus defines the observed state of NetworkFence
             properties:

--- a/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
+++ b/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
@@ -108,6 +108,8 @@ spec:
             x-kubernetes-validations:
             - message: parameters are immutable
               rule: has(self.parameters) == has(oldSelf.parameters)
+            - message: secret is immutable
+              rule: has(self.secret) == has(oldSelf.secret)
           status:
             description: NetworkFenceStatus defines the observed state of NetworkFence
             properties:

--- a/config/crd/bases/replication.storage.openshift.io_volumereplicationclasses.yaml
+++ b/config/crd/bases/replication.storage.openshift.io_volumereplicationclasses.yaml
@@ -61,6 +61,9 @@ spec:
             required:
             - provisioner
             type: object
+            x-kubernetes-validations:
+            - message: parameters are immutable
+              rule: has(self.parameters) == has(oldSelf.parameters)
           status:
             description: VolumeReplicationClassStatus defines the observed state of
               VolumeReplicationClass.

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -213,6 +213,9 @@ spec:
             - driver
             - fenceState
             type: object
+            x-kubernetes-validations:
+            - message: parameters are immutable
+              rule: has(self.parameters) == has(oldSelf.parameters)
           status:
             description: NetworkFenceStatus defines the observed state of NetworkFence
             properties:

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -778,6 +778,9 @@ spec:
             required:
             - provisioner
             type: object
+            x-kubernetes-validations:
+            - message: parameters are immutable
+              rule: has(self.parameters) == has(oldSelf.parameters)
           status:
             description: VolumeReplicationClassStatus defines the observed state of
               VolumeReplicationClass.

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -216,6 +216,8 @@ spec:
             x-kubernetes-validations:
             - message: parameters are immutable
               rule: has(self.parameters) == has(oldSelf.parameters)
+            - message: secret is immutable
+              rule: has(self.secret) == has(oldSelf.secret)
           status:
             description: NetworkFenceStatus defines the observed state of NetworkFence
             properties:


### PR DESCRIPTION
With current code we cannot update the parameters/secret once created but Currently we have a bug in spec where secrets/parameters can be deleted once created but we should not allow that operation as well. This PR contains the fix which doesn't allow the deletion of parameters/secrets once created.