### PR TITLE
build: require go 1.23 or newer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 # Copy the contents of the repository
 COPY . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons

--- a/build/Containerfile.sidecar
+++ b/build/Containerfile.sidecar
@@ -1,5 +1,5 @@
 # Build the sidecar binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 # Copy the contents of the repository
 COPY . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/csi-addons/kubernetes-csi-addons
 
-go 1.22.7
-
-toolchain go1.22.9
+go 1.23.0
 
 require (
 	github.com/container-storage-interface/spec v1.11.0


### PR DESCRIPTION
Latest Kubernetes packages depend on Go 1.23.0.

See-also: #728
