### PR TITLE
rebase: use toolchain for 1.22.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/csi-addons/kubernetes-csi-addons
 
-go 1.22.6
+go 1.22.5
+
+toolchain go1.22.6
 
 require (
 	github.com/container-storage-interface/spec v1.10.0


### PR DESCRIPTION
we dont have downstream golang with version 1.22.6 and csi-addons needs 1.22.6 to build for that reason we can use the toolchain to enforce the soft dependency.