### PR TITLE
deploy: run all containers with read-only filesystem

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,7 @@ spec:
                   fieldPath: metadata.namespace
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           livenessProbe:
             httpGet:
               path: /healthz

--- a/config/manager/manager_auth_proxy_patch.yaml
+++ b/config/manager/manager_auth_proxy_patch.yaml
@@ -30,6 +30,9 @@ spec:
             requests:
               cpu: 10m
               memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
         - name: manager
           args:
             - "--namespace=$(POD_NAMESPACE)"

--- a/deploy/controller/setup-controller.yaml
+++ b/deploy/controller/setup-controller.yaml
@@ -56,6 +56,9 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       - args:
         - --namespace=$(POD_NAMESPACE)
         - --health-probe-bind-address=:8081
@@ -91,6 +94,7 @@ spec:
             memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       securityContext:
         runAsNonRoot: true
       serviceAccountName: csi-addons-controller-manager


### PR DESCRIPTION
Prevent potential abuse of the container storage a little more, by
running all containers with a read-only filesystem.