### PR TITLE
rebase: use go.mod for go version

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Generate the bundle contents
         run: make bundle

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/kind-deploy.yaml
+++ b/.github/workflows/kind-deploy.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Build container container image
         uses: docker/build-push-action@v6

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Generate the bundle contents
         run: make bundle TAG=${{ github.ref_name }}
@@ -129,7 +129,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Generate manifests for installation by kubectl
         run: make manifests TAG=${{ github.ref_name }}

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Generate the bundle contents
         run: make bundle

--- a/.github/workflows/test-golang.yaml
+++ b/.github/workflows/test-golang.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Install Protoc
         # action @v1.3.0 can install protoc 3.19, @v2 installs protoc v21.0+
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Verify Go modules
         run: go mod verify
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Golang
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version-file: go.mod
 
       - name: Vendor all dependencies
         run: go mod vendor


### PR DESCRIPTION
instead of defining own go version in test files we can use go.mod to setup the required version.