### PR TITLE
replication: add new Validated condition

### DIFF
--- a/api/replication.storage/v1alpha1/volumereplication_types.go
+++ b/api/replication.storage/v1alpha1/volumereplication_types.go
@@ -33,6 +33,7 @@ const (
 	ConditionCompleted = "Completed"
 	ConditionDegraded  = "Degraded"
 	ConditionResyncing = "Resyncing"
+	ConditionValidated = "Validated"
 )
 
 // These are valid conditions.
@@ -60,6 +61,10 @@ const (
 	FailedToResync = "FailedToResync"
 	// NotResyncing condition represents the volume is not resyncing.
 	NotResyncing = "NotResyncing"
+	// PrerequisiteMet condition represents that the prerequisite is met.
+	PrerequisiteMet = "PrerequisiteMet"
+	// PrerequisiteNotMet condition represents that the prerequisite is not met.
+	PrerequisiteNotMet = "PrerequisiteNotMet"
 )
 
 // ReplicationState represents the replication operations to be performed on the volume.

--- a/internal/controller/replication.storage/status.go
+++ b/internal/controller/replication.storage/status.go
@@ -65,6 +65,40 @@ func setFailedPromotionCondition(conditions *[]metav1.Condition, observedGenerat
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 	})
+	setStatusCondition(conditions, &metav1.Condition{
+		Type:               v1alpha1.ConditionValidated,
+		Reason:             v1alpha1.PrerequisiteMet,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+	})
+}
+
+// sets conditions when volume promotion was failed due to failed validation.
+func setFailedValidationCondition(conditions *[]metav1.Condition, observedGeneration int64) {
+	setStatusCondition(conditions, &metav1.Condition{
+		Type:               v1alpha1.ConditionCompleted,
+		Reason:             v1alpha1.FailedToPromote,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+	})
+	setStatusCondition(conditions, &metav1.Condition{
+		Type:               v1alpha1.ConditionDegraded,
+		Reason:             v1alpha1.Error,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+	})
+	setStatusCondition(conditions, &metav1.Condition{
+		Type:               v1alpha1.ConditionResyncing,
+		Reason:             v1alpha1.NotResyncing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+	})
+	setStatusCondition(conditions, &metav1.Condition{
+		Type:               v1alpha1.ConditionValidated,
+		Reason:             v1alpha1.PrerequisiteNotMet,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+	})
 }
 
 // sets conditions when volume is demoted and ready to use (resync completed).


### PR DESCRIPTION
This commit adds new Validated condition.
This is initially used to indicate the csi driver
responded with FailedPrecondition grpc code for
EnableReplication request using
`PrerequisiteNotMet` reason.