### PR TITLE
build: update kube-rbac-proxy to v0.18.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ SKIP_RANGE ?=
 # the kube-rbac-proxy can easily be tested. Products that include CSI-Addons
 # may want to provide a different location of the container-image.
 # The default value is set in config/default/kustomization.yaml
-RBAC_PROXY_IMG ?= gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+RBAC_PROXY_IMG ?= quay.io/brancz/kube-rbac-proxy:v0.18.0
 
 # The default version of the bundle (CSV) can be found in
 # config/manifests/bases/csi-addons.clusterserviceversion.yaml . When tagging a

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -29,7 +29,7 @@ images:
   newName: quay.io/csiaddons/k8s-controller
   newTag: latest
 - name: rbac-proxy
-  newName: gcr.io/kubebuilder/kube-rbac-proxy
-  newTag: v0.8.0
+  newName: quay.io/brancz/kube-rbac-proxy
+  newTag: v0.18.0
 patches:
 - path: manager_auth_proxy_patch.yaml

--- a/deploy/controller/setup-controller.yaml
+++ b/deploy/controller/setup-controller.yaml
@@ -52,7 +52,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
kube-rbac-proxy was pulled from the Google Container Registry, and
Kubernetes managed projects prefer not to use that anymore.

The container-image is (for now, still) maintained outside of the
Kubernetes project, and it is recommended to pull it from quay.io.

While validating the container-image location, it seems that there is a
new version available. Now also using the latest v0.18.0.

Updates: #643
Signed-off-by: Niels de Vos <ndevos@ibm.com>
