### PR TITLE
Prefer NetworkFenceClass for secrets and params

### DIFF
--- a/api/csiaddons/v1alpha1/networkfence_types.go
+++ b/api/csiaddons/v1alpha1/networkfence_types.go
@@ -64,11 +64,17 @@ type SecretSpec struct {
 }
 
 // NetworkFenceSpec defines the desired state of NetworkFence
-// +kubebuilder:validation:XValidation:rule="has(self.parameters) == has(oldSelf.parameters)",message="parameters are immutable"
-// +kubebuilder:validation:XValidation:rule="has(self.secret) == has(oldSelf.secret)",message="secret is immutable"
+// +kubebuilder:validation:XValidation:rule="has(self.driver) || has(self.networkFenceClassName)",message="one of driver or networkFenceClassName must be present"
+// +kubebuilder:validation:XValidation:rule="has(self.networkFenceClassName) || has(self.secret)",message="secret must be present when networkFenceClassName is not specified"
 type NetworkFenceSpec struct {
-	// Driver contains  the name of CSI driver.
-	// +kubebuilder:validation:Required
+	// NetworkFenceClassName contains the name of the NetworkFenceClass
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="networkFenceClassName is immutable"
+	NetworkFenceClassName string `json:"networkFenceClassName"`
+
+	// Driver contains the name of CSI driver, required if NetworkFenceClassName is absent
+	// +kubebuilder:deprecatedversion:warning="specifying driver in networkfence is deprecated, please use networkFenceClassName instead"
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="driver is immutable"
 	Driver string `json:"driver"`
 
@@ -84,9 +90,14 @@ type NetworkFenceSpec struct {
 	Cidrs []string `json:"cidrs"`
 
 	// Secret is a kubernetes secret, which is required to perform the fence/unfence operation.
+	// +kubebuilder:deprecatedversion:warning="specifying secrets in networkfence is deprecated, please use networkFenceClassName instead"
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="secrets are immutable"
 	Secret SecretSpec `json:"secret,omitempty"`
 
 	// Parameters is used to pass additional parameters to the CSI driver.
+	// +kubebuilder:deprecatedversion:warning="specifying parameters in networkfence is deprecated, please use networkFenceClassName instead"
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="parameters are immutable"
 	Parameters map[string]string `json:"parameters,omitempty"`
 }

--- a/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
+++ b/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
@@ -62,7 +62,8 @@ spec:
                   type: string
                 type: array
               driver:
-                description: Driver contains  the name of CSI driver.
+                description: Driver contains the name of CSI driver, required if NetworkFenceClassName
+                  is absent
                 type: string
                 x-kubernetes-validations:
                 - message: driver is immutable
@@ -76,6 +77,12 @@ spec:
                 - Fenced
                 - Unfenced
                 type: string
+              networkFenceClassName:
+                description: NetworkFenceClassName contains the name of the NetworkFenceClass
+                type: string
+                x-kubernetes-validations:
+                - message: networkFenceClassName is immutable
+                  rule: self == oldSelf
               parameters:
                 additionalProperties:
                   type: string
@@ -105,18 +112,19 @@ spec:
                       rule: self == oldSelf
                 type: object
                 x-kubernetes-validations:
+                - message: secrets are immutable
+                  rule: self == oldSelf
                 - message: secret is immutable
                   rule: self == oldSelf
             required:
             - cidrs
-            - driver
             - fenceState
             type: object
             x-kubernetes-validations:
-            - message: parameters are immutable
-              rule: has(self.parameters) == has(oldSelf.parameters)
-            - message: secret is immutable
-              rule: has(self.secret) == has(oldSelf.secret)
+            - message: one of driver or networkFenceClassName must be present
+              rule: has(self.driver) || has(self.networkFenceClassName)
+            - message: secret must be present when networkFenceClassName is not specified
+              rule: has(self.networkFenceClassName) || has(self.secret)
           status:
             description: NetworkFenceStatus defines the observed state of NetworkFence
             properties:

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -721,7 +721,8 @@ spec:
                   type: string
                 type: array
               driver:
-                description: Driver contains  the name of CSI driver.
+                description: Driver contains the name of CSI driver, required if NetworkFenceClassName
+                  is absent
                 type: string
                 x-kubernetes-validations:
                 - message: driver is immutable
@@ -735,6 +736,12 @@ spec:
                 - Fenced
                 - Unfenced
                 type: string
+              networkFenceClassName:
+                description: NetworkFenceClassName contains the name of the NetworkFenceClass
+                type: string
+                x-kubernetes-validations:
+                - message: networkFenceClassName is immutable
+                  rule: self == oldSelf
               parameters:
                 additionalProperties:
                   type: string
@@ -764,18 +771,19 @@ spec:
                       rule: self == oldSelf
                 type: object
                 x-kubernetes-validations:
+                - message: secrets are immutable
+                  rule: self == oldSelf
                 - message: secret is immutable
                   rule: self == oldSelf
             required:
             - cidrs
-            - driver
             - fenceState
             type: object
             x-kubernetes-validations:
-            - message: parameters are immutable
-              rule: has(self.parameters) == has(oldSelf.parameters)
-            - message: secret is immutable
-              rule: has(self.secret) == has(oldSelf.secret)
+            - message: one of driver or networkFenceClassName must be present
+              rule: has(self.driver) || has(self.networkFenceClassName)
+            - message: secret must be present when networkFenceClassName is not specified
+              rule: has(self.networkFenceClassName) || has(self.secret)
           status:
             description: NetworkFenceStatus defines the observed state of NetworkFence
             properties:

--- a/docs/networkfence.md
+++ b/docs/networkfence.md
@@ -2,7 +2,15 @@
 
 NetworkFence is a cluster-scoped custom resource that allows Kubernetes to invoke "Network fence" operation on a storage provider.
 
-The user needs to specify the list of CIDR blocks on which network fencing operation will be performed; alongside the csi driver name.
+The user needs to specify the list of CIDR blocks on which network fencing operation will be performed along with either of
+`networkFenceClassName` or the csi driver name. When a `networkFenceClassName` is specified, the secret name, namespace
+and parameters are read from the `NetworkFenceClass`.
+
+When both `networkFenceClassName` and `driver` are specified `networkFenceClassName` has the higher precedence.
+
+> **Note:** Specifying `driver`, `secret` and `parameters` inside `NetworkFence` is deprecated, users are encouraged
+> to use `networkFenceClassName` along with a `NetworkFenceClass` instead.
+
 The creation of NetworkFence CR will add a network fence, and its deletion will undo the operation.
 
 ## Fence Operation
@@ -13,10 +21,14 @@ kind: NetworkFence
 metadata:
   name: network-fence-sample
 spec:
-  driver: example.driver
+  networkFenceClassName: network-fence-class
   cidrs:
     - 10.90.89.66/32
     - 11.67.12.42/24
+  # The fields driver, secret and parameters are deprecated.
+  # It is recommended to use networkFenceClassName to specify these.
+  # Note: `driver` is referred to as the `provisioner` in NetworkFenceClass.
+  driver: example.driver
   secret:
     name: fence-secret
     namespace: default
@@ -26,7 +38,8 @@ spec:
 
 > **Note**: Creation of a NetworkFence CR blocks access to the corresponding CIDR block; which is then unblocked the CR deletion.
 
-- `provisioner`: specifies the name of storage provisioner.
+- `networkFenceClassName`: specifies the name of the NetworkFenceClass.
+- `driver`: specifies the name of storage provisioner.
 - `cidrs`: refers to the CIDR blocks on which the mentioned fence/unfence operation is to be performed.
 - `secret`: refers to the kubernetes secret required for network fencing operation.
   - `name`: specifies the name of the secret


### PR DESCRIPTION
This patch adds support for reading the driver, secrets and
parameters from `NetworkFenceClass` if `NetworkFenceClassName` is specified 
in the spec for `NetworkFence`.