### PR TITLE
Lower case should be used for HTTP/2 fields

### DIFF
--- a/internal/kubernetes/token/grpc.go
+++ b/internal/kubernetes/token/grpc.go
@@ -40,7 +40,7 @@ import (
 )
 
 const bearerPrefix = "Bearer "
-const authorizationKey = "Authorization"
+const authorizationKey = "authorization"
 
 func WithServiceAccountToken() grpc.DialOption {
 	return grpc.WithUnaryInterceptor(addAuthorizationHeader)

--- a/sidecar/internal/csiaddonsnode/csiaddonsnode.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode.go
@@ -60,7 +60,7 @@ type Manager struct {
 	// CSI-driver that is included in the CSIAddonsNode object.
 	Client client.Client
 
-	// Config is a ReST Config for the Kubernets API.
+	// Config is a ReST Config for the Kubernetes API.
 	Config *rest.Config
 
 	// kubernetes client to interact with the Kubernetes API.


### PR DESCRIPTION
As per https://www.ietf.org/archive/id/draft-ietf-httpbis-http2bis-02.html#section-8.1.2 lower case should be used and gRPC library is automatically converting to lower case. 
Fixes issue https://github.com/csi-addons/kubernetes-csi-addons/issues/750
