### PR TITLE
Fix key and ownerRef bug

### DIFF
--- a/internal/controller/csiaddons/csiaddonsnode_controller.go
+++ b/internal/controller/csiaddons/csiaddonsnode_controller.go
@@ -105,7 +105,9 @@ func (r *CSIAddonsNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// namespace + "/" + leader identity(pod name) is the key for the connection.
 	// this key is used by GetLeaderByDriver to get the connection
-	key := csiAddonsNode.Namespace + "/" + podName
+	// util.NormalizeLeaseName() is used to sanitize the leader identity used for the leases
+	// csiaddonsnode need to store the key with same format so that it can be used to get the connection.
+	key := csiAddonsNode.Namespace + "/" + util.NormalizeLeaseName(podName)
 
 	logger = logger.WithValues("EndPoint", endPoint)
 


### PR DESCRIPTION
csi-lib-utils/leaderelection:sanitizeName() is used to sanitize the leader identity used for the leases csiaddonsnode need to store the key with same format so that it can be used to get the connection.


The pod owned by deployment might move to new nodes and this might create the stale CSIAddonsNode object on the old node if we set Deployment as the ownerRef (this could leave stale connection in connection map and a CR).
so, we need to set the pod as the owner for the deployment as we dont store any details that are required later on for any other operations like Fencing etc.
