### PR TITLE
fix empty volume group creation through cli tool

### DIFF
--- a/cmd/csi-addons/volumegroup.go
+++ b/cmd/csi-addons/volumegroup.go
@@ -75,10 +75,12 @@ func (vgb *VolumeGroupBase) SetParameters(parameters string) error {
 	return nil
 }
 
-// SetVolumeIDs sets and parses the volume IDs
+// SetVolumeIDs sets and parses the volume IDs, only if volumeids are provided.
 func (vgb *VolumeGroupBase) SetVolumeIDs(volumeids string) {
-	volumeIDs := strings.Split(volumeids, ",")
-	vgb.volumeIDs = volumeIDs
+	if volumeids != "" {
+		volumeIDs := strings.Split(volumeids, ",")
+		vgb.volumeIDs = volumeIDs
+	}
 }
 
 // Parses the parameters to convert them from string format to map[string]string format


### PR DESCRIPTION
when creating empty volume group through cli, the strings.Split() function returns a [""] value, i.e, a slice of length 1 having the value as 1 (`[""]`) empty string. As a result, the csi panics when it tries to find the volumeID with the respective value.