### PR TITLE
ci: drop linux/arm/v7 from the platforms for building container-images

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: ${{ secrets.BUILD_PLATFORMS }}
+          platforms: ${{ vars.BUILD_PLATFORMS }}
           push: true
           tags: quay.io/csiaddons/k8s-controller:latest
 
@@ -95,6 +95,6 @@ jobs:
         with:
           context: .
           file: build/Containerfile.sidecar
-          platforms: ${{ secrets.BUILD_PLATFORMS }}
+          platforms: ${{ vars.BUILD_PLATFORMS }}
           push: true
           tags: quay.io/csiaddons/k8s-sidecar:latest

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -52,7 +52,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: ${{ secrets.BUILD_PLATFORMS }}
+          platforms: ${{ vars.BUILD_PLATFORMS }}
           push: false
           tags: quay.io/csiaddons/k8s-controller:latest
 
@@ -74,6 +74,6 @@ jobs:
         with:
           context: .
           file: build/Containerfile.sidecar
-          platforms: ${{ secrets.BUILD_PLATFORMS }}
+          platforms: ${{ vars.BUILD_PLATFORMS }}
           push: false
           tags: quay.io/csiaddons/k8s-sidecar:latest

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -9,20 +9,20 @@ environments wants to run the build tests for all platforms. The workflows can
 be configured to select platforms that the `docker/setup-buildx-action`
 supports.
 
-For this configuration, a new Secret should be created in the GitHub
+For this configuration, a new Variable should be created in the GitHub
 Settings of the repository. 'Normal' environment variables seem not possible.
 
-An example of the GitHub Secret that will build the container-images on AMD64,
-and both 32-bit and 64-bit Arm platforms:
+An example of the GitHub Variable that will build the container-images on
+AMD64, and both 32-bit and 64-bit Arm platforms:
 
-- `BUILD_PLATFORMS`: `linux/amd64,linux/arm64,linux/arm/v7`
+- `BUILD_PLATFORMS`: `linux/amd64,linux/arm64`
 
-Detailed steps on creating the GitHub Secret can be found in [the GitHub
-Documentation][gh_doc_secret].
+Detailed steps on creating the GitHub Variable can be found in [the GitHub
+Documentation][gh_doc_variable].
 
 In case the `BUILD_PLATFORMS` environment variable is not set, the
 `docker/setup-buildx-action` action defaults to the single architecture where
 the workflow is run (usually `linux/amd64`).
 
 [workflows]: .github/workflows/
-[gh_doc_secret]: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
+[gh_doc_variable]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository


### PR DESCRIPTION
There is not need for `secrets.BUILD_PLATFORMS`, as the platforms are
not confidential. Instead a variable has been created in the GitHub
repository settings for it now.

The `secrets.BUILD_PLATFORMS` includes linux/arm/v7, which is a slow and
phased out architecture. All reasonable ARM platforms are linux/arm64
now. Dropping the linux/arm/v7 platform makes building the container
images much faster.

Closes: #719