### PR TITLE
replication: add missing VRC name for VGR

### DIFF
--- a/apis/replication.storage/v1alpha1/volumegroupreplication_types.go
+++ b/apis/replication.storage/v1alpha1/volumegroupreplication_types.go
@@ -27,6 +27,11 @@ type VolumeGroupReplicationSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeGroupReplicationClassName is immutable"
 	VolumeGroupReplicationClassName string `json:"volumeGroupReplicationClassName"`
 
+	// volumeReplicationClassName is the volumeReplicationClass name for VolumeReplication object
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumReplicationClassName is immutable"
+	VolumeReplicationClassName string `json:"volumeReplicationClassName"`
+
 	// Name of the VolumeReplication object created for this volumeGroupReplication
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeReplicationName is immutable"

--- a/config/crd/bases/replication.storage.openshift.io_volumegroupreplications.yaml
+++ b/config/crd/bases/replication.storage.openshift.io_volumegroupreplications.yaml
@@ -130,6 +130,13 @@ spec:
                 x-kubernetes-validations:
                 - message: volumeGroupReplicationContentName is immutable
                   rule: self == oldSelf
+              volumeReplicationClassName:
+                description: volumeReplicationClassName is the volumeReplicationClass
+                  name for VolumeReplication object
+                type: string
+                x-kubernetes-validations:
+                - message: volumReplicationClassName is immutable
+                  rule: self == oldSelf
               volumeReplicationName:
                 description: Name of the VolumeReplication object created for this
                   volumeGroupReplication
@@ -142,6 +149,7 @@ spec:
             - replicationState
             - source
             - volumeGroupReplicationClassName
+            - volumeReplicationClassName
             type: object
           status:
             description: VolumeGroupReplicationStatus defines the observed state of

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -1153,6 +1153,13 @@ spec:
                 x-kubernetes-validations:
                 - message: volumeGroupReplicationContentName is immutable
                   rule: self == oldSelf
+              volumeReplicationClassName:
+                description: volumeReplicationClassName is the volumeReplicationClass
+                  name for VolumeReplication object
+                type: string
+                x-kubernetes-validations:
+                - message: volumReplicationClassName is immutable
+                  rule: self == oldSelf
               volumeReplicationName:
                 description: Name of the VolumeReplication object created for this
                   volumeGroupReplication
@@ -1165,6 +1172,7 @@ spec:
             - replicationState
             - source
             - volumeGroupReplicationClassName
+            - volumeReplicationClassName
             type: object
           status:
             description: VolumeGroupReplicationStatus defines the observed state of


### PR DESCRIPTION
we need to have a VRC name to create the VR, this PR adds a new field to the VGR to pass down the VRC name for the VolumeReplication object.