### PR TITLE
ci: use golang 1.22.0 for main build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csi-addons/kubernetes-csi-addons
 
-go 1.22.2
+go 1.22.0
 
 require (
 	github.com/container-storage-interface/spec v1.9.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/csi-addons/kubernetes-csi-addons/tools
 
-go 1.22.2
+go 1.22.0
 
 require (
 	github.com/operator-framework/operator-sdk v1.34.2


### PR DESCRIPTION
some CI/developers will not have flexibility  to switch to the latest version, we are sticking to the first release version of golang 1.22