### PR TITLE
Fix key in connection pool

### DIFF
--- a/internal/controller/csiaddons/csiaddonsnode_controller.go
+++ b/internal/controller/csiaddons/csiaddonsnode_controller.go
@@ -42,8 +42,6 @@ import (
 
 var (
 	csiAddonsNodeFinalizer = csiaddonsv1alpha1.GroupVersion.Group + "/csiaddonsnode"
-
-	errLegacyEndpoint = errors.New("legacy formatted endpoint")
 )
 
 // CSIAddonsNodeReconciler reconciles a CSIAddonsNode object
@@ -207,9 +205,7 @@ func (r *CSIAddonsNodeReconciler) removeFinalizer(
 // by GRPC to connect to the sidecar.
 func (r *CSIAddonsNodeReconciler) resolveEndpoint(ctx context.Context, rawURL string) (string, error) {
 	namespace, podname, port, err := parseEndpoint(rawURL)
-	if err != nil && errors.Is(err, errLegacyEndpoint) {
-		return rawURL, nil
-	} else if err != nil {
+	if err != nil {
 		return "", err
 	}
 
@@ -231,11 +227,6 @@ func (r *CSIAddonsNodeReconciler) resolveEndpoint(ctx context.Context, rawURL st
 // format. When the recommended format is used, it returns the Namespace,
 // PodName, Port and error instead.
 func parseEndpoint(rawURL string) (string, string, string, error) {
-	// assume old formatted endpoint, don't parse it
-	if !strings.Contains(rawURL, "://") {
-		return "", "", "", errLegacyEndpoint
-	}
-
 	endpoint, err := url.Parse(rawURL)
 	if err != nil {
 		return "", "", "", fmt.Errorf("failed to parse endpoint %q: %w", rawURL, err)

--- a/internal/controller/csiaddons/csiaddonsnode_controller_test.go
+++ b/internal/controller/csiaddons/csiaddonsnode_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/csi-addons/spec/lib/go/identity"
@@ -26,11 +25,8 @@ import (
 )
 
 func TestParseEndpoint(t *testing.T) {
-	_, _, _, err := parseEndpoint("1.2.3.4:5678")
-	assert.True(t, errors.Is(err, errLegacyEndpoint))
-
 	// test empty namespace
-	_, _, _, err = parseEndpoint("pod://pod-name:5678")
+	_, _, _, err := parseEndpoint("pod://pod-name:5678")
 	assert.Error(t, err)
 
 	// test empty namespace


### PR DESCRIPTION
In the connection pool we store the connection with unique identifier, the pod name and the namespace is used as the key to the connection  in the pool and GetLeaderByDriver get the leader based on the driver name and uses the identity of the leader which is pod name as the key to get the connection.