### PR TITLE
Use protobuf encoding for core K8s apis

### DIFF
--- a/cmd/csi-addons/main.go
+++ b/cmd/csi-addons/main.go
@@ -25,6 +25,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -121,6 +122,8 @@ func getKubernetesClient() *kubernetes.Clientset {
 	if err != nil {
 		panic(err.Error())
 	}
+
+	config.ContentType = runtime.ContentTypeProtobuf
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
For core K8s API objects like Pods, Nodes, etc., we can use protobuf encoding which reduces CPU consumption related to (de)serialization, reduces overall latency of the API call, reduces memory footprint, reduces the amount of work performed by the GC and results in quicker propagation of objects to event handlers of shared informers.