### PR TITLE
Explicitly disable gRPC idle timeout

### DIFF
--- a/internal/connection/connection.go
+++ b/internal/connection/connection.go
@@ -38,8 +38,11 @@ type Connection struct {
 // NewConnection establishes connection with sidecar, fetches capability and returns Connection object
 // filled with required information.
 func NewConnection(ctx context.Context, endpoint, nodeID, driverName string) (*Connection, error) {
-	opts := grpc.WithTransportCredentials(insecure.NewCredentials())
-	cc, err := grpc.Dial(endpoint, opts)
+	opts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithIdleTimeout(time.Duration(0)),
+	}
+	cc, err := grpc.Dial(endpoint, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The idle timeout was disabled, but has been enabled by default in
google.golang.org/grpc v1.59. The kubernetes-csi-addons operator acts
similarly to the Kubernetes external-provisioner, and benefits from
having a functional gRPC connection open to the csi-addons sidecars that
run alongside CSI-drivers.

See-also: kubernetes-csi/external-provisioner#1099
Signed-off-by: Niels de Vos <ndevos@ibm.com>
