### PR TITLE
build: address FROM/as casing warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 
 # Copy the contents of the repository
 COPY . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons

--- a/build/Containerfile.sidecar
+++ b/build/Containerfile.sidecar
@@ -1,5 +1,5 @@
 # Build the sidecar binary
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 
 # Copy the contents of the repository
 COPY . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons


### PR DESCRIPTION
GitHub Actions report the following warning:

> The 'as' keyword should match the case of the 'from' keyword
> FromAsCasing: 'as' and 'FROM' keywords' casing do not match

All other container build commands are CAPITALIZED, changing 'as' to 'AS'
matches it now.

See-also: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
Signed-off-by: Niels de Vos <ndevos@ibm.com>
