### PR TITLE
remove namespace name from pvc owner annotation

### DIFF
--- a/internal/controller/replication.storage/pvc_test.go
+++ b/internal/controller/replication.storage/pvc_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	replicationv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
@@ -181,7 +180,6 @@ func TestGetVolumeHandle(t *testing.T) {
 func TestVolumeReplicationReconciler_annotatePVCWithOwner(t *testing.T) {
 	t.Parallel()
 	vrName := "test-vr"
-	vrNamespace := "test-ns"
 
 	testcases := []struct {
 		name          string
@@ -200,7 +198,7 @@ func TestVolumeReplicationReconciler_annotatePVCWithOwner(t *testing.T) {
 					Name:      "pvc-name",
 					Namespace: mockNamespace,
 					Annotations: map[string]string{
-						replicationv1alpha1.VolumeReplicationNameAnnotation: fmt.Sprintf("%s/%s", vrNamespace, vrName),
+						replicationv1alpha1.VolumeReplicationNameAnnotation: vrName,
 					},
 				},
 			},
@@ -232,8 +230,7 @@ func TestVolumeReplicationReconciler_annotatePVCWithOwner(t *testing.T) {
 		ctx := context.TODO()
 		logger := log.FromContext(ctx)
 		reconciler := createFakeVolumeReplicationReconciler(t, testPVC, volumeReplication)
-		reqOwner := fmt.Sprintf("%s/%s", volumeReplication.Namespace, volumeReplication.Name)
-		err := annotatePVCWithOwner(reconciler.Client, ctx, logger, reqOwner, testPVC, replicationv1alpha1.VolumeReplicationNameAnnotation)
+		err := annotatePVCWithOwner(reconciler.Client, ctx, logger, volumeReplication.Name, testPVC, replicationv1alpha1.VolumeReplicationNameAnnotation)
 		if tc.errorExpected {
 			assert.Error(t, err)
 		} else {
@@ -248,7 +245,7 @@ func TestVolumeReplicationReconciler_annotatePVCWithOwner(t *testing.T) {
 			err = reconciler.Get(ctx, pvcNamespacedName, testPVC)
 			assert.NoError(t, err)
 
-			assert.Equal(t, testPVC.Annotations[replicationv1alpha1.VolumeReplicationNameAnnotation], reqOwner)
+			assert.Equal(t, testPVC.Annotations[replicationv1alpha1.VolumeReplicationNameAnnotation], volumeReplication.Name)
 		}
 
 		err = removeOwnerFromPVCAnnotation(reconciler.Client, ctx, log.FromContext(context.TODO()), testPVC, replicationv1alpha1.VolumeReplicationNameAnnotation)

--- a/internal/controller/replication.storage/volumegroupreplication_controller.go
+++ b/internal/controller/replication.storage/volumegroupreplication_controller.go
@@ -602,8 +602,7 @@ func (r *VolumeGroupReplicationReconciler) updateFinalizerAndAnnotationOnPVCs(vg
 
 	// Annotate each new PVC with owner and add finalizer to it
 	for _, pvc := range toAddPVCs {
-		reqOwner := fmt.Sprintf("%s/%s", vgr.Namespace, vgr.Name)
-		err := annotatePVCWithOwner(r.Client, r.ctx, r.log, reqOwner, &pvc, replicationv1alpha1.VolumeGroupReplicationNameAnnotation)
+		err := annotatePVCWithOwner(r.Client, r.ctx, r.log, vgr.Name, &pvc, replicationv1alpha1.VolumeGroupReplicationNameAnnotation)
 		if err != nil {
 			r.log.Error(err, "Failed to add VGR owner annotation on PVC")
 			return nil, err

--- a/internal/controller/replication.storage/volumegroupreplication_test.go
+++ b/internal/controller/replication.storage/volumegroupreplication_test.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -185,8 +184,7 @@ func TestVolumeGroupReplication(t *testing.T) {
 				assert.Equal(t, pvc.Name, mockVGRPersistentVolumeClaim.Name)
 			}
 			// Check PVC annotation
-			expectedOwner := fmt.Sprintf("%s/%s", volumeGroupReplication.Namespace, volumeGroupReplication.Name)
-			assert.Equal(t, expectedOwner, pvc.Annotations[replicationv1alpha1.VolumeGroupReplicationNameAnnotation])
+			assert.Equal(t, volumeGroupReplication.Name, pvc.Annotations[replicationv1alpha1.VolumeGroupReplicationNameAnnotation])
 			// Check VGRContent Created
 			assert.NotEmpty(t, vgr.Spec.VolumeGroupReplicationContentName)
 		} else {

--- a/internal/controller/replication.storage/volumereplication_controller.go
+++ b/internal/controller/replication.storage/volumereplication_controller.go
@@ -233,8 +233,7 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 		switch instance.Spec.DataSource.Kind {
 		case pvcDataSource:
-			reqOwner := fmt.Sprintf("%s/%s", instance.Namespace, instance.Name)
-			err = annotatePVCWithOwner(r.Client, ctx, logger, reqOwner, pvc, replicationv1alpha1.VolumeReplicationNameAnnotation)
+			err = annotatePVCWithOwner(r.Client, ctx, logger, instance.Name, pvc, replicationv1alpha1.VolumeReplicationNameAnnotation)
 			if err != nil {
 				logger.Error(err, "Failed to annotate PVC owner")
 				return ctrl.Result{}, err


### PR DESCRIPTION
Remove namespace name from pvc owner annotation.
Name should be enough to identify vgr/vr the pvc belongs to as the annotation key for vr and vgr is different and both are namespaced scope CRs which would belong to the same namespace as PVC.