### PR TITLE
replace custom ContainsInSlice() with standard slices.Contains()

### DIFF
--- a/controllers/csiaddons/csiaddonsnode_controller.go
+++ b/controllers/csiaddons/csiaddonsnode_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/apis/csiaddons/v1alpha1"
@@ -166,7 +167,7 @@ func (r *CSIAddonsNodeReconciler) addFinalizer(
 	logger *logr.Logger,
 	csiAddonsNode *csiaddonsv1alpha1.CSIAddonsNode) error {
 
-	if !util.ContainsInSlice(csiAddonsNode.Finalizers, csiAddonsNodeFinalizer) {
+	if !slices.Contains(csiAddonsNode.Finalizers, csiAddonsNodeFinalizer) {
 		logger.Info("Adding finalizer")
 
 		csiAddonsNode.Finalizers = append(csiAddonsNode.Finalizers, csiAddonsNodeFinalizer)
@@ -186,7 +187,7 @@ func (r *CSIAddonsNodeReconciler) removeFinalizer(
 	logger *logr.Logger,
 	csiAddonsNode *csiaddonsv1alpha1.CSIAddonsNode) error {
 
-	if util.ContainsInSlice(csiAddonsNode.Finalizers, csiAddonsNodeFinalizer) {
+	if slices.Contains(csiAddonsNode.Finalizers, csiAddonsNodeFinalizer) {
 		logger.Info("Removing finalizer")
 
 		csiAddonsNode.Finalizers = util.RemoveFromSlice(csiAddonsNode.Finalizers, csiAddonsNodeFinalizer)

--- a/controllers/csiaddons/networkfence_controller.go
+++ b/controllers/csiaddons/networkfence_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -124,7 +125,7 @@ func (r *NetworkFenceReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// check if the networkfence object is getting deleted and handle it.
 	if !nf.instance.GetDeletionTimestamp().IsZero() {
-		if util.ContainsInSlice(nwFence.GetFinalizers(), networkFenceFinalizer) {
+		if slices.Contains(nwFence.GetFinalizers(), networkFenceFinalizer) {
 
 			err := nf.removeFinalizerFromNetworkFence(ctx)
 			if err != nil {
@@ -270,7 +271,7 @@ func (nf *NetworkFenceInstance) unfenceClusterNetwork(ctx context.Context, reque
 
 // addFinalizerToNetworkFence adds a finalizer to the Networkfence instance.
 func (nf *NetworkFenceInstance) addFinalizerToNetworkFence(ctx context.Context) error {
-	if !util.ContainsInSlice(nf.instance.Finalizers, networkFenceFinalizer) {
+	if !slices.Contains(nf.instance.Finalizers, networkFenceFinalizer) {
 		nf.logger.Info("adding finalizer to NetworkFence object", "Finalizer", networkFenceFinalizer)
 
 		nf.instance.Finalizers = append(nf.instance.Finalizers, networkFenceFinalizer)
@@ -285,7 +286,7 @@ func (nf *NetworkFenceInstance) addFinalizerToNetworkFence(ctx context.Context) 
 
 // removeFinalizerFromNetworkFence removes the finalizer from the Networkfence instance.
 func (nf *NetworkFenceInstance) removeFinalizerFromNetworkFence(ctx context.Context) error {
-	if util.ContainsInSlice(nf.instance.Finalizers, networkFenceFinalizer) {
+	if slices.Contains(nf.instance.Finalizers, networkFenceFinalizer) {
 		nf.logger.Info("removing finalizer from NetworkFence object", "Finalizer", networkFenceFinalizer)
 
 		nf.instance.Finalizers = util.RemoveFromSlice(nf.instance.Finalizers, networkFenceFinalizer)

--- a/controllers/csiaddons/persistentvolumeclaim_controller.go
+++ b/controllers/csiaddons/persistentvolumeclaim_controller.go
@@ -21,12 +21,12 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/apis/csiaddons/v1alpha1"
 	"github.com/csi-addons/kubernetes-csi-addons/internal/connection"
-	"github.com/csi-addons/kubernetes-csi-addons/internal/util"
 
 	"github.com/go-logr/logr"
 	"github.com/robfig/cron/v3"
@@ -221,7 +221,7 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 func (r *PersistentVolumeClaimReconciler) checkDriverSupportReclaimsSpace(logger *logr.Logger, annotations map[string]string, driver string) (bool, bool) {
 	reclaimSpaceSupportedByDriver := false
 
-	if drivers, ok := annotations[csiAddonsDriverAnnotation]; ok && util.ContainsInSlice(strings.Split(drivers, ","), driver) {
+	if drivers, ok := annotations[csiAddonsDriverAnnotation]; ok && slices.Contains(strings.Split(drivers, ","), driver) {
 		reclaimSpaceSupportedByDriver = true
 	}
 

--- a/controllers/replication.storage/finalizers.go
+++ b/controllers/replication.storage/finalizers.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/apis/replication.storage/v1alpha1"
 	"github.com/csi-addons/kubernetes-csi-addons/internal/util"
@@ -35,7 +36,7 @@ const (
 // addFinalizerToVR adds the VR finalizer on the VolumeReplication instance.
 func (r *VolumeReplicationReconciler) addFinalizerToVR(logger logr.Logger, vr *replicationv1alpha1.VolumeReplication,
 ) error {
-	if !util.ContainsInSlice(vr.ObjectMeta.Finalizers, volumeReplicationFinalizer) {
+	if !slices.Contains(vr.ObjectMeta.Finalizers, volumeReplicationFinalizer) {
 		logger.Info("adding finalizer to volumeReplication object", "Finalizer", volumeReplicationFinalizer)
 		vr.ObjectMeta.Finalizers = append(vr.ObjectMeta.Finalizers, volumeReplicationFinalizer)
 		if err := r.Client.Update(context.TODO(), vr); err != nil {
@@ -50,7 +51,7 @@ func (r *VolumeReplicationReconciler) addFinalizerToVR(logger logr.Logger, vr *r
 
 // removeFinalizerFromVR removes the VR finalizer from the VolumeReplication instance.
 func (r *VolumeReplicationReconciler) removeFinalizerFromVR(logger logr.Logger, vr *replicationv1alpha1.VolumeReplication) error {
-	if util.ContainsInSlice(vr.ObjectMeta.Finalizers, volumeReplicationFinalizer) {
+	if slices.Contains(vr.ObjectMeta.Finalizers, volumeReplicationFinalizer) {
 		logger.Info("removing finalizer from volumeReplication object", "Finalizer", volumeReplicationFinalizer)
 		vr.ObjectMeta.Finalizers = util.RemoveFromSlice(vr.ObjectMeta.Finalizers, volumeReplicationFinalizer)
 		if err := r.Client.Update(context.TODO(), vr); err != nil {
@@ -65,7 +66,7 @@ func (r *VolumeReplicationReconciler) removeFinalizerFromVR(logger logr.Logger, 
 
 // addFinalizerToPVC adds the VR finalizer on the PersistentVolumeClaim.
 func (r *VolumeReplicationReconciler) addFinalizerToPVC(logger logr.Logger, pvc *corev1.PersistentVolumeClaim) error {
-	if !util.ContainsInSlice(pvc.ObjectMeta.Finalizers, pvcReplicationFinalizer) {
+	if !slices.Contains(pvc.ObjectMeta.Finalizers, pvcReplicationFinalizer) {
 		logger.Info("adding finalizer to PersistentVolumeClaim object", "Finalizer", pvcReplicationFinalizer)
 		pvc.ObjectMeta.Finalizers = append(pvc.ObjectMeta.Finalizers, pvcReplicationFinalizer)
 		if err := r.Client.Update(context.TODO(), pvc); err != nil {
@@ -81,7 +82,7 @@ func (r *VolumeReplicationReconciler) addFinalizerToPVC(logger logr.Logger, pvc 
 // removeFinalizerFromPVC removes the VR finalizer on PersistentVolumeClaim.
 func (r *VolumeReplicationReconciler) removeFinalizerFromPVC(logger logr.Logger, pvc *corev1.PersistentVolumeClaim,
 ) error {
-	if util.ContainsInSlice(pvc.ObjectMeta.Finalizers, pvcReplicationFinalizer) {
+	if slices.Contains(pvc.ObjectMeta.Finalizers, pvcReplicationFinalizer) {
 		logger.Info("removing finalizer from PersistentVolumeClaim object", "Finalizer", pvcReplicationFinalizer)
 		pvc.ObjectMeta.Finalizers = util.RemoveFromSlice(pvc.ObjectMeta.Finalizers, pvcReplicationFinalizer)
 		if err := r.Client.Update(context.TODO(), pvc); err != nil {

--- a/controllers/replication.storage/volumereplication_controller.go
+++ b/controllers/replication.storage/volumereplication_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/apis/replication.storage/v1alpha1"
@@ -215,7 +216,7 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			return reconcile.Result{}, err
 		}
 	} else {
-		if util.ContainsInSlice(instance.GetFinalizers(), volumeReplicationFinalizer) {
+		if slices.Contains(instance.GetFinalizers(), volumeReplicationFinalizer) {
 			err = r.disableVolumeReplication(vr)
 			if err != nil {
 				logger.Error(err, "failed to disable replication")

--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -16,26 +16,13 @@ limitations under the License.
 
 package util
 
-// ConstainsInSlice find given string in given slice.
-func ContainsInSlice(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-
-	return false
-}
+import (
+	"slices"
+)
 
 // RemoveFromSlice removes given string from given slice.
 func RemoveFromSlice(slice []string, s string) []string {
-	result := []string{}
-	for _, item := range slice {
-		if item == s {
-			continue
-		}
-		result = append(result, item)
-	}
-
-	return result
+	return slices.DeleteFunc(slice, func(v string) bool {
+		return s == v
+	})
 }

--- a/internal/util/strings_test.go
+++ b/internal/util/strings_test.go
@@ -22,57 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestContainsInSlice(t *testing.T) {
-	type args struct {
-		slice []string
-		s     string
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "present",
-			args: args{
-				slice: []string{"hello", "hi", "hey"},
-				s:     "hello",
-			},
-			want: true,
-		},
-		{
-			name: "absent",
-			args: args{
-				slice: []string{"hello", "hi", "hey"},
-				s:     "bye",
-			},
-			want: false,
-		},
-		{
-			name: "nil slice",
-			args: args{
-				slice: nil,
-				s:     "hello",
-			},
-			want: false,
-		},
-		{
-			name: "empty slice",
-			args: args{
-				slice: []string{},
-				s:     "hello",
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			res := ContainsInSlice(tt.args.slice, tt.args.s)
-			assert.Equal(t, tt.want, res)
-		})
-	}
-}
-
 func TestRemoveFromSlice(t *testing.T) {
 	type args struct {
 		slice []string


### PR DESCRIPTION
With Go 1.21 the "slices" package can be used for many operations on slices. The custom ContainsInSlice() function can be replaced by the standard slices.Contains().