### PR TITLE
replication: fix problem with setReplication

### DIFF
--- a/internal/sidecar/service/volumereplication.go
+++ b/internal/sidecar/service/volumereplication.go
@@ -69,7 +69,7 @@ func (rs *ReplicationServer) EnableVolumeReplication(
 		Parameters:    req.GetParameters(),
 		Secrets:       data,
 	}
-	err = setReplicationSource(repReq.ReplicationSource, req.GetReplicationSource())
+	err = setReplicationSource(&repReq.ReplicationSource, req.GetReplicationSource())
 	if err != nil {
 		klog.Errorf("Failed to set replication source: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -102,7 +102,7 @@ func (rs *ReplicationServer) DisableVolumeReplication(
 		Parameters:    req.GetParameters(),
 		Secrets:       data,
 	}
-	err = setReplicationSource(repReq.ReplicationSource, req.GetReplicationSource())
+	err = setReplicationSource(&repReq.ReplicationSource, req.GetReplicationSource())
 	if err != nil {
 		klog.Errorf("Failed to set replication source: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -135,7 +135,7 @@ func (rs *ReplicationServer) PromoteVolume(
 		Force:         req.GetForce(),
 		Secrets:       data,
 	}
-	err = setReplicationSource(repReq.ReplicationSource, req.GetReplicationSource())
+	err = setReplicationSource(&repReq.ReplicationSource, req.GetReplicationSource())
 	if err != nil {
 		klog.Errorf("Failed to set replication source: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -168,7 +168,7 @@ func (rs *ReplicationServer) DemoteVolume(
 		Force:         req.GetForce(),
 		Secrets:       data,
 	}
-	err = setReplicationSource(repReq.ReplicationSource, req.GetReplicationSource())
+	err = setReplicationSource(&repReq.ReplicationSource, req.GetReplicationSource())
 	if err != nil {
 		klog.Errorf("Failed to set replication source: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -201,7 +201,7 @@ func (rs *ReplicationServer) ResyncVolume(
 		Force:         req.GetForce(),
 		Secrets:       data,
 	}
-	err = setReplicationSource(repReq.ReplicationSource, req.GetReplicationSource())
+	err = setReplicationSource(&repReq.ReplicationSource, req.GetReplicationSource())
 	if err != nil {
 		klog.Errorf("Failed to set replication source: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -234,7 +234,7 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(
 		ReplicationId: req.GetReplicationId(),
 		Secrets:       data,
 	}
-	err = setReplicationSource(repReq.ReplicationSource, req.GetReplicationSource())
+	err = setReplicationSource(&repReq.ReplicationSource, req.GetReplicationSource())
 	if err != nil {
 		klog.Errorf("Failed to set replication source: %v", err)
 		return nil, status.Error(codes.Internal, err.Error())
@@ -259,9 +259,9 @@ func (rs *ReplicationServer) GetVolumeReplicationInfo(
 }
 
 // setReplicationSource sets the replication source for the given ReplicationSource.
-func setReplicationSource(src *csiReplication.ReplicationSource, req *proto.ReplicationSource) error {
-	if src == nil {
-		src = &csiReplication.ReplicationSource{}
+func setReplicationSource(src **csiReplication.ReplicationSource, req *proto.ReplicationSource) error {
+	if *src == nil {
+		*src = &csiReplication.ReplicationSource{}
 	}
 
 	switch {
@@ -270,12 +270,12 @@ func setReplicationSource(src *csiReplication.ReplicationSource, req *proto.Repl
 	case req.GetVolume() == nil && req.GetVolumeGroup() == nil:
 		return errors.New("either volume or volume group is required")
 	case req.GetVolume() != nil:
-		src.Type = &csiReplication.ReplicationSource_Volume{Volume: &csiReplication.ReplicationSource_VolumeSource{
+		(*src).Type = &csiReplication.ReplicationSource_Volume{Volume: &csiReplication.ReplicationSource_VolumeSource{
 			VolumeId: req.GetVolume().GetVolumeId(),
 		}}
 		return nil
 	case req.GetVolumeGroup() != nil:
-		src.Type = &csiReplication.ReplicationSource_Volumegroup{Volumegroup: &csiReplication.ReplicationSource_VolumeGroupSource{
+		(*src).Type = &csiReplication.ReplicationSource_Volumegroup{Volumegroup: &csiReplication.ReplicationSource_VolumeGroupSource{
 			VolumeGroupId: req.GetVolumeGroup().GetVolumeGroupId(),
 		}}
 		return nil

--- a/internal/sidecar/service/volumereplication_test.go
+++ b/internal/sidecar/service/volumereplication_test.go
@@ -43,12 +43,26 @@ func Test_setReplicationSource(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "set replication source when request is not set",
+			name: "set replication source when request is nil",
 			args: args{
-				src: &csiReplication.ReplicationSource{},
-				req: &proto.ReplicationSource{},
+				src: nil,
+				req: nil,
 			},
 			wantErr: true,
+		},
+		{
+			name: "set replication source is nil but request is not nil",
+			args: args{
+				src: nil,
+				req: &proto.ReplicationSource{
+					Type: &proto.ReplicationSource_Volume{
+						Volume: &proto.ReplicationSource_VolumeSource{
+							VolumeId: volID,
+						},
+					},
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "set replication source when volume is set",
@@ -81,16 +95,16 @@ func Test_setReplicationSource(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := setReplicationSource(tt.args.src, tt.args.req); (err != nil) != tt.wantErr {
+			if err := setReplicationSource(&tt.args.src, tt.args.req); (err != nil) != tt.wantErr {
 				t.Errorf("setReplicationSource() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if tt.args.req.GetVolume() != nil {
-				if tt.args.req.GetVolume().GetVolumeId() != volID {
+				if tt.args.src.GetVolume().GetVolumeId() != volID {
 					t.Errorf("setReplicationSource() got = %v volumeID, expected = %v volumeID", tt.args.req.GetVolume().GetVolumeId(), volID)
 				}
 			}
 			if tt.args.req.GetVolumeGroup() != nil {
-				if tt.args.req.GetVolumeGroup().GetVolumeGroupId() != groupID {
+				if tt.args.src.GetVolumegroup().GetVolumeGroupId() != groupID {
 					t.Errorf("setReplicationSource() got = %v groupID, expected = %v volumeID", tt.args.req.GetVolumeGroup().GetVolumeGroupId(), groupID)
 				}
 			}


### PR DESCRIPTION
When src is nil, we create a new instance of csiReplication.ReplicationSource but this newly created instance does not
propagate back to the caller since Go passes pointers by value, This commit fixes the problem.