### PR TITLE
deploy: remove extra prefix: csi-addons-

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,13 +1,6 @@
 # Adds namespace to all resources.
 namespace: csi-addons-system
 
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: csi-addons-
-
 # Labels to add to all resources and selectors.
 #labels:
 #- includeSelectors: true


### PR DESCRIPTION
Unnecessary prefix: csi-addons- was added by mistake in default kustomization.yaml in below commit

https://github.com/csi-addons/kubernetes-csi-addons/commit/90c23d244b198b6df9d2350bd1ab80d8e0c1d784#diff-c006b1ef995eeeb57408cce42bd84db8dfc0cbe18df03222857665cebb1ac6fd