### PR TITLE
sanitize connection pool key pod name

### DIFF
--- a/internal/controller/csiaddons/csiaddonsnode_controller.go
+++ b/internal/controller/csiaddons/csiaddonsnode_controller.go
@@ -101,7 +101,7 @@ func (r *CSIAddonsNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if !csiAddonsNode.DeletionTimestamp.IsZero() {
 		// if deletion timestamp is set, the CSIAddonsNode is getting deleted,
 		// delete connections and remove finalizer.
-		logger.Info("Deleting connection")
+		logger.Info("Deleting connection", "Key", key)
 		r.ConnPool.Delete(key)
 		err = r.removeFinalizer(ctx, &logger, csiAddonsNode)
 		return ctrl.Result{}, err
@@ -139,7 +139,7 @@ func (r *CSIAddonsNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	logger.Info("Successfully connected to sidecar")
 	r.ConnPool.Put(key, newConn)
-	logger.Info("Added connection to connection pool")
+	logger.Info("Added connection to connection pool", "Key", key)
 
 	csiAddonsNode.Status.State = csiaddonsv1alpha1.CSIAddonsNodeStateConnected
 	csiAddonsNode.Status.Message = "Successfully established connection with sidecar"

--- a/internal/controller/csiaddons/csiaddonsnode_controller.go
+++ b/internal/controller/csiaddons/csiaddonsnode_controller.go
@@ -95,7 +95,7 @@ func (r *CSIAddonsNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	nodeID := csiAddonsNode.Spec.Driver.NodeID
 	driverName := csiAddonsNode.Spec.Driver.Name
 
-	key := csiAddonsNode.Namespace + "/" + csiAddonsNode.Name
+	key := csiAddonsNode.Namespace + "/" + util.NormalizeLeaseName(csiAddonsNode.Name)
 	logger = logger.WithValues("NodeID", nodeID, "DriverName", driverName)
 
 	if !csiAddonsNode.DeletionTimestamp.IsZero() {

--- a/internal/controller/replication.storage/volumereplication_controller.go
+++ b/internal/controller/replication.storage/volumereplication_controller.go
@@ -510,7 +510,7 @@ func getInfoReconcileInterval(parameters map[string]string, logger logr.Logger) 
 func (r *VolumeReplicationReconciler) getReplicationClient(ctx context.Context, driverName, dataSource string) (grpcClient.VolumeReplication, error) {
 	conn, err := r.Connpool.GetLeaderByDriver(ctx, r.Client, driverName)
 	if err != nil {
-		return nil, fmt.Errorf("no leader for the ControllerService of driver %q", driverName)
+		return nil, fmt.Errorf("no leader for the ControllerService of driver %q: %w", driverName, err)
 	}
 
 	for _, cap := range conn.Capabilities {


### PR DESCRIPTION
The csi-addons sidecar sanitizes the holder identity. The connection pool stores the mapping with key as the unsanitized name for csiaddonsnode, which leads to the `failed to find the namespace where driver` issue. 

To address this, we should sanitize the csiaddonsnode name before entering it into connection pool.
