### PR TITLE
Add a Volume Condition Reporter to the sidecar

### DIFF
--- a/docs/volume-condition.md
+++ b/docs/volume-condition.md
@@ -1,0 +1,100 @@
+# Volume Condition Reporter
+
+The Volume Condition Reporter uses the [Container Storage Interface
+Specification's `NodeGetVolumeStats` operation][nodegetvolumestats] to detect
+if a PersistentVolume has an _abnormal_ condition. CSI drivers can return the
+condition of a volume in the `NodeVolumeStatsResponse` message.
+
+## Usage
+
+The Volume Condition Reporter is disabled by default. Enabling the
+`--enable-volume-condition` for the CSI-Addons sidecar starts the Volume
+Condition Reporter.
+
+## Abnormal Volume Condition reporting
+
+Once enabled, the healthy and abnormal volume condition is reported in the logs
+of the CSI-Addons sidecar, and as an Event for the PersistentVolumeClaim.
+
+Users will see the Event in their Namespace, and also when they describe (with
+`kubectl describe ...`) the PersistentVolumeClaim.
+
+### Future Enhancements
+
+Additional options for reporting include:
+
+- include the volume condition in the metrics (similar to [KEP-4132][k8s_kep])
+- generate an event for one or more of
+
+  1. the PersistentVolume
+  1. the Pod that uses the PersistentVolumeClaim
+  1. the Node where the volume condition is abnormal
+
+- annotate one or more of
+
+  1. the PersistentVolume
+  1. the PersistentVolumeClaim
+  1. the Pod that uses the PersistentVolumeClaim
+  1. the Node where the volume condition is abnormal
+     > unlikely acceptable, needs permissions to the Node object
+
+## Potential Consumers of Abnormal Volume Condition check results
+
+More feedback on the reporting and recovery steps are needed, but there are
+potential approaches that could use the reported volume condition:
+
+- [Rook](https://rook.io) is a Kubernetes Operator that is able to [Network
+  Fence][rook_fencing] a workernode where a Ceph volume is unhealthy.
+
+- [Node Problem Detector][k8s_npd] provides a generic interface for reporting
+  problems on a node. A project like [medik8s](https://medik8s.io/) can remedy
+  node problems once they are reported.
+
+## Dependencies
+
+The `NodeGetVolumeStats` operation in the current CSI Specification (v1.8.0)
+defines the `VolumeCondition` as an _alpha_ feature. Very few CSI-drivers seem
+to implement the volume condition at the moment. Drivers that implement the
+feature, are required to expose `VOLUME_CONDITION` as a
+`NodeServiceCapability`, otherwise the Volume Condition Reporter will not be
+able to check the condition of the volume.
+
+## Required Permissions (RBAC)
+
+When a Kubernetes cluster uses Role Based Access Control (RBAC) like OpenShift,
+the CSI-Addons sidecar requires extra permissions to check and report the
+volume condition.
+
+```yaml
+---
+# permissions for csi-addons sidecar to create events.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csiaddons-events-editor-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - persistentvolumeclaims
+    verbs:
+      - get
+```
+
+[nodegetvolumestats]: https://github.com/container-storage-interface/spec/blob/master/spec.md#nodegetvolumestats
+[rook_fencing]: https://rook.github.io/docs/rook/v1.12/Storage-Configuration/Block-Storage-RBD/block-storage/#handling-node-loss
+[k8s_npd]: https://github.com/kubernetes/node-problem-detector/
+[k8s_kep]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/1432-volume-health-monitor/README.md

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	k8s.io/apimachinery v0.33.3
 	k8s.io/client-go v0.33.3
 	k8s.io/klog/v2 v2.130.1
+	k8s.io/mount-utils v0.33.2
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	sigs.k8s.io/controller-runtime v0.21.0
 )
@@ -54,6 +55,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/moby/sys/mountinfo v0.7.2 h1:1shs6aH5s4o5H2zQLn796ADW1wMrIwHsyJ2v9KouLrg=
+github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -249,6 +251,8 @@ k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUyGcf03XZEP0ZIKgKj35LS4=
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
+k8s.io/mount-utils v0.33.2 h1:mZAFhoGs/MwJziVlUpA072vqMhXRc0LGl/W3wybLP20=
+k8s.io/mount-utils v0.33.2/go.mod h1:1JR4rKymg8B8bCPo618hpSAdrpO6XLh0Acqok/xVwPE=
 k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=

--- a/sidecar/internal/client/client.go
+++ b/sidecar/internal/client/client.go
@@ -137,12 +137,7 @@ func (c *clientImpl) HasControllerService() (bool, error) {
 		return false, err
 	}
 
-	caps := rsp.GetCapabilities()
-	if len(caps) == 0 {
-		return false, errors.New("driver does not have any capabilities")
-	}
-
-	for _, c := range caps {
+	for _, c := range rsp.GetCapabilities() {
 		svc := c.GetService()
 		if svc != nil && svc.GetType() == identity.Capability_Service_CONTROLLER_SERVICE {
 			return true, nil

--- a/sidecar/internal/volume-condition/event_recorder.go
+++ b/sidecar/internal/volume-condition/event_recorder.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package condition
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/volume"
+)
+
+type eventRecorder struct {
+	client   *kubernetes.Clientset
+	recorder record.EventRecorder
+}
+
+// assert on conditionRecorder interface
+var _ conditionRecorder = &eventRecorder{}
+
+// WithEventRecorder can be passed to the VolumeConditionRecorder so that it
+// will create an Event for the PersistentVolumeClaim with the volume
+// condition.
+func WithEventRecorder() RecorderOption {
+	return RecorderOption{
+		newRecorder: newEventRecorder,
+	}
+}
+
+func newEventRecorder(client *kubernetes.Clientset, hostname string) (conditionRecorder, error) {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(
+		&typedcorev1.EventSinkImpl{
+			Interface: client.CoreV1().Events(""),
+		},
+	)
+	recorder := eventBroadcaster.NewRecorder(
+		scheme.Scheme,
+		corev1.EventSource{
+			Component: "CSI-Addons",
+			Host:      hostname,
+		},
+	)
+
+	return &eventRecorder{
+		client:   client,
+		recorder: recorder,
+	}, nil
+}
+
+func (er *eventRecorder) record(
+	ctx context.Context,
+	pv *corev1.PersistentVolume,
+	vc volume.VolumeCondition,
+) error {
+	claim := pv.Spec.ClaimRef
+	if claim == nil {
+		return fmt.Errorf("persistent volume %q does not have a claim (unused?)", pv.Name)
+	}
+
+	pvc, err := er.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(
+		ctx,
+		claim.Name,
+		metav1.GetOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to get persistent volume claim %q in namespace %q: %w",
+			claim.Name,
+			claim.Namespace,
+			err,
+		)
+	}
+
+	severity := corev1.EventTypeNormal
+	if !vc.IsHealthy() {
+		severity = corev1.EventTypeWarning
+	}
+
+	er.recorder.Event(pvc, severity, vc.GetReason(), vc.GetMessage())
+
+	return nil
+}

--- a/sidecar/internal/volume-condition/log_recorder.go
+++ b/sidecar/internal/volume-condition/log_recorder.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package condition
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/volume"
+)
+
+type logRecorder struct{}
+
+// assert on conditionRecorder interface
+var _ conditionRecorder = &logRecorder{}
+
+// WithLogRecorder can be passed to the VolumeConditionReporter so that it
+// will report the volume condition in the logs of the CSI-Addons sidecar.
+func WithLogRecorder() RecorderOption {
+	return RecorderOption{
+		newRecorder: func(client *kubernetes.Clientset, hostname string) (conditionRecorder, error) {
+			return &logRecorder{}, nil
+		},
+	}
+}
+
+func (lr *logRecorder) record(
+	ctx context.Context,
+	pv *corev1.PersistentVolume,
+	vc volume.VolumeCondition,
+) error {
+	if vc.IsHealthy() {
+		msg := vc.GetMessage()
+		if msg != "" {
+			msg = ": " + msg
+		}
+		klog.Infof("persistent volume %q is healthy"+msg, pv.GetName())
+	} else {
+		klog.Warningf(
+			"persistent volume %q is not healthy: %v",
+			pv.GetName(),
+			vc.GetMessage(),
+		)
+	}
+
+	return nil
+}

--- a/sidecar/internal/volume-condition/node/node.go
+++ b/sidecar/internal/volume-condition/node/node.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/volume"
+)
+
+// Node can handle requests for the local worker node.
+type Node interface {
+	// ListCSIVolumes returns a slice of CSI-volumes that are attached to the
+	// local worker node.
+	ListCSIVolumes(ctx context.Context) ([]volume.CSIVolume, error)
+}
+
+type node struct {
+	clientset *kubernetes.Clientset
+
+	// nodename is used to filter the attachments by node
+	nodename string
+}
+
+// assert that node implements the Node interface.
+var _ Node = &node{}
+
+// NewNode creates a new Node that represents the local worker node.
+func NewNode(ctx context.Context, clientset *kubernetes.Clientset, nodename string) (Node, error) {
+	// verify that my local Node exists, will be fetched again in .ListCSIVolumes()
+	_, err := clientset.CoreV1().Nodes().Get(ctx, nodename, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not get my local Node %q: %v", nodename, err)
+	}
+
+	return &node{
+		clientset: clientset,
+		nodename:  nodename,
+	}, nil
+}
+
+func (n *node) ListCSIVolumes(ctx context.Context) ([]volume.CSIVolume, error) {
+	localNode, err := n.clientset.CoreV1().Nodes().Get(ctx, n.nodename, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not get Node %q: %v", n.nodename, err)
+	}
+
+	vols := []volume.CSIVolume{}
+	for _, attached := range localNode.Status.VolumesAttached {
+		var vol volume.CSIVolume
+		vol, err = newAttachedCSIVolume(attached.Name)
+		if err != nil {
+			klog.Infof("skipping non-CSI volume: %v", err)
+			continue
+		}
+
+		vols = append(vols, vol)
+	}
+
+	return vols, nil
+}
+
+// newAttachedCSIVolume parses a UniqueVolumeName that can be obtained from the list of attached
+// volumes on a node.
+// UniqueVolumeName is a string like "kubernetes.io/csi/ebs.csi.aws.com^vol-0c577c9c55718d592"
+// "vol-0c577c9c55718d592" is the volumeHandle (as in PV.Spec.CSI.volumeHandle)
+func newAttachedCSIVolume(name corev1.UniqueVolumeName) (volume.CSIVolume, error) {
+	const (
+		csiDriverPrefix       = "kubernetes.io/csi/"
+		driverVolumeSeparator = "^"
+	)
+
+	driverVolume, found := strings.CutPrefix(string(name), csiDriverPrefix)
+	if !found {
+		return nil, fmt.Errorf("attached volume %q is not a CSI volume", name)
+	}
+
+	parts := strings.Split(driverVolume, driverVolumeSeparator)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("format of attached volume %q is not supported: %s", name, driverVolume)
+	}
+
+	return volume.NewCSIVolume(parts[0], parts[1]), nil
+}

--- a/sidecar/internal/volume-condition/node/node_test.go
+++ b/sidecar/internal/volume-condition/node/node_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestNewAttachedCSIVolume(t *testing.T) {
+	cases := []struct {
+		name        string
+		volumeName  corev1.UniqueVolumeName
+		csiDriver   string // CSIVolume.GetDriver()
+		csiVolume   string // CSIVolume.GetVolumeID()
+		expectError bool
+	}{
+		{
+			name:        "happy path",
+			volumeName:  "kubernetes.io/csi/ebs.csi.aws.com^vol-0c577c9c55718d592",
+			csiDriver:   "ebs.csi.aws.com",
+			csiVolume:   "vol-0c577c9c55718d592",
+			expectError: false,
+		},
+		{
+			name:        "not a csi driver",
+			volumeName:  corev1.UniqueVolumeName("kubernetes.io/native/ebs.csi.aws.com^vol-0c577c9c55718d592"),
+			csiDriver:   "ebs.csi.aws.com",
+			csiVolume:   "vol-0c577c9c55718d592",
+			expectError: true,
+		},
+		{
+			name:        "repeated path component separator",
+			volumeName:  corev1.UniqueVolumeName("kubernetes.io/csi^ebs.csi.aws.com^vol-0c577c9c55718d592"),
+			csiDriver:   "ebs.csi.aws.com",
+			csiVolume:   "vol-0c577c9c55718d592",
+			expectError: true,
+		},
+		{
+			name:        "incorrect UniqueVolumeName format",
+			volumeName:  corev1.UniqueVolumeName("kubernetes.io/csi/ebs.csi.aws.com~vol-0c577c9c55718d592"),
+			csiDriver:   "ebs.csi.aws.com",
+			csiVolume:   "vol-0c577c9c55718d592",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			volume, err := newAttachedCSIVolume(tt.volumeName)
+			if tt.expectError {
+				assert.NotNil(t, err)
+				return
+			} else {
+				assert.Nil(t, err)
+			}
+
+			assert.Equal(t, tt.csiDriver, volume.GetDriver())
+			assert.Equal(t, tt.csiVolume, volume.GetVolumeID())
+		})
+	}
+}

--- a/sidecar/internal/volume-condition/platform/kubelet.go
+++ b/sidecar/internal/volume-condition/platform/kubelet.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"k8s.io/mount-utils"
+)
+
+// kubelet contains the paths for Kubernetes based platforms
+type kubelet struct {
+	basedir    string
+	pluginPath string
+	csiPath    string
+	mounter    mount.Interface
+}
+
+// assert that kubelet implements the Platform interface.
+var _ Platform = &kubelet{}
+
+// getKubelet() returns a *kubelet with default paths. Other functions could do
+// some detection or inspection, and return a *kubelet for microk8s or other
+// variations.
+func getKubelet() Platform {
+	return &kubelet{
+		basedir:    "/var/lib/kubelet",
+		pluginPath: "/plugins",
+		csiPath:    "/kubernetes.io/csi",
+		mounter:    mount.NewWithoutSystemd("/bin/mount"),
+	}
+}
+
+// GetStagingPath checks the known kubelet path where the volume may be mounted.
+// The staging path looks like:
+// /var/lib/kubelet
+//   - /plugins
+//   - /kubernetes.io/csi
+//   - /openshift-storage.rbd.csi.ceph.com
+//   - /07d25c3a330223ce3dd44b6bbd5911523785b0cf44f1624fc9b949c0fbdd9d00
+//   - /globalmount
+//   - /0001-0011-openshift-storage-0000000000000001-316a945f-00b5-45e7-a9e1-56658da698b9
+//
+// Where 07d25c3a330223ce3dd44b6bbd5911523785b0cf44f1624fc9b949c0fbdd9d00 = sha256sum(volumeID)
+func (k *kubelet) GetStagingPath(driver, volumeID string) (string, error) {
+	hash := sha256.Sum256([]byte(volumeID))
+
+	stagingPath := filepath.Join(
+		k.basedir,
+		k.pluginPath,
+		k.csiPath,
+		driver,
+		fmt.Sprintf("%x", hash),
+		"globalmount",
+	)
+
+	if k.isMountPoint(stagingPath) {
+		return stagingPath, nil
+	}
+
+	// special case for Ceph-CSI: stagingPath ending with "/globalmount" is not a
+	// mountpoint. Add the volumeID to the path and check again.
+	stagingPath = filepath.Join(stagingPath, volumeID)
+	if k.isMountPoint(stagingPath) {
+		return stagingPath, nil
+	}
+
+	// TODO: maybe need to check if it is a directory or blockdevice?
+	// fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/%s/%s", "spec-0", "dev")
+	// fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/staging/%s", "spec-0")
+
+	return "", fmt.Errorf("could not find a mountpoint at %q", stagingPath)
+
+}
+
+func (k *kubelet) GetPublishPath(driver, volumeID string) (string, error) {
+	path, _, err := k.getPublishDetails(driver, volumeID)
+	if err != nil {
+		return "", fmt.Errorf("failed to find publish path for volume handle %q of driver %q: %w", volumeID, driver, err)
+	}
+
+	return path, nil
+}
+
+func (k *kubelet) GetCSISocket(driver string) string {
+	// TODO: should probably check if it is UNIX domain socket
+	return filepath.Join(
+		"unix://",
+		k.basedir,
+		k.pluginPath,
+		driver,
+		"csi.sock",
+	)
+}
+
+func (k *kubelet) ResolvePersistentVolumeName(driver, volumeID string) (string, error) {
+	_, pvName, err := k.getPublishDetails(driver, volumeID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get persistent volume name for volume handle %q of driver %q: %w", volumeID, driver, err)
+	}
+
+	return pvName, nil
+}
+
+func (k *kubelet) isMountPoint(path string) bool {
+	isMnt, err := k.mounter.IsMountPoint(path)
+	if err != nil {
+		klog.Errorf("failed to check if %q is a mountpoint: %v", path, err)
+		return false
+	}
+
+	return isMnt
+}
+
+// getPublishDetails tries to find the directory where the volume is mounted.
+//
+// Kubelet uses /var/lib/kubelet/pods/*/volumes/*/vol_data.json for storing
+// details about the mountpoint. The JSON file can be parsed and checked if the
+// drivername and volumeID match what we are looking for.
+//
+// The publish path is the in the same directory as where the vol_data.json
+// resides. The volume is mounted on a directory called "mount".
+//
+// TODO: blockmode
+// fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/publish/%s/%s", "spec-0", testPodUID)
+func (k *kubelet) getPublishDetails(driver, volumeID string) (string, string, error) {
+	volDatas, err := filepath.Glob(
+		filepath.Join(
+			k.basedir,
+			"pods",
+			"*", // UUID of a Pod
+			"volumes/kubernetes.io~csi/",
+			"*", // name of a PersistentVolume
+			"vol_data.json",
+		),
+	)
+	if err != nil {
+		return "", "", fmt.Errorf("could not find vol_data.json: %v", err)
+	}
+
+	for _, filename := range volDatas {
+		data, err := os.ReadFile(filename)
+		if err != nil {
+			klog.Errorf("failed to read file %q: %v", filename, err)
+			continue
+		}
+
+		vd := struct {
+			Driver               string `json:"driverName"`
+			PersistentVolumeName string `json:"specVolID"`
+			VolumeID             string `json:"volumeHandle"`
+		}{}
+		err = json.Unmarshal(data, &vd)
+		if err != nil {
+			klog.Errorf("failed to parse JSON from %q: %v", filename, err)
+			continue
+		}
+
+		if vd.Driver != driver || vd.VolumeID != volumeID {
+			continue
+		}
+
+		// TODO: is this correct for block-volumes too?
+		return strings.ReplaceAll(filename, "vol_data.json", "mount"), vd.PersistentVolumeName, nil
+	}
+
+	return "", "", fmt.Errorf("could not find a vol_data.json for driver %q and volumeID %q", driver, volumeID)
+}

--- a/sidecar/internal/volume-condition/platform/platform.go
+++ b/sidecar/internal/volume-condition/platform/platform.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+// Platform provides functions that a Driver can use to find details about the
+// deployment. Different platforms use different directories and paths to
+// communicate with drivers, and locations where volumes are mounted.
+type Platform interface {
+	// GetStagingPath returns the volume staging path that a platform uses.
+	// Not all drivers use the staging path, in which case no staging path
+	// can be found and an error is returned.
+	GetStagingPath(driver, volumeID string) (string, error)
+
+	// GetPublishPath returns the path where the volume is mounted and
+	// made available for apps/pods to use.
+	GetPublishPath(driver, volumeID string) (string, error)
+
+	// GetCSISocket returns the UNIX Domain Socket for a particular
+	// CSI-driver.
+	GetCSISocket(driver string) string
+
+	// ResolvePersistentVolumeName tries to identify the name of the
+	// PersistentVolume, based on the volumeID.
+	ResolvePersistentVolumeName(driver, volumeID string) (string, error)
+}
+
+// singletonPlatform is used to create the Platform utility object once. While
+// the application runs, the platform will not suddenly change.
+var singletonPlatform Platform = nil
+
+// GetPlatform returns the object with utility functions for the current running
+// variant of Kubernetes.
+func GetPlatform() Platform {
+	if singletonPlatform != nil {
+		return singletonPlatform
+	}
+
+	// TODO: switch on detecting different platforms (kind, microk8s?)
+	singletonPlatform = getKubelet()
+
+	return singletonPlatform
+}

--- a/sidecar/internal/volume-condition/recorder.go
+++ b/sidecar/internal/volume-condition/recorder.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package condition
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/volume"
+)
+
+// conditionRecorder provides the interface for recorders that will record the
+// volume condition.
+type conditionRecorder interface {
+	record(ctx context.Context, pv *corev1.PersistentVolume, vc volume.VolumeCondition) error
+}
+
+// RecorderOption is the interface for creating new recorders. The
+// VolumeConditionReporter will use this interface to configure a recorder
+// and uses it to report the volume condition.
+type RecorderOption struct {
+	newRecorder func(client *kubernetes.Clientset, hostname string) (conditionRecorder, error)
+}

--- a/sidecar/internal/volume-condition/reporter.go
+++ b/sidecar/internal/volume-condition/reporter.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package condition
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/node"
+	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/platform"
+	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/volume"
+)
+
+// VolumeConditionReporter provides the entrypoint for running the volume
+// condition checks and reporting the results.
+type VolumeConditionReporter interface {
+	// Run starts the checking of volumes at the given interval. This
+	// function is not expected to ever end, only if there is a critical
+	// error.
+	Run(ctx context.Context, interval time.Duration) error
+}
+
+type volumeConditionReporter struct {
+	client *kubernetes.Clientset
+
+	driver    volume.Driver
+	localNode node.Node
+	recorders []conditionRecorder
+
+	// conditionCache tracks the condition by volume-handle
+	conditionCache map[string]volume.VolumeCondition
+}
+
+// NewVolumeConditionReporter creates a new VolumeConditionReporter. The
+// drivername that is passed is used to find the matching CSI-driver on the
+// local node. Multiple RecorderOptions can be passed, which will be used
+// to report the volume condition.
+func NewVolumeConditionReporter(
+	ctx context.Context,
+	client *kubernetes.Clientset,
+	hostname, drivername string,
+	recorderOptions []RecorderOption,
+) (VolumeConditionReporter, error) {
+	drv, err := volume.FindDriver(ctx, drivername)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find driver %q: %w", drivername, err)
+	}
+
+	if !drv.SupportsVolumeCondition() {
+		return nil, fmt.Errorf("driver %q does not support volume-condition", drivername)
+	}
+
+	n, err := node.NewNode(ctx, client, hostname)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %q: %w", hostname, err)
+	}
+
+	// TODO: use options for the recorders
+	recorders := make([]conditionRecorder, len(recorderOptions))
+	for i, opt := range recorderOptions {
+		var rec conditionRecorder
+		rec, err = opt.newRecorder(client, hostname)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create recorder: %w", err)
+		}
+
+		recorders[i] = rec
+	}
+
+	return &volumeConditionReporter{
+		client:         client,
+		recorders:      recorders,
+		driver:         drv,
+		localNode:      n,
+		conditionCache: make(map[string]volume.VolumeCondition, 0),
+	}, nil
+}
+
+// Run starts the volume condition reporter. This function never returns, only
+// if a critical error occurs.
+// Only new/updated volume conditions are reported, this prevents noise of
+// recurring conditions.
+func (cvr *volumeConditionReporter) Run(ctx context.Context, interval time.Duration) error {
+	running := time.Tick(interval)
+	if running == nil {
+		return fmt.Errorf("interval %v is invalid", interval)
+	}
+
+	for range running {
+		volumes, err := cvr.localNode.ListCSIVolumes(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to list volumes: %w", err)
+		}
+
+		for _, v := range volumes {
+			if v.GetDriver() != cvr.driver.GetDrivername() {
+				continue
+			}
+
+			vc, err := cvr.driver.GetVolumeCondition(v)
+			if err != nil {
+				klog.Errorf("failed to check if %q is healthy: %v", v.GetVolumeID(), err)
+				continue
+			} else if vc == nil {
+				klog.Errorf(
+					"driver %q did not return a volume condition for volume %q",
+					cvr.driver.GetDrivername(),
+					v,
+				)
+				continue
+			}
+
+			if !cvr.isUpdatedVolumeCondition(v.GetVolumeID(), vc) {
+				// skip recording if there is no update
+				continue
+			}
+
+			cvr.recordVolumeCondition(ctx, v.GetVolumeID(), vc)
+		}
+
+		cvr.pruneConditionCache(volumes)
+	}
+
+	return nil
+}
+
+// isUpdatedVolumeCondition checks the conditionCache, and updates it in case
+// the passed vc is assumed to be an update.
+func (cvr *volumeConditionReporter) isUpdatedVolumeCondition(volumeID string, vc volume.VolumeCondition) bool {
+	lastCondition := cvr.conditionCache[volumeID]
+	if lastCondition == nil ||
+		(lastCondition.IsHealthy() != vc.IsHealthy() || lastCondition.GetMessage() != vc.GetMessage()) {
+		// vc is an update, store in the cache
+		cvr.conditionCache[volumeID] = vc
+		return true
+	}
+
+	return false
+}
+
+// pruneConditionCache removed inactive volume-handles from the
+// cvr.conditionCache. This is done by creating a new cache, and have the old
+// cvr.conditionCache get garbage collected.
+func (cvr *volumeConditionReporter) pruneConditionCache(volumes []volume.CSIVolume) {
+	newConditionCache := make(map[string]volume.VolumeCondition, len(volumes))
+	for _, v := range volumes {
+		volumeID := v.GetVolumeID()
+		newConditionCache[volumeID] = cvr.conditionCache[volumeID]
+	}
+
+	cvr.conditionCache = newConditionCache
+}
+
+// recordVolumeCondition resolves the PersistentVolume from the given volumeID
+// and loops through all recorders to report the volume condition.
+func (cvr *volumeConditionReporter) recordVolumeCondition(ctx context.Context, volumeID string, vc volume.VolumeCondition) {
+	pvName, err := platform.GetPlatform().ResolvePersistentVolumeName(cvr.driver.GetDrivername(), volumeID)
+	if err != nil {
+		klog.Errorf("failed to resolve persistent volume name: %v", err)
+		return
+	}
+
+	pv, err := cvr.client.CoreV1().PersistentVolumes().Get(ctx, pvName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get persistent volume %q: %v", pvName, err)
+		return
+	}
+
+	for _, recorder := range cvr.recorders {
+		err = recorder.record(ctx, pv, vc)
+		if err != nil {
+			klog.Warningf(
+				"%T failed to record volume condition for persistent volume %q: %v",
+				recorder,
+				pv.Name,
+				err,
+			)
+		}
+	}
+}

--- a/sidecar/internal/volume-condition/volume/condition.go
+++ b/sidecar/internal/volume-condition/volume/condition.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+const (
+	VolumeConditionHealthy  = "VolumeConditionHealthy"
+	VolumeConditionAbnormal = "VolumeConditionAbnormal"
+)
+
+type VolumeCondition interface {
+	IsHealthy() bool
+	GetReason() string
+	GetMessage() string
+}
+
+type volumeCondition struct {
+	healthy bool
+	message string
+}
+
+// assert that volumeCondition implements VolumeCondition
+var _ VolumeCondition = volumeCondition{}
+
+func (vc volumeCondition) IsHealthy() bool {
+	return vc.healthy
+}
+
+func (vc volumeCondition) GetReason() string {
+	if vc.healthy {
+		return VolumeConditionHealthy
+	}
+
+	return VolumeConditionAbnormal
+}
+
+func (vc volumeCondition) GetMessage() string {
+	return vc.message
+}

--- a/sidecar/internal/volume-condition/volume/driver.go
+++ b/sidecar/internal/volume-condition/volume/driver.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/platform"
+)
+
+// Driver provides the API for communicating with a CSI-driver.
+type Driver interface {
+	// GetDrivername returns the name of the CSI-driver.
+	GetDrivername() string
+	// SupportsVolumeCondition can be used to check if the CSI-driver
+	// supports reporting the VolumeCondition (if the node has the
+	// VOLUME_CONDITION capability).
+	SupportsVolumeCondition() bool
+	// GetVolumeCondition requests the VolumeCondition from the
+	// CSI-driver.
+	GetVolumeCondition(CSIVolume) (VolumeCondition, error)
+}
+
+type csiDriver struct {
+	name string
+
+	nodeClient csi.NodeClient
+
+	supportVolumeCondition  bool
+	supportsNodeStageVolume bool
+}
+
+// FindDriver tries to connect to the CSI-driver with the given name. If
+// a connection is made, it verifies the identity of the driver and its
+// capabilities.
+func FindDriver(ctx context.Context, name string) (Driver, error) {
+	endpoint := platform.GetPlatform().GetCSISocket(name)
+	conn, err := grpc.NewClient(
+		endpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to endpoint %s: %w", endpoint, err)
+	}
+
+	// verify that the requested drivername is indeed connected on the socket
+	identityClient := csi.NewIdentityClient(conn)
+	res, err := identityClient.GetPluginInfo(ctx, &csi.GetPluginInfoRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to get info from CSI driver %q: %w", name, err)
+	} else if res.GetName() != name {
+		return nil, fmt.Errorf("CSI driver %q incorrectly identifies itself as %q", name, res.GetName())
+	}
+
+	drv := &csiDriver{
+		name:       name,
+		nodeClient: csi.NewNodeClient(conn),
+	}
+
+	err = drv.detectCapabilities(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect the capabilities of CSI driver %q: %w", name, err)
+	}
+
+	return drv, nil
+}
+
+func (drv *csiDriver) GetDrivername() string {
+	return drv.name
+}
+
+func (drv *csiDriver) SupportsVolumeCondition() bool {
+	return drv.supportVolumeCondition
+}
+
+func (drv *csiDriver) GetVolumeCondition(v CSIVolume) (VolumeCondition, error) {
+	var (
+		err        error
+		volumePath string
+	)
+
+	if drv.supportsNodeStageVolume {
+		volumePath, err = platform.GetPlatform().GetStagingPath(drv.name, v.GetVolumeID())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get staging path: %w", err)
+		}
+	} else {
+		volumePath, err = platform.GetPlatform().GetPublishPath(drv.name, v.GetVolumeID())
+		if err != nil {
+			return nil, fmt.Errorf("failed to get publish path: %w", err)
+		}
+	}
+
+	req := &csi.NodeGetVolumeStatsRequest{
+		VolumeId:   v.GetVolumeID(),
+		VolumePath: volumePath,
+	}
+
+	res, err := drv.nodeClient.NodeGetVolumeStats(context.TODO(), req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to call NodeGetVolumeStats: %w", err)
+	}
+
+	if res.GetVolumeCondition() == nil {
+		return nil, fmt.Errorf("VolumeCondition unknown")
+	}
+
+	vc := &volumeCondition{
+		healthy: !res.GetVolumeCondition().GetAbnormal(),
+		message: res.GetVolumeCondition().GetMessage(),
+	}
+
+	return vc, err
+}
+
+// detectCapabilities calls the NodeGetCapabilities gRPC procedure to detect
+// the capabilities of the CSI-driver.
+func (drv *csiDriver) detectCapabilities(ctx context.Context) error {
+	res, err := drv.nodeClient.NodeGetCapabilities(ctx, &csi.NodeGetCapabilitiesRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to get capabilities of driver %q: %v", drv.name, err)
+	}
+
+	for _, capability := range res.GetCapabilities() {
+		switch capability.GetRpc().GetType() {
+		case csi.NodeServiceCapability_RPC_VOLUME_CONDITION:
+			drv.supportVolumeCondition = true
+		case csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME:
+			drv.supportsNodeStageVolume = true
+		}
+	}
+
+	return nil
+}

--- a/sidecar/internal/volume-condition/volume/volume.go
+++ b/sidecar/internal/volume-condition/volume/volume.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+// CSIVolume describes an attached volume.
+type CSIVolume interface {
+	// GetDriver returns the name of the CSI-driver that is responsible
+	// for this volume.
+	GetDriver() string
+	// GetVolumeID returns the ID (volume-handle) of the volume.
+	GetVolumeID() string
+}
+
+type csiVolume struct {
+	drivername string
+	volumeID   string
+}
+
+// NewCSIVolume creates a new CSIVolume with the given drivername and volumeID.
+func NewCSIVolume(drivername, volumeID string) CSIVolume {
+	return &csiVolume{
+		drivername: drivername,
+		volumeID:   volumeID,
+	}
+}
+
+func (vol *csiVolume) GetDriver() string {
+	return vol.drivername
+}
+
+func (vol *csiVolume) GetVolumeID() string {
+	return vol.volumeID
+}

--- a/vendor/github.com/moby/sys/mountinfo/LICENSE
+++ b/vendor/github.com/moby/sys/mountinfo/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/moby/sys/mountinfo/doc.go
+++ b/vendor/github.com/moby/sys/mountinfo/doc.go
@@ -1,0 +1,44 @@
+// Package mountinfo provides a set of functions to retrieve information about OS mounts.
+//
+// Currently it supports Linux. For historical reasons, there is also some support for FreeBSD and OpenBSD,
+// and a shallow implementation for Windows, but in general this is Linux-only package, so
+// the rest of the document only applies to Linux, unless explicitly specified otherwise.
+//
+// In Linux, information about mounts seen by the current process is available from
+// /proc/self/mountinfo. Note that due to mount namespaces, different processes can
+// see different mounts. A per-process mountinfo table is available from /proc/<PID>/mountinfo,
+// where <PID> is a numerical process identifier.
+//
+// In general, /proc is not a very efficient interface, and mountinfo is not an exception.
+// For example, there is no way to get information about a specific mount point (i.e. it
+// is all-or-nothing). This package tries to hide the /proc ineffectiveness by using
+// parse filters while reading mountinfo. A filter can skip some entries, or stop
+// processing the rest of the file once the needed information is found.
+//
+// For mountinfo filters that accept path as an argument, the path must be absolute,
+// having all symlinks resolved, and being cleaned (i.e. no extra slashes or dots).
+// One way to achieve all of the above is to employ filepath.Abs followed by
+// filepath.EvalSymlinks (the latter calls filepath.Clean on the result so
+// there is no need to explicitly call filepath.Clean).
+//
+// NOTE that in many cases there is no need to consult mountinfo at all. Here are some
+// of the cases where mountinfo should not be parsed:
+//
+// 1. Before performing a mount. Usually, this is not needed, but if required (say to
+// prevent over-mounts), to check whether a directory is mounted, call os.Lstat
+// on it and its parent directory, and compare their st.Sys().(*syscall.Stat_t).Dev
+// fields -- if they differ, then the directory is the mount point. NOTE this does
+// not work for bind mounts. Optionally, the filesystem type can also be checked
+// by calling unix.Statfs and checking the Type field (i.e. filesystem type).
+//
+// 2. After performing a mount. If there is no error returned, the mount succeeded;
+// checking the mount table for a new mount is redundant and expensive.
+//
+// 3. Before performing an unmount. It is more efficient to do an unmount and ignore
+// a specific error (EINVAL) which tells the directory is not mounted.
+//
+// 4. After performing an unmount. If there is no error returned, the unmount succeeded.
+//
+// 5. To find the mount point root of a specific directory. You can perform os.Stat()
+// on the directory and traverse up until the Dev field of a parent directory differs.
+package mountinfo

--- a/vendor/github.com/moby/sys/mountinfo/mounted_linux.go
+++ b/vendor/github.com/moby/sys/mountinfo/mounted_linux.go
@@ -1,0 +1,101 @@
+package mountinfo
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// MountedFast is a method of detecting a mount point without reading
+// mountinfo from procfs. A caller can only trust the result if no error
+// and sure == true are returned. Otherwise, other methods (e.g. parsing
+// /proc/mounts) have to be used. If unsure, use Mounted instead (which
+// uses MountedFast, but falls back to parsing mountinfo if needed).
+//
+// If a non-existent path is specified, an appropriate error is returned.
+// In case the caller is not interested in this particular error, it should
+// be handled separately using e.g. errors.Is(err, fs.ErrNotExist).
+//
+// This function is only available on Linux. When available (since kernel
+// v5.6), openat2(2) syscall is used to reliably detect all mounts. Otherwise,
+// the implementation falls back to using stat(2), which can reliably detect
+// normal (but not bind) mounts.
+func MountedFast(path string) (mounted, sure bool, err error) {
+	// Root is always mounted.
+	if path == string(os.PathSeparator) {
+		return true, true, nil
+	}
+
+	path, err = normalizePath(path)
+	if err != nil {
+		return false, false, err
+	}
+	mounted, sure, err = mountedFast(path)
+	return
+}
+
+// mountedByOpenat2 is a method of detecting a mount that works for all kinds
+// of mounts (incl. bind mounts), but requires a recent (v5.6+) linux kernel.
+func mountedByOpenat2(path string) (bool, error) {
+	dir, last := filepath.Split(path)
+
+	dirfd, err := unix.Openat2(unix.AT_FDCWD, dir, &unix.OpenHow{
+		Flags: unix.O_PATH | unix.O_CLOEXEC,
+	})
+	if err != nil {
+		return false, &os.PathError{Op: "openat2", Path: dir, Err: err}
+	}
+	fd, err := unix.Openat2(dirfd, last, &unix.OpenHow{
+		Flags:   unix.O_PATH | unix.O_CLOEXEC | unix.O_NOFOLLOW,
+		Resolve: unix.RESOLVE_NO_XDEV,
+	})
+	_ = unix.Close(dirfd)
+	switch err {
+	case nil: // definitely not a mount
+		_ = unix.Close(fd)
+		return false, nil
+	case unix.EXDEV: // definitely a mount
+		return true, nil
+	}
+	// not sure
+	return false, &os.PathError{Op: "openat2", Path: path, Err: err}
+}
+
+// mountedFast is similar to MountedFast, except it expects a normalized path.
+func mountedFast(path string) (mounted, sure bool, err error) {
+	// Root is always mounted.
+	if path == string(os.PathSeparator) {
+		return true, true, nil
+	}
+
+	// Try a fast path, using openat2() with RESOLVE_NO_XDEV.
+	mounted, err = mountedByOpenat2(path)
+	if err == nil {
+		return mounted, true, nil
+	}
+
+	// Another fast path: compare st.st_dev fields.
+	mounted, err = mountedByStat(path)
+	// This does not work for bind mounts, so false negative
+	// is possible, therefore only trust if return is true.
+	if mounted && err == nil {
+		return true, true, nil
+	}
+
+	return
+}
+
+func mounted(path string) (bool, error) {
+	path, err := normalizePath(path)
+	if err != nil {
+		return false, err
+	}
+	mounted, sure, err := mountedFast(path)
+	if sure && err == nil {
+		return mounted, nil
+	}
+
+	// Fallback to parsing mountinfo.
+	return mountedByMountinfo(path)
+}

--- a/vendor/github.com/moby/sys/mountinfo/mounted_unix.go
+++ b/vendor/github.com/moby/sys/mountinfo/mounted_unix.go
@@ -1,0 +1,53 @@
+//go:build linux || freebsd || openbsd || darwin
+// +build linux freebsd openbsd darwin
+
+package mountinfo
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func mountedByStat(path string) (bool, error) {
+	var st unix.Stat_t
+
+	if err := unix.Lstat(path, &st); err != nil {
+		return false, &os.PathError{Op: "stat", Path: path, Err: err}
+	}
+	dev := st.Dev
+	parent := filepath.Dir(path)
+	if err := unix.Lstat(parent, &st); err != nil {
+		return false, &os.PathError{Op: "stat", Path: parent, Err: err}
+	}
+	if dev != st.Dev {
+		// Device differs from that of parent,
+		// so definitely a mount point.
+		return true, nil
+	}
+	// NB: this does not detect bind mounts on Linux.
+	return false, nil
+}
+
+func normalizePath(path string) (realPath string, err error) {
+	if realPath, err = filepath.Abs(path); err != nil {
+		return "", err
+	}
+	if realPath, err = filepath.EvalSymlinks(realPath); err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(realPath); err != nil {
+		return "", err
+	}
+	return realPath, nil
+}
+
+func mountedByMountinfo(path string) (bool, error) {
+	entries, err := GetMounts(SingleEntryFilter(path))
+	if err != nil {
+		return false, err
+	}
+
+	return len(entries) > 0, nil
+}

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo.go
@@ -1,0 +1,67 @@
+package mountinfo
+
+import (
+	"os"
+)
+
+// GetMounts retrieves a list of mounts for the current running process,
+// with an optional filter applied (use nil for no filter).
+func GetMounts(f FilterFunc) ([]*Info, error) {
+	return parseMountTable(f)
+}
+
+// Mounted determines if a specified path is a mount point. In case of any
+// error, false (and an error) is returned.
+//
+// If a non-existent path is specified, an appropriate error is returned.
+// In case the caller is not interested in this particular error, it should
+// be handled separately using e.g. errors.Is(err, fs.ErrNotExist).
+func Mounted(path string) (bool, error) {
+	// root is always mounted
+	if path == string(os.PathSeparator) {
+		return true, nil
+	}
+	return mounted(path)
+}
+
+// Info reveals information about a particular mounted filesystem. This
+// struct is populated from the content in the /proc/<pid>/mountinfo file.
+type Info struct {
+	// ID is a unique identifier of the mount (may be reused after umount).
+	ID int
+
+	// Parent is the ID of the parent mount (or of self for the root
+	// of this mount namespace's mount tree).
+	Parent int
+
+	// Major and Minor are the major and the minor components of the Dev
+	// field of unix.Stat_t structure returned by unix.*Stat calls for
+	// files on this filesystem.
+	Major, Minor int
+
+	// Root is the pathname of the directory in the filesystem which forms
+	// the root of this mount.
+	Root string
+
+	// Mountpoint is the pathname of the mount point relative to the
+	// process's root directory.
+	Mountpoint string
+
+	// Options is a comma-separated list of mount options.
+	Options string
+
+	// Optional are zero or more fields of the form "tag[:value]",
+	// separated by a space.  Currently, the possible optional fields are
+	// "shared", "master", "propagate_from", and "unbindable". For more
+	// information, see mount_namespaces(7) Linux man page.
+	Optional string
+
+	// FSType is the filesystem type in the form "type[.subtype]".
+	FSType string
+
+	// Source is filesystem-specific information, or "none".
+	Source string
+
+	// VFSOptions is a comma-separated list of superblock options.
+	VFSOptions string
+}

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_bsd.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_bsd.go
@@ -1,0 +1,56 @@
+//go:build freebsd || openbsd || darwin
+// +build freebsd openbsd darwin
+
+package mountinfo
+
+import "golang.org/x/sys/unix"
+
+// parseMountTable returns information about mounted filesystems
+func parseMountTable(filter FilterFunc) ([]*Info, error) {
+	count, err := unix.Getfsstat(nil, unix.MNT_WAIT)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]unix.Statfs_t, count)
+	_, err = unix.Getfsstat(entries, unix.MNT_WAIT)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*Info
+	for _, entry := range entries {
+		var skip, stop bool
+		mountinfo := getMountinfo(&entry)
+
+		if filter != nil {
+			// filter out entries we're not interested in
+			skip, stop = filter(mountinfo)
+			if skip {
+				continue
+			}
+		}
+
+		out = append(out, mountinfo)
+		if stop {
+			break
+		}
+	}
+	return out, nil
+}
+
+func mounted(path string) (bool, error) {
+	path, err := normalizePath(path)
+	if err != nil {
+		return false, err
+	}
+	// Fast path: compare st.st_dev fields.
+	// This should always work for FreeBSD and OpenBSD.
+	mounted, err := mountedByStat(path)
+	if err == nil {
+		return mounted, nil
+	}
+
+	// Fallback to parsing mountinfo
+	return mountedByMountinfo(path)
+}

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_filters.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_filters.go
@@ -1,0 +1,63 @@
+package mountinfo
+
+import "strings"
+
+// FilterFunc is a type defining a callback function for GetMount(),
+// used to filter out mountinfo entries we're not interested in,
+// and/or stop further processing if we found what we wanted.
+//
+// It takes a pointer to the Info struct (fully populated with all available
+// fields on the GOOS platform), and returns two booleans:
+//
+// skip: true if the entry should be skipped;
+//
+// stop: true if parsing should be stopped after the entry.
+type FilterFunc func(*Info) (skip, stop bool)
+
+// PrefixFilter discards all entries whose mount points do not start with, or
+// are equal to the path specified in prefix. The prefix path must be absolute,
+// have all symlinks resolved, and cleaned (i.e. no extra slashes or dots).
+//
+// PrefixFilter treats prefix as a path, not a partial prefix, which means that
+// given "/foo", "/foo/bar" and "/foobar" entries, PrefixFilter("/foo") returns
+// "/foo" and "/foo/bar", and discards "/foobar".
+func PrefixFilter(prefix string) FilterFunc {
+	return func(m *Info) (bool, bool) {
+		skip := !strings.HasPrefix(m.Mountpoint+"/", prefix+"/")
+		return skip, false
+	}
+}
+
+// SingleEntryFilter looks for a specific entry.
+func SingleEntryFilter(mp string) FilterFunc {
+	return func(m *Info) (bool, bool) {
+		if m.Mountpoint == mp {
+			return false, true // don't skip, stop now
+		}
+		return true, false // skip, keep going
+	}
+}
+
+// ParentsFilter returns all entries whose mount points
+// can be parents of a path specified, discarding others.
+//
+// For example, given /var/lib/docker/something, entries
+// like /var/lib/docker, /var and / are returned.
+func ParentsFilter(path string) FilterFunc {
+	return func(m *Info) (bool, bool) {
+		skip := !strings.HasPrefix(path, m.Mountpoint)
+		return skip, false
+	}
+}
+
+// FSTypeFilter returns all entries that match provided fstype(s).
+func FSTypeFilter(fstype ...string) FilterFunc {
+	return func(m *Info) (bool, bool) {
+		for _, t := range fstype {
+			if m.FSType == t {
+				return false, false // don't skip, keep going
+			}
+		}
+		return true, false // skip, keep going
+	}
+}

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_freebsdlike.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_freebsdlike.go
@@ -1,0 +1,14 @@
+//go:build freebsd || darwin
+// +build freebsd darwin
+
+package mountinfo
+
+import "golang.org/x/sys/unix"
+
+func getMountinfo(entry *unix.Statfs_t) *Info {
+	return &Info{
+		Mountpoint: unix.ByteSliceToString(entry.Mntonname[:]),
+		FSType:     unix.ByteSliceToString(entry.Fstypename[:]),
+		Source:     unix.ByteSliceToString(entry.Mntfromname[:]),
+	}
+}

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_linux.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_linux.go
@@ -1,0 +1,250 @@
+package mountinfo
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+// GetMountsFromReader retrieves a list of mounts from the
+// reader provided, with an optional filter applied (use nil
+// for no filter). This can be useful in tests or benchmarks
+// that provide fake mountinfo data, or when a source other
+// than /proc/thread-self/mountinfo needs to be read from.
+//
+// This function is Linux-specific.
+func GetMountsFromReader(r io.Reader, filter FilterFunc) ([]*Info, error) {
+	s := bufio.NewScanner(r)
+	out := []*Info{}
+	for s.Scan() {
+		var err error
+
+		/*
+		   See http://man7.org/linux/man-pages/man5/proc.5.html
+
+		   36 35 98:0 /mnt1 /mnt2 rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+		   (1)(2)(3)   (4)   (5)      (6)      (7)   (8) (9)   (10)         (11)
+
+		   (1) mount ID:  unique identifier of the mount (may be reused after umount)
+		   (2) parent ID:  ID of parent (or of self for the top of the mount tree)
+		   (3) major:minor:  value of st_dev for files on filesystem
+		   (4) root:  root of the mount within the filesystem
+		   (5) mount point:  mount point relative to the process's root
+		   (6) mount options:  per mount options
+		   (7) optional fields:  zero or more fields of the form "tag[:value]"
+		   (8) separator:  marks the end of the optional fields
+		   (9) filesystem type:  name of filesystem of the form "type[.subtype]"
+		   (10) mount source:  filesystem specific information or "none"
+		   (11) super options:  per super block options
+
+		   In other words, we have:
+		    * 6 mandatory fields	(1)..(6)
+		    * 0 or more optional fields	(7)
+		    * a separator field		(8)
+		    * 3 mandatory fields	(9)..(11)
+		*/
+
+		text := s.Text()
+		fields := strings.Split(text, " ")
+		numFields := len(fields)
+		if numFields < 10 {
+			// should be at least 10 fields
+			return nil, fmt.Errorf("parsing '%s' failed: not enough fields (%d)", text, numFields)
+		}
+
+		// separator field
+		sepIdx := numFields - 4
+		// In Linux <= 3.9 mounting a cifs with spaces in a share
+		// name (like "//srv/My Docs") _may_ end up having a space
+		// in the last field of mountinfo (like "unc=//serv/My Docs").
+		// Since kernel 3.10-rc1, cifs option "unc=" is ignored,
+		// so spaces should not appear.
+		//
+		// Check for a separator, and work around the spaces bug
+		for fields[sepIdx] != "-" {
+			sepIdx--
+			if sepIdx == 5 {
+				return nil, fmt.Errorf("parsing '%s' failed: missing - separator", text)
+			}
+		}
+
+		p := &Info{}
+
+		p.Mountpoint, err = unescape(fields[4])
+		if err != nil {
+			return nil, fmt.Errorf("parsing '%s' failed: mount point: %w", fields[4], err)
+		}
+		p.FSType, err = unescape(fields[sepIdx+1])
+		if err != nil {
+			return nil, fmt.Errorf("parsing '%s' failed: fstype: %w", fields[sepIdx+1], err)
+		}
+		p.Source, err = unescape(fields[sepIdx+2])
+		if err != nil {
+			return nil, fmt.Errorf("parsing '%s' failed: source: %w", fields[sepIdx+2], err)
+		}
+		p.VFSOptions = fields[sepIdx+3]
+
+		// ignore any numbers parsing errors, as there should not be any
+		p.ID, _ = strconv.Atoi(fields[0])
+		p.Parent, _ = strconv.Atoi(fields[1])
+		mm := strings.SplitN(fields[2], ":", 3)
+		if len(mm) != 2 {
+			return nil, fmt.Errorf("parsing '%s' failed: unexpected major:minor pair %s", text, mm)
+		}
+		p.Major, _ = strconv.Atoi(mm[0])
+		p.Minor, _ = strconv.Atoi(mm[1])
+
+		p.Root, err = unescape(fields[3])
+		if err != nil {
+			return nil, fmt.Errorf("parsing '%s' failed: root: %w", fields[3], err)
+		}
+
+		p.Options = fields[5]
+
+		// zero or more optional fields
+		p.Optional = strings.Join(fields[6:sepIdx], " ")
+
+		// Run the filter after parsing all fields.
+		var skip, stop bool
+		if filter != nil {
+			skip, stop = filter(p)
+			if skip {
+				continue
+			}
+		}
+
+		out = append(out, p)
+		if stop {
+			break
+		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+var (
+	haveProcThreadSelf     bool
+	haveProcThreadSelfOnce sync.Once
+)
+
+func parseMountTable(filter FilterFunc) (_ []*Info, err error) {
+	haveProcThreadSelfOnce.Do(func() {
+		_, err := os.Stat("/proc/thread-self/mountinfo")
+		haveProcThreadSelf = err == nil
+	})
+
+	// We need to lock ourselves to the current OS thread in order to make sure
+	// that the thread referenced by /proc/thread-self stays alive until we
+	// finish parsing the file.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	var f *os.File
+	if haveProcThreadSelf {
+		f, err = os.Open("/proc/thread-self/mountinfo")
+	} else {
+		// On pre-3.17 kernels (such as CentOS 7), we don't have
+		// /proc/thread-self/ so we need to manually construct
+		// /proc/self/task/<tid>/ as a fallback.
+		f, err = os.Open("/proc/self/task/" + strconv.Itoa(unix.Gettid()) + "/mountinfo")
+		if os.IsNotExist(err) {
+			// If /proc/self/task/... failed, it means that our active pid
+			// namespace doesn't match the pid namespace of the /proc mount. In
+			// this case we just have to make do with /proc/self, since there
+			// is no other way of figuring out our tid in a parent pid
+			// namespace on pre-3.17 kernels.
+			f, err = os.Open("/proc/self/mountinfo")
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return GetMountsFromReader(f, filter)
+}
+
+// PidMountInfo retrieves the list of mounts from a given process' mount
+// namespace. Unless there is a need to get mounts from a mount namespace
+// different from that of a calling process, use GetMounts.
+//
+// This function is Linux-specific.
+//
+// Deprecated: this will be removed before v1; use GetMountsFromReader with
+// opened /proc/<pid>/mountinfo as an argument instead.
+func PidMountInfo(pid int) ([]*Info, error) {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/mountinfo", pid))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return GetMountsFromReader(f, nil)
+}
+
+// A few specific characters in mountinfo path entries (root and mountpoint)
+// are escaped using a backslash followed by a character's ascii code in octal.
+//
+//	space              -- as \040
+//	tab (aka \t)       -- as \011
+//	newline (aka \n)   -- as \012
+//	backslash (aka \\) -- as \134
+//
+// This function converts path from mountinfo back, i.e. it unescapes the above sequences.
+func unescape(path string) (string, error) {
+	// try to avoid copying
+	if strings.IndexByte(path, '\\') == -1 {
+		return path, nil
+	}
+
+	// The following code is UTF-8 transparent as it only looks for some
+	// specific characters (backslash and 0..7) with values < utf8.RuneSelf,
+	// and everything else is passed through as is.
+	buf := make([]byte, len(path))
+	bufLen := 0
+	for i := 0; i < len(path); i++ {
+		if path[i] != '\\' {
+			buf[bufLen] = path[i]
+			bufLen++
+			continue
+		}
+		s := path[i:]
+		if len(s) < 4 {
+			// too short
+			return "", fmt.Errorf("bad escape sequence %q: too short", s)
+		}
+		c := s[1]
+		switch c {
+		case '0', '1', '2', '3', '4', '5', '6', '7':
+			v := c - '0'
+			for j := 2; j < 4; j++ { // one digit already; two more
+				if s[j] < '0' || s[j] > '7' {
+					return "", fmt.Errorf("bad escape sequence %q: not a digit", s[:3])
+				}
+				x := s[j] - '0'
+				v = (v << 3) | x
+			}
+			if v > 255 {
+				return "", fmt.Errorf("bad escape sequence %q: out of range" + s[:3])
+			}
+			buf[bufLen] = v
+			bufLen++
+			i += 3
+			continue
+		default:
+			return "", fmt.Errorf("bad escape sequence %q: not a digit" + s[:3])
+
+		}
+	}
+
+	return string(buf[:bufLen]), nil
+}

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_openbsd.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_openbsd.go
@@ -1,0 +1,11 @@
+package mountinfo
+
+import "golang.org/x/sys/unix"
+
+func getMountinfo(entry *unix.Statfs_t) *Info {
+	return &Info{
+		Mountpoint: unix.ByteSliceToString(entry.F_mntonname[:]),
+		FSType:     unix.ByteSliceToString(entry.F_fstypename[:]),
+		Source:     unix.ByteSliceToString(entry.F_mntfromname[:]),
+	}
+}

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_unsupported.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_unsupported.go
@@ -1,0 +1,19 @@
+//go:build !windows && !linux && !freebsd && !openbsd && !darwin
+// +build !windows,!linux,!freebsd,!openbsd,!darwin
+
+package mountinfo
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var errNotImplemented = fmt.Errorf("not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
+
+func parseMountTable(_ FilterFunc) ([]*Info, error) {
+	return nil, errNotImplemented
+}
+
+func mounted(path string) (bool, error) {
+	return false, errNotImplemented
+}

--- a/vendor/github.com/moby/sys/mountinfo/mountinfo_windows.go
+++ b/vendor/github.com/moby/sys/mountinfo/mountinfo_windows.go
@@ -1,0 +1,10 @@
+package mountinfo
+
+func parseMountTable(_ FilterFunc) ([]*Info, error) {
+	// Do NOT return an error!
+	return nil, nil
+}
+
+func mounted(_ string) (bool, error) {
+	return false, nil
+}

--- a/vendor/k8s.io/mount-utils/LICENSE
+++ b/vendor/k8s.io/mount-utils/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/mount-utils/OWNERS
+++ b/vendor/k8s.io/mount-utils/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - jingxu97
+  - saad-ali
+  - jsafrane
+  - msau42
+  - andyzhangx
+  - gnufied
+approvers:
+  - jingxu97
+  - saad-ali
+  - jsafrane
+labels:
+  - sig/storage

--- a/vendor/k8s.io/mount-utils/README.md
+++ b/vendor/k8s.io/mount-utils/README.md
@@ -1,0 +1,31 @@
+## Purpose
+
+This repository defines an interface to mounting filesystems to be consumed by 
+various Kubernetes and out-of-tree CSI components. 
+
+Consumers of this repository can make use of functions like 'Mount' to mount 
+source to target as fstype with given options, 'Unmount' to unmount a target.
+Other useful functions include 'List' all mounted file systems and find all
+mount references to a path using 'GetMountRefs'
+
+## Community, discussion, contribution, and support
+
+Learn how to engage with the Kubernetes community on the [community
+page](http://kubernetes.io/community/).
+
+You can reach the maintainers of this repository at:
+
+- Slack: #sig-storage (on https://kubernetes.slack.com -- get an
+  invite at slack.kubernetes.io)
+- Mailing List:
+  https://groups.google.com/forum/#!forum/kubernetes-sig-storage
+
+### Code of Conduct
+
+Participation in the Kubernetes community is governed by the [Kubernetes
+Code of Conduct](code-of-conduct.md).
+
+### Contibution Guidelines
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
+

--- a/vendor/k8s.io/mount-utils/SECURITY_CONTACTS
+++ b/vendor/k8s.io/mount-utils/SECURITY_CONTACTS
@@ -1,0 +1,18 @@
+# Defined below are the security contacts for this repo.
+#
+# They are the contact point for the Product Security Committee to reach out
+# to for triaging and handling of incoming issues.
+#
+# The below names agree to abide by the
+# [Embargo Policy](https://git.k8s.io/security/private-distributors-list.md#embargo-policy)
+# and will be removed and replaced if they violate that agreement.
+#
+# DO NOT REPORT SECURITY VULNERABILITIES DIRECTLY TO THESE NAMES, FOLLOW THE
+# INSTRUCTIONS AT https://kubernetes.io/security/
+
+saad-ali
+cjcullen
+joelsmith
+liggitt
+philips
+tallclair

--- a/vendor/k8s.io/mount-utils/code-of-conduct.md
+++ b/vendor/k8s.io/mount-utils/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/vendor/k8s.io/mount-utils/doc.go
+++ b/vendor/k8s.io/mount-utils/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mount defines an interface to mounting filesystems.
+package mount

--- a/vendor/k8s.io/mount-utils/fake_mounter.go
+++ b/vendor/k8s.io/mount-utils/fake_mounter.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"k8s.io/klog/v2"
+)
+
+// FakeMounter implements mount.Interface for tests.
+type FakeMounter struct {
+	MountPoints []MountPoint
+	log         []FakeAction
+	// Error to return for a path when calling IsLikelyNotMountPoint
+	MountCheckErrors map[string]error
+	// Some tests run things in parallel, make sure the mounter does not produce
+	// any golang's DATA RACE warnings.
+	mutex               sync.Mutex
+	UnmountFunc         UnmountFunc
+	skipMountPointCheck bool
+}
+
+// UnmountFunc is a function callback to be executed during the Unmount() call.
+type UnmountFunc func(path string) error
+
+var _ Interface = &FakeMounter{}
+
+const (
+	// FakeActionMount is the string for specifying mount as FakeAction.Action
+	FakeActionMount = "mount"
+	// FakeActionUnmount is the string for specifying unmount as FakeAction.Action
+	FakeActionUnmount = "unmount"
+)
+
+// FakeAction objects are logged every time a fake mount or unmount is called.
+type FakeAction struct {
+	Action string // "mount" or "unmount"
+	Target string // applies to both mount and unmount actions
+	Source string // applies only to "mount" actions
+	FSType string // applies only to "mount" actions
+}
+
+// NewFakeMounter returns a FakeMounter struct that implements Interface and is
+// suitable for testing purposes.
+func NewFakeMounter(mps []MountPoint) *FakeMounter {
+	return &FakeMounter{
+		MountPoints: mps,
+	}
+}
+
+func (f *FakeMounter) WithSkipMountPointCheck() *FakeMounter {
+	f.skipMountPointCheck = true
+	return f
+}
+
+// ResetLog clears all the log entries in FakeMounter
+func (f *FakeMounter) ResetLog() {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	f.log = []FakeAction{}
+}
+
+// GetLog returns the slice of FakeActions taken by the mounter
+func (f *FakeMounter) GetLog() []FakeAction {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	return f.log
+}
+
+// Mount records the mount event and updates the in-memory mount points for FakeMounter
+func (f *FakeMounter) Mount(source string, target string, fstype string, options []string) error {
+	return f.MountSensitive(source, target, fstype, options, nil /* sensitiveOptions */)
+}
+
+// Mount records the mount event and updates the in-memory mount points for FakeMounter
+// sensitiveOptions to be passed in a separate parameter from the normal
+// mount options and ensures the sensitiveOptions are never logged. This
+// method should be used by callers that pass sensitive material (like
+// passwords) as mount options.
+func (f *FakeMounter) MountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	opts := []string{}
+
+	for _, option := range options {
+		// find 'bind' option
+		if option == "bind" {
+			// This is a bind-mount. In order to mimic linux behaviour, we must
+			// use the original device of the bind-mount as the real source.
+			// E.g. when mounted /dev/sda like this:
+			//      $ mount /dev/sda /mnt/test
+			//      $ mount -o bind /mnt/test /mnt/bound
+			// then /proc/mount contains:
+			// /dev/sda /mnt/test
+			// /dev/sda /mnt/bound
+			// (and not /mnt/test /mnt/bound)
+			// I.e. we must use /dev/sda as source instead of /mnt/test in the
+			// bind mount.
+			for _, mnt := range f.MountPoints {
+				if source == mnt.Path {
+					source = mnt.Device
+					break
+				}
+			}
+		}
+		// reuse MountPoint.Opts field to mark mount as readonly
+		opts = append(opts, option)
+	}
+
+	// If target is a symlink, get its absolute path
+	absTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		absTarget = target
+	}
+	f.MountPoints = append(f.MountPoints, MountPoint{Device: source, Path: absTarget, Type: fstype, Opts: append(opts, sensitiveOptions...)})
+	klog.V(5).Infof("Fake mounter: mounted %s to %s", source, absTarget)
+	f.log = append(f.log, FakeAction{Action: FakeActionMount, Target: absTarget, Source: source, FSType: fstype})
+	return nil
+}
+
+func (f *FakeMounter) MountSensitiveWithoutSystemd(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+	return f.MountSensitive(source, target, fstype, options, nil /* sensitiveOptions */)
+}
+
+func (f *FakeMounter) MountSensitiveWithoutSystemdWithMountFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
+	return f.MountSensitive(source, target, fstype, options, nil /* sensitiveOptions */)
+}
+
+// Unmount records the unmount event and updates the in-memory mount points for FakeMounter
+func (f *FakeMounter) Unmount(target string) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	// If target is a symlink, get its absolute path
+	absTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		absTarget = target
+	}
+
+	newMountpoints := []MountPoint{}
+	for _, mp := range f.MountPoints {
+		if mp.Path == absTarget {
+			if f.UnmountFunc != nil {
+				err := f.UnmountFunc(absTarget)
+				if err != nil {
+					return err
+				}
+			}
+			klog.V(5).Infof("Fake mounter: unmounted %s from %s", mp.Device, absTarget)
+			// Don't copy it to newMountpoints
+			continue
+		}
+		newMountpoints = append(newMountpoints, MountPoint{Device: mp.Device, Path: mp.Path, Type: mp.Type})
+	}
+	f.MountPoints = newMountpoints
+	f.log = append(f.log, FakeAction{Action: FakeActionUnmount, Target: absTarget})
+	delete(f.MountCheckErrors, target)
+	return nil
+}
+
+// List returns all the in-memory mountpoints for FakeMounter
+func (f *FakeMounter) List() ([]MountPoint, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	return f.MountPoints, nil
+}
+
+// IsLikelyNotMountPoint determines whether a path is a mountpoint by checking
+// if the absolute path to file is in the in-memory mountpoints
+func (f *FakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	err := f.MountCheckErrors[file]
+	if err != nil {
+		return false, err
+	}
+
+	_, err = os.Stat(file)
+	if err != nil {
+		return true, err
+	}
+
+	// If file is a symlink, get its absolute path
+	absFile, err := filepath.EvalSymlinks(file)
+	if err != nil {
+		absFile = file
+	}
+
+	for _, mp := range f.MountPoints {
+		if mp.Path == absFile {
+			klog.V(5).Infof("isLikelyNotMountPoint for %s: mounted %s, false", file, mp.Path)
+			return false, nil
+		}
+	}
+	klog.V(5).Infof("isLikelyNotMountPoint for %s: true", file)
+	return true, nil
+}
+
+func (f *FakeMounter) CanSafelySkipMountPointCheck() bool {
+	return f.skipMountPointCheck
+}
+
+func (f *FakeMounter) IsMountPoint(file string) (bool, error) {
+	notMnt, err := f.IsLikelyNotMountPoint(file)
+	if err != nil {
+		return false, err
+	}
+	return !notMnt, nil
+}
+
+// GetMountRefs finds all mount references to the path, returns a
+// list of paths.
+func (f *FakeMounter) GetMountRefs(pathname string) ([]string, error) {
+	realpath, err := filepath.EvalSymlinks(pathname)
+	if err != nil {
+		// Ignore error in FakeMounter, because we actually didn't create files.
+		realpath = pathname
+	}
+	return getMountRefsByDev(f, realpath)
+}

--- a/vendor/k8s.io/mount-utils/mount.go
+++ b/vendor/k8s.io/mount-utils/mount.go
@@ -1,0 +1,401 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// TODO(thockin): This whole pkg is pretty linux-centric.  As soon as we have
+// an alternate platform, we will need to abstract further.
+
+package mount
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	utilexec "k8s.io/utils/exec"
+)
+
+const (
+	// Default mount command if mounter path is not specified.
+	defaultMountCommand = "mount"
+	// Log message where sensitive mount options were removed
+	sensitiveOptionsRemoved = "<masked>"
+)
+
+// Interface defines the set of methods to allow for mount operations on a system.
+type Interface interface {
+	// Mount mounts source to target as fstype with given options.
+	// options MUST not contain sensitive material (like passwords).
+	Mount(source string, target string, fstype string, options []string) error
+	// MountSensitive is the same as Mount() but this method allows
+	// sensitiveOptions to be passed in a separate parameter from the normal
+	// mount options and ensures the sensitiveOptions are never logged. This
+	// method should be used by callers that pass sensitive material (like
+	// passwords) as mount options.
+	MountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error
+	// MountSensitiveWithoutSystemd is the same as MountSensitive() but this method disable using systemd mount.
+	MountSensitiveWithoutSystemd(source string, target string, fstype string, options []string, sensitiveOptions []string) error
+	// MountSensitiveWithoutSystemdWithMountFlags is the same as MountSensitiveWithoutSystemd() with additional mount flags
+	MountSensitiveWithoutSystemdWithMountFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error
+	// Unmount unmounts given target.
+	Unmount(target string) error
+	// List returns a list of all mounted filesystems.  This can be large.
+	// On some platforms, reading mounts directly from the OS is not guaranteed
+	// consistent (i.e. it could change between chunked reads). This is guaranteed
+	// to be consistent.
+	List() ([]MountPoint, error)
+	// IsLikelyNotMountPoint uses heuristics to determine if a directory
+	// is not a mountpoint.
+	// It should return ErrNotExist when the directory does not exist.
+	// IsLikelyNotMountPoint does NOT properly detect all mountpoint types
+	// most notably linux bind mounts and symbolic link. For callers that do not
+	// care about such situations, this is a faster alternative to calling List()
+	// and scanning that output.
+	IsLikelyNotMountPoint(file string) (bool, error)
+	// CanSafelySkipMountPointCheck indicates whether this mounter returns errors on
+	// operations for targets that are not mount points. If this returns true, no such
+	// errors will be returned.
+	CanSafelySkipMountPointCheck() bool
+	// IsMountPoint determines if a directory is a mountpoint.
+	// It should return ErrNotExist when the directory does not exist.
+	// IsMountPoint is more expensive than IsLikelyNotMountPoint.
+	// IsMountPoint detects bind mounts in linux.
+	// IsMountPoint may enumerate all the mountpoints using List() and
+	// the list of mountpoints may be large, then it uses
+	// isMountPointMatch to evaluate whether the directory is a mountpoint.
+	IsMountPoint(file string) (bool, error)
+	// GetMountRefs finds all mount references to pathname, returning a slice of
+	// paths. Pathname can be a mountpoint path or a normal	directory
+	// (for bind mount). On Linux, pathname is excluded from the slice.
+	// For example, if /dev/sdc was mounted at /path/a and /path/b,
+	// GetMountRefs("/path/a") would return ["/path/b"]
+	// GetMountRefs("/path/b") would return ["/path/a"]
+	// On Windows there is no way to query all mount points; as long as pathname is
+	// a valid mount, it will be returned.
+	GetMountRefs(pathname string) ([]string, error)
+}
+
+// Compile-time check to ensure all Mounter implementations satisfy
+// the mount interface.
+var _ Interface = &Mounter{}
+
+type MounterForceUnmounter interface {
+	Interface
+	// UnmountWithForce unmounts given target but will retry unmounting with force option
+	// after given timeout.
+	UnmountWithForce(target string, umountTimeout time.Duration) error
+}
+
+// MountPoint represents a single line in /proc/mounts or /etc/fstab.
+type MountPoint struct { // nolint: golint
+	Device string
+	Path   string
+	Type   string
+	Opts   []string // Opts may contain sensitive mount options (like passwords) and MUST be treated as such (e.g. not logged).
+	Freq   int
+	Pass   int
+}
+
+type MountErrorType string // nolint: golint
+
+const (
+	FilesystemMismatch  MountErrorType = "FilesystemMismatch"
+	HasFilesystemErrors MountErrorType = "HasFilesystemErrors"
+	UnformattedReadOnly MountErrorType = "UnformattedReadOnly"
+	FormatFailed        MountErrorType = "FormatFailed"
+	GetDiskFormatFailed MountErrorType = "GetDiskFormatFailed"
+	UnknownMountError   MountErrorType = "UnknownMountError"
+)
+
+type MountError struct { // nolint: golint
+	Type    MountErrorType
+	Message string
+}
+
+func (mountError MountError) String() string {
+	return mountError.Message
+}
+
+func (mountError MountError) Error() string {
+	return mountError.Message
+}
+
+func NewMountError(mountErrorValue MountErrorType, format string, args ...interface{}) error {
+	mountError := MountError{
+		Type:    mountErrorValue,
+		Message: fmt.Sprintf(format, args...),
+	}
+	return mountError
+}
+
+// SafeFormatAndMount probes a device to see if it is formatted.
+// Namely it checks to see if a file system is present. If so it
+// mounts it otherwise the device is formatted first then mounted.
+type SafeFormatAndMount struct {
+	Interface
+	Exec utilexec.Interface
+
+	formatSem     chan any
+	formatTimeout time.Duration
+}
+
+func NewSafeFormatAndMount(mounter Interface, exec utilexec.Interface, opts ...Option) *SafeFormatAndMount {
+	res := &SafeFormatAndMount{
+		Interface: mounter,
+		Exec:      exec,
+	}
+	for _, opt := range opts {
+		opt(res)
+	}
+	return res
+}
+
+type Option func(*SafeFormatAndMount)
+
+// WithMaxConcurrentFormat sets the maximum number of concurrent format
+// operations executed by the mounter. The timeout controls the maximum
+// duration of a format operation before its concurrency token is released.
+// Once a token is released, it can be acquired by another concurrent format
+// operation. The original operation is allowed to complete.
+// If n < 1, concurrency is set to unlimited.
+func WithMaxConcurrentFormat(n int, timeout time.Duration) Option {
+	return func(mounter *SafeFormatAndMount) {
+		if n > 0 {
+			mounter.formatSem = make(chan any, n)
+			mounter.formatTimeout = timeout
+		}
+	}
+}
+
+// FormatAndMount formats the given disk, if needed, and mounts it.
+// That is if the disk is not formatted and it is not being mounted as
+// read-only it will format it first then mount it. Otherwise, if the
+// disk is already formatted or it is being mounted as read-only, it
+// will be mounted without formatting.
+// options MUST not contain sensitive material (like passwords).
+func (mounter *SafeFormatAndMount) FormatAndMount(source string, target string, fstype string, options []string) error {
+	return mounter.FormatAndMountSensitive(source, target, fstype, options, nil /* sensitiveOptions */)
+}
+
+// FormatAndMountSensitive is the same as FormatAndMount but this method allows
+// sensitiveOptions to be passed in a separate parameter from the normal mount
+// options and ensures the sensitiveOptions are never logged. This method should
+// be used by callers that pass sensitive material (like passwords) as mount
+// options.
+func (mounter *SafeFormatAndMount) FormatAndMountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+	return mounter.FormatAndMountSensitiveWithFormatOptions(source, target, fstype, options, sensitiveOptions, nil /* formatOptions */)
+}
+
+// FormatAndMountSensitiveWithFormatOptions behaves exactly the same as
+// FormatAndMountSensitive, but allows for options to be passed when the disk
+// is formatted. These options are NOT validated in any way and should never
+// come directly from untrusted user input as that would be an injection risk.
+func (mounter *SafeFormatAndMount) FormatAndMountSensitiveWithFormatOptions(source string, target string, fstype string, options []string, sensitiveOptions []string, formatOptions []string) error {
+	return mounter.formatAndMountSensitive(source, target, fstype, options, sensitiveOptions, formatOptions)
+}
+
+// getMountRefsByDev finds all references to the device provided
+// by mountPath; returns a list of paths.
+// Note that mountPath should be path after the evaluation of any symblolic links.
+func getMountRefsByDev(mounter Interface, mountPath string) ([]string, error) {
+	mps, err := mounter.List()
+	if err != nil {
+		return nil, err
+	}
+
+	// Finding the device mounted to mountPath.
+	diskDev := ""
+	for i := range mps {
+		if mountPath == mps[i].Path {
+			diskDev = mps[i].Device
+			break
+		}
+	}
+
+	// Find all references to the device.
+	var refs []string
+	for i := range mps {
+		if mps[i].Device == diskDev || mps[i].Device == mountPath {
+			if mps[i].Path != mountPath {
+				refs = append(refs, mps[i].Path)
+			}
+		}
+	}
+	return refs, nil
+}
+
+// IsNotMountPoint determines if a directory is a mountpoint.
+// It should return ErrNotExist when the directory does not exist.
+// IsNotMountPoint is more expensive than IsLikelyNotMountPoint
+// and depends on IsMountPoint.
+//
+// If an error occurs, it returns true (assuming it is not a mountpoint)
+// when ErrNotExist is returned for callers similar to IsLikelyNotMountPoint.
+//
+// Deprecated: This function is kept to keep changes backward compatible with
+// previous library version. Callers should prefer mounter.IsMountPoint.
+func IsNotMountPoint(mounter Interface, file string) (bool, error) {
+	isMnt, err := mounter.IsMountPoint(file)
+	if err != nil {
+		return true, err
+	}
+	return !isMnt, nil
+}
+
+// GetDeviceNameFromMount given a mnt point, find the device from /proc/mounts
+// returns the device name, reference count, and error code.
+func GetDeviceNameFromMount(mounter Interface, mountPath string) (string, int, error) {
+	mps, err := mounter.List()
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Find the device name.
+	// FIXME if multiple devices mounted on the same mount path, only the first one is returned.
+	device := ""
+	// If mountPath is symlink, need get its target path.
+	slTarget, err := filepath.EvalSymlinks(mountPath)
+	if err != nil {
+		slTarget = mountPath
+	}
+	for i := range mps {
+		if mps[i].Path == slTarget {
+			device = mps[i].Device
+			break
+		}
+	}
+
+	// Find all references to the device.
+	refCount := 0
+	for i := range mps {
+		if mps[i].Device == device {
+			refCount++
+		}
+	}
+	return device, refCount, nil
+}
+
+// MakeBindOpts detects whether a bind mount is being requested and makes the remount options to
+// use in case of bind mount, due to the fact that bind mount doesn't respect mount options.
+// The list equals:
+//
+//	options - 'bind' + 'remount' (no duplicate)
+func MakeBindOpts(options []string) (bool, []string, []string) {
+	bind, bindOpts, bindRemountOpts, _ := MakeBindOptsSensitive(options, nil /* sensitiveOptions */)
+	return bind, bindOpts, bindRemountOpts
+}
+
+// MakeBindOptsSensitive is the same as MakeBindOpts but this method allows
+// sensitiveOptions to be passed in a separate parameter from the normal mount
+// options and ensures the sensitiveOptions are never logged. This method should
+// be used by callers that pass sensitive material (like passwords) as mount
+// options.
+func MakeBindOptsSensitive(options []string, sensitiveOptions []string) (bool, []string, []string, []string) {
+	// Because we have an FD opened on the subpath bind mount, the "bind" option
+	// needs to be included, otherwise the mount target will error as busy if you
+	// remount as readonly.
+	//
+	// As a consequence, all read only bind mounts will no longer change the underlying
+	// volume mount to be read only.
+	bindRemountOpts := []string{"bind", "remount"}
+	bindRemountSensitiveOpts := []string{}
+	bind := false
+	bindOpts := []string{"bind"}
+
+	// _netdev is a userspace mount option and does not automatically get added when
+	// bind mount is created and hence we must carry it over.
+	if checkForNetDev(options, sensitiveOptions) {
+		bindOpts = append(bindOpts, "_netdev")
+	}
+
+	for _, option := range options {
+		switch option {
+		case "bind":
+			bind = true
+		case "remount":
+		default:
+			bindRemountOpts = append(bindRemountOpts, option)
+		}
+	}
+
+	for _, sensitiveOption := range sensitiveOptions {
+		switch sensitiveOption {
+		case "bind":
+			bind = true
+		case "remount":
+		default:
+			bindRemountSensitiveOpts = append(bindRemountSensitiveOpts, sensitiveOption)
+		}
+	}
+
+	return bind, bindOpts, bindRemountOpts, bindRemountSensitiveOpts
+}
+
+func checkForNetDev(options []string, sensitiveOptions []string) bool {
+	for _, option := range options {
+		if option == "_netdev" {
+			return true
+		}
+	}
+	for _, sensitiveOption := range sensitiveOptions {
+		if sensitiveOption == "_netdev" {
+			return true
+		}
+	}
+	return false
+}
+
+// PathWithinBase checks if give path is within given base directory.
+func PathWithinBase(fullPath, basePath string) bool {
+	rel, err := filepath.Rel(basePath, fullPath)
+	if err != nil {
+		return false
+	}
+	if StartsWithBackstep(rel) {
+		// Needed to escape the base path.
+		return false
+	}
+	return true
+}
+
+// StartsWithBackstep checks if the given path starts with a backstep segment.
+func StartsWithBackstep(rel string) bool {
+	// normalize to / and check for ../
+	return rel == ".." || strings.HasPrefix(filepath.ToSlash(rel), "../")
+}
+
+// sanitizedOptionsForLogging will return a comma separated string containing
+// options and sensitiveOptions. Each entry in sensitiveOptions will be
+// replaced with the string sensitiveOptionsRemoved
+// e.g. o1,o2,<masked>,<masked>
+func sanitizedOptionsForLogging(options []string, sensitiveOptions []string) string {
+	separator := ""
+	if len(options) > 0 && len(sensitiveOptions) > 0 {
+		separator = ","
+	}
+
+	sensitiveOptionsStart := ""
+	sensitiveOptionsEnd := ""
+	if len(sensitiveOptions) > 0 {
+		sensitiveOptionsStart = strings.Repeat(sensitiveOptionsRemoved+",", len(sensitiveOptions)-1)
+		sensitiveOptionsEnd = sensitiveOptionsRemoved
+	}
+
+	return strings.Join(options, ",") +
+		separator +
+		sensitiveOptionsStart +
+		sensitiveOptionsEnd
+}

--- a/vendor/k8s.io/mount-utils/mount_helper_common.go
+++ b/vendor/k8s.io/mount-utils/mount_helper_common.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// CleanupMountPoint unmounts the given path and deletes the remaining directory
+// if successful. If extensiveMountPointCheck is true IsNotMountPoint will be
+// called instead of IsLikelyNotMountPoint. IsNotMountPoint is more expensive
+// but properly handles bind mounts within the same fs.
+func CleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool) error {
+	pathExists, pathErr := PathExists(mountPath)
+	if !pathExists && pathErr == nil {
+		klog.Warningf("Warning: mount cleanup skipped because path does not exist: %v", mountPath)
+		return nil
+	}
+	corruptedMnt := IsCorruptedMnt(pathErr)
+	if pathErr != nil && !corruptedMnt {
+		return fmt.Errorf("Error checking path: %v", pathErr)
+	}
+	return doCleanupMountPoint(mountPath, mounter, extensiveMountPointCheck, corruptedMnt)
+}
+
+func CleanupMountWithForce(mountPath string, mounter MounterForceUnmounter, extensiveMountPointCheck bool, umountTimeout time.Duration) error {
+	pathExists, pathErr := PathExists(mountPath)
+	if !pathExists && pathErr == nil {
+		klog.Warningf("Warning: mount cleanup skipped because path does not exist: %v", mountPath)
+		return nil
+	}
+	corruptedMnt := IsCorruptedMnt(pathErr)
+	if pathErr != nil && !corruptedMnt {
+		return fmt.Errorf("Error checking path: %v", pathErr)
+	}
+
+	if corruptedMnt || mounter.CanSafelySkipMountPointCheck() {
+		klog.V(4).Infof("unmounting %q (corruptedMount: %t, mounterCanSkipMountPointChecks: %t)",
+			mountPath, corruptedMnt, mounter.CanSafelySkipMountPointCheck())
+		if err := mounter.UnmountWithForce(mountPath, umountTimeout); err != nil {
+			return err
+		}
+		return removePath(mountPath)
+	}
+
+	notMnt, err := removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
+	// if mountPath is not a mount point, it's just been removed or there was an error
+	if err != nil || notMnt {
+		return err
+	}
+
+	klog.V(4).Infof("%q is a mountpoint, unmounting", mountPath)
+	if err := mounter.UnmountWithForce(mountPath, umountTimeout); err != nil {
+		return err
+	}
+
+	notMnt, err = removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
+	// if mountPath is not a mount point, it's either just been removed or there was an error
+	if notMnt {
+		return err
+	}
+	// mountPath is still a mount point
+	return fmt.Errorf("failed to cleanup mount point %v", mountPath)
+}
+
+// doCleanupMountPoint unmounts the given path and
+// deletes the remaining directory if successful.
+// if extensiveMountPointCheck is true
+// IsNotMountPoint will be called instead of IsLikelyNotMountPoint.
+// IsNotMountPoint is more expensive but properly handles bind mounts within the same fs.
+// if corruptedMnt is true, it means that the mountPath is a corrupted mountpoint, and the mount point check
+// will be skipped. The mount point check will also be skipped if the mounter supports it.
+func doCleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool, corruptedMnt bool) error {
+	if corruptedMnt || mounter.CanSafelySkipMountPointCheck() {
+		klog.V(4).Infof("unmounting %q (corruptedMount: %t, mounterCanSkipMountPointChecks: %t)",
+			mountPath, corruptedMnt, mounter.CanSafelySkipMountPointCheck())
+		if err := mounter.Unmount(mountPath); err != nil {
+			return err
+		}
+		return removePath(mountPath)
+	}
+
+	notMnt, err := removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
+	// if mountPath is not a mount point, it's just been removed or there was an error
+	if err != nil || notMnt {
+		return err
+	}
+
+	klog.V(4).Infof("%q is a mountpoint, unmounting", mountPath)
+	if err := mounter.Unmount(mountPath); err != nil {
+		return err
+	}
+
+	notMnt, err = removePathIfNotMountPoint(mountPath, mounter, extensiveMountPointCheck)
+	// if mountPath is not a mount point, it's either just been removed or there was an error
+	if notMnt {
+		return err
+	}
+	// mountPath is still a mount point
+	return fmt.Errorf("failed to cleanup mount point %v", mountPath)
+}
+
+// removePathIfNotMountPoint verifies if given mountPath is a mount point if not it attempts
+// to remove the directory. Returns true and nil if directory was not a mount point and removed.
+func removePathIfNotMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool) (bool, error) {
+	var notMnt bool
+	var err error
+
+	if extensiveMountPointCheck {
+		notMnt, err = IsNotMountPoint(mounter, mountPath)
+	} else {
+		notMnt, err = mounter.IsLikelyNotMountPoint(mountPath)
+	}
+
+	if err != nil {
+		if os.IsNotExist(err) {
+			klog.V(4).Infof("%q does not exist", mountPath)
+			return true, nil
+		}
+		return notMnt, err
+	}
+
+	if notMnt {
+		klog.V(4).Infof("%q is not a mountpoint, deleting", mountPath)
+		return notMnt, os.Remove(mountPath)
+	}
+	return notMnt, nil
+}
+
+// removePath attempts to remove the directory. Returns nil if the directory was removed or does not exist.
+func removePath(mountPath string) error {
+	klog.V(4).Infof("Deleting path %q", mountPath)
+	err := os.Remove(mountPath)
+	if os.IsNotExist(err) {
+		klog.V(4).Infof("%q does not exist", mountPath)
+		return nil
+	}
+	return err
+}

--- a/vendor/k8s.io/mount-utils/mount_helper_unix.go
+++ b/vendor/k8s.io/mount-utils/mount_helper_unix.go
@@ -1,0 +1,256 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+	utilio "k8s.io/utils/io"
+)
+
+const (
+	// At least number of fields per line in /proc/<pid>/mountinfo.
+	expectedAtLeastNumFieldsPerMountInfo = 10
+	// How many times to retry for a consistent read of /proc/mounts.
+	maxListTries = 10
+)
+
+// IsCorruptedMnt return true if err is about corrupted mount point
+func IsCorruptedMnt(err error) bool {
+	if err == nil {
+		return false
+	}
+	var underlyingError error
+	switch pe := err.(type) {
+	case nil:
+		return false
+	case *os.PathError:
+		underlyingError = pe.Err
+	case *os.LinkError:
+		underlyingError = pe.Err
+	case *os.SyscallError:
+		underlyingError = pe.Err
+	case syscall.Errno:
+		underlyingError = err
+	}
+
+	return errors.Is(underlyingError, syscall.ENOTCONN) ||
+		errors.Is(underlyingError, syscall.ESTALE) ||
+		errors.Is(underlyingError, syscall.EIO) ||
+		errors.Is(underlyingError, syscall.EACCES) ||
+		errors.Is(underlyingError, syscall.EHOSTDOWN) ||
+		errors.Is(underlyingError, syscall.EWOULDBLOCK) ||
+		errors.Is(underlyingError, syscall.ENODEV)
+}
+
+// MountInfo represents a single line in /proc/<pid>/mountinfo.
+type MountInfo struct { // nolint: golint
+	// Unique ID for the mount (maybe reused after umount).
+	ID int
+	// The ID of the parent mount (or of self for the root of this mount namespace's mount tree).
+	ParentID int
+	// Major indicates one half of the device ID which identifies the device class
+	// (parsed from `st_dev` for files on this filesystem).
+	Major int
+	// Minor indicates one half of the device ID which identifies a specific
+	// instance of device (parsed from `st_dev` for files on this filesystem).
+	Minor int
+	// The pathname of the directory in the filesystem which forms the root of this mount.
+	Root string
+	// Mount source, filesystem-specific information. e.g. device, tmpfs name.
+	Source string
+	// Mount point, the pathname of the mount point.
+	MountPoint string
+	// Optional fieds, zero or more fields of the form "tag[:value]".
+	OptionalFields []string
+	// The filesystem type in the form "type[.subtype]".
+	FsType string
+	// Per-mount options.
+	MountOptions []string
+	// Per-superblock options.
+	SuperOptions []string
+}
+
+// ParseMountInfo parses /proc/xxx/mountinfo.
+func ParseMountInfo(filename string) ([]MountInfo, error) {
+	content, err := readMountInfo(filename)
+	if err != nil {
+		return []MountInfo{}, err
+	}
+	contentStr := string(content)
+	infos := []MountInfo{}
+
+	for _, line := range strings.Split(contentStr, "\n") {
+		if line == "" {
+			// the last split() item is empty string following the last \n
+			continue
+		}
+		// See `man proc` for authoritative description of format of the file.
+		fields := strings.Fields(line)
+		if len(fields) < expectedAtLeastNumFieldsPerMountInfo {
+			return nil, fmt.Errorf("wrong number of fields in (expected at least %d, got %d): %s", expectedAtLeastNumFieldsPerMountInfo, len(fields), line)
+		}
+		id, err := strconv.Atoi(fields[0])
+		if err != nil {
+			return nil, err
+		}
+		parentID, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return nil, err
+		}
+		mm := strings.Split(fields[2], ":")
+		if len(mm) != 2 {
+			return nil, fmt.Errorf("parsing '%s' failed: unexpected minor:major pair %s", line, mm)
+		}
+		major, err := strconv.Atoi(mm[0])
+		if err != nil {
+			return nil, fmt.Errorf("parsing '%s' failed: unable to parse major device id, err:%v", mm[0], err)
+		}
+		minor, err := strconv.Atoi(mm[1])
+		if err != nil {
+			return nil, fmt.Errorf("parsing '%s' failed: unable to parse minor device id, err:%v", mm[1], err)
+		}
+
+		info := MountInfo{
+			ID:           id,
+			ParentID:     parentID,
+			Major:        major,
+			Minor:        minor,
+			Root:         fields[3],
+			MountPoint:   fields[4],
+			MountOptions: splitMountOptions(fields[5]),
+		}
+		// All fields until "-" are "optional fields".
+		i := 6
+		for ; i < len(fields) && fields[i] != "-"; i++ {
+			info.OptionalFields = append(info.OptionalFields, fields[i])
+		}
+		// Parse the rest 3 fields.
+		i++
+		if len(fields)-i < 3 {
+			return nil, fmt.Errorf("expect 3 fields in %s, got %d", line, len(fields)-i)
+		}
+		info.FsType = fields[i]
+		info.Source = fields[i+1]
+		info.SuperOptions = splitMountOptions(fields[i+2])
+		infos = append(infos, info)
+	}
+	return infos, nil
+}
+
+// splitMountOptions parses comma-separated list of mount options into an array.
+// It respects double quotes - commas in them are not considered as the option separator.
+func splitMountOptions(s string) []string {
+	inQuotes := false
+	list := strings.FieldsFunc(s, func(r rune) bool {
+		if r == '"' {
+			inQuotes = !inQuotes
+		}
+		// Report a new field only when outside of double quotes.
+		return r == ',' && !inQuotes
+	})
+	return list
+}
+
+// isMountPointMatch returns true if the path in mp is the same as dir.
+// Handles case where mountpoint dir has been renamed due to stale NFS mount.
+func isMountPointMatch(mp MountPoint, dir string) bool {
+	return strings.TrimSuffix(mp.Path, "\\040(deleted)") == dir
+}
+
+// PathExists returns true if the specified path exists.
+// TODO: clean this up to use pkg/util/file/FileExists
+func PathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	} else if errors.Is(err, fs.ErrNotExist) {
+		err = syscall.Access(path, syscall.F_OK)
+		if err == nil {
+			// The access syscall says the file exists, the stat syscall says it
+			// doesn't. This was observed on CIFS when the path was removed at
+			// the server somehow. POSIX calls this a stale file handle, let's fake
+			// that error and treat the path as existing but corrupted.
+			klog.Warningf("Potential stale file handle detected: %s", path)
+			return true, syscall.ESTALE
+		}
+		return false, nil
+	} else if IsCorruptedMnt(err) {
+		return true, err
+	}
+	return false, err
+}
+
+// These variables are used solely by kernelHasMountinfoBug.
+var (
+	hasMountinfoBug       bool
+	checkMountinfoBugOnce sync.Once
+)
+
+// kernelHasMountinfoBug checks if the kernel bug that can lead to incomplete
+// mountinfo being read is fixed. It does so by checking the kernel version.
+//
+// The bug was fixed by the kernel commit 9f6c61f96f2d97 (since Linux 5.8).
+// Alas, there is no better way to check if the bug is fixed other than to
+// rely on the kernel version returned by uname.
+func kernelHasMountinfoBug() bool {
+	checkMountinfoBugOnce.Do(func() {
+		// Assume old kernel.
+		hasMountinfoBug = true
+
+		uname := unix.Utsname{}
+		err := unix.Uname(&uname)
+		if err != nil {
+			return
+		}
+
+		end := bytes.IndexByte(uname.Release[:], 0)
+		v := bytes.SplitN(uname.Release[:end], []byte{'.'}, 3)
+		if len(v) != 3 {
+			return
+		}
+		major, _ := strconv.Atoi(string(v[0]))
+		minor, _ := strconv.Atoi(string(v[1]))
+
+		if major > 5 || (major == 5 && minor >= 8) {
+			hasMountinfoBug = false
+		}
+	})
+
+	return hasMountinfoBug
+}
+
+func readMountInfo(path string) ([]byte, error) {
+	if kernelHasMountinfoBug() {
+		return utilio.ConsistentRead(path, maxListTries)
+	}
+
+	return os.ReadFile(path)
+}

--- a/vendor/k8s.io/mount-utils/mount_helper_windows.go
+++ b/vendor/k8s.io/mount-utils/mount_helper_windows.go
@@ -1,0 +1,111 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"k8s.io/klog/v2"
+)
+
+// following failure codes are from https://docs.microsoft.com/en-us/windows/desktop/debug/system-error-codes--1300-1699-
+// ERROR_BAD_NETPATH                 = 53
+// ERROR_NETWORK_BUSY                = 54
+// ERROR_UNEXP_NET_ERR               = 59
+// ERROR_NETNAME_DELETED             = 64
+// ERROR_NETWORK_ACCESS_DENIED       = 65
+// ERROR_BAD_DEV_TYPE                = 66
+// ERROR_BAD_NET_NAME                = 67
+// ERROR_SESSION_CREDENTIAL_CONFLICT = 1219
+// ERROR_LOGON_FAILURE               = 1326
+// WSAEHOSTDOWN                      = 10064
+var errorNoList = [...]int{53, 54, 59, 64, 65, 66, 67, 1219, 1326, 10064}
+
+// IsCorruptedMnt return true if err is about corrupted mount point
+func IsCorruptedMnt(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var underlyingError error
+	switch pe := err.(type) {
+	case nil:
+		return false
+	case *os.PathError:
+		underlyingError = pe.Err
+	case *os.LinkError:
+		underlyingError = pe.Err
+	case *os.SyscallError:
+		underlyingError = pe.Err
+	}
+
+	if ee, ok := underlyingError.(syscall.Errno); ok {
+		for _, errno := range errorNoList {
+			if int(ee) == errno {
+				klog.Warningf("IsCorruptedMnt failed with error: %v, error code: %v", err, errno)
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// NormalizeWindowsPath makes sure the given path is a valid path on Windows
+// systems by making sure all instances of `/` are replaced with `\\`, and the
+// path beings with `c:`
+func NormalizeWindowsPath(path string) string {
+	normalizedPath := strings.Replace(path, "/", "\\", -1)
+	if strings.HasPrefix(normalizedPath, "\\") {
+		normalizedPath = "c:" + normalizedPath
+	}
+	return normalizedPath
+}
+
+// ValidateDiskNumber : disk number should be a number in [0, 99]
+func ValidateDiskNumber(disk string) error {
+	if _, err := strconv.Atoi(disk); err != nil {
+		return fmt.Errorf("wrong disk number format: %q, err: %v", disk, err)
+	}
+	return nil
+}
+
+// isMountPointMatch determines if the mountpoint matches the dir
+func isMountPointMatch(mp MountPoint, dir string) bool {
+	return mp.Path == dir
+}
+
+// PathExists returns true if the specified path exists.
+// TODO: clean this up to use pkg/util/file/FileExists
+func PathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	} else if IsCorruptedMnt(err) {
+		return true, err
+	}
+	return false, err
+}

--- a/vendor/k8s.io/mount-utils/mount_linux.go
+++ b/vendor/k8s.io/mount-utils/mount_linux.go
@@ -1,0 +1,924 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/moby/sys/mountinfo"
+	"golang.org/x/sys/unix"
+
+	"k8s.io/klog/v2"
+	utilexec "k8s.io/utils/exec"
+)
+
+const (
+	// Number of fields per line in /proc/mounts as per the fstab man page.
+	expectedNumFieldsPerLine = 6
+	// Location of the mount file to use
+	procMountsPath = "/proc/mounts"
+	// Location of the mountinfo file
+	procMountInfoPath = "/proc/self/mountinfo"
+	// 'fsck' found errors and corrected them
+	fsckErrorsCorrected = 1
+	// 'fsck' found errors but exited without correcting them
+	fsckErrorsUncorrected = 4
+	// Error thrown by exec cmd.Run() when process spawned by cmd.Start() completes before cmd.Wait() is called (see - k/k issue #103753)
+	errNoChildProcesses = "wait: no child processes"
+	// Error returned by some `umount` implementations when the specified path is not a mount point
+	errNotMounted = "not mounted"
+)
+
+var (
+	// Error statx support since Linux 4.11, https://man7.org/linux/man-pages/man2/statx.2.html
+	errStatxNotSupport = errors.New("the statx syscall is not supported. At least Linux kernel 4.11 is needed")
+)
+
+// Mounter provides the default implementation of mount.Interface
+// for the linux platform.  This implementation assumes that the
+// kubelet is running in the host's root mount namespace.
+type Mounter struct {
+	mounterPath                string
+	withSystemd                *bool
+	trySystemd                 bool
+	withSafeNotMountedBehavior bool
+}
+
+var _ MounterForceUnmounter = &Mounter{}
+
+// New returns a mount.Interface for the current system.
+// It provides options to override the default mounter behavior.
+// mounterPath allows using an alternative to `/bin/mount` for mounting.
+func New(mounterPath string) Interface {
+	return &Mounter{
+		mounterPath:                mounterPath,
+		trySystemd:                 true,
+		withSafeNotMountedBehavior: detectSafeNotMountedBehavior(),
+	}
+}
+
+// NewWithoutSystemd returns a Linux specific mount.Interface for the current
+// system. It provides options to override the default mounter behavior.
+// mounterPath allows using an alternative to `/bin/mount` for mounting. Any
+// detection for systemd functionality is disabled with this Mounter.
+func NewWithoutSystemd(mounterPath string) Interface {
+	return &Mounter{
+		mounterPath:                mounterPath,
+		trySystemd:                 false,
+		withSafeNotMountedBehavior: detectSafeNotMountedBehavior(),
+	}
+}
+
+// hasSystemd validates that the withSystemd bool is set, if it is not,
+// detectSystemd will be called once for this Mounter instance.
+func (mounter *Mounter) hasSystemd() bool {
+	if !mounter.trySystemd {
+		mounter.withSystemd = &mounter.trySystemd
+	}
+
+	if mounter.withSystemd == nil {
+		withSystemd := detectSystemd()
+		mounter.withSystemd = &withSystemd
+	}
+
+	return *mounter.withSystemd
+}
+
+// Map unix.Statfs mount flags ro, nodev, noexec, nosuid, noatime, relatime,
+// nodiratime to mount option flag strings.
+func getBindMountOptions(path string, statfs func(path string, buf *unix.Statfs_t) (err error)) ([]string, error) {
+	var s unix.Statfs_t
+	var mountOpts []string
+	if err := statfs(path, &s); err != nil {
+		return nil, &os.PathError{Op: "statfs", Path: path, Err: err}
+	}
+	flagMapping := map[int]string{
+		unix.MS_RDONLY:     "ro",
+		unix.MS_NODEV:      "nodev",
+		unix.MS_NOEXEC:     "noexec",
+		unix.MS_NOSUID:     "nosuid",
+		unix.MS_NOATIME:    "noatime",
+		unix.MS_RELATIME:   "relatime",
+		unix.MS_NODIRATIME: "nodiratime",
+	}
+	for k, v := range flagMapping {
+		if int(s.Flags)&k == k {
+			mountOpts = append(mountOpts, v)
+		}
+	}
+	return mountOpts, nil
+}
+
+// Performs a bind mount with the specified options, and then remounts
+// the mount point with the same `nodev`, `nosuid`, `noexec`, `nosuid`, `noatime`,
+// `relatime`, `nodiratime` options as the original mount point.
+func (mounter *Mounter) bindMountSensitive(mounterPath string, mountCmd string, source string, target string, fstype string, bindOpts []string, bindRemountOpts []string, bindRemountOptsSensitive []string, mountFlags []string, systemdMountRequired bool) error {
+	err := mounter.doMount(mounterPath, mountCmd, source, target, fstype, bindOpts, bindRemountOptsSensitive, mountFlags, systemdMountRequired)
+	if err != nil {
+		return err
+	}
+	// Check if the source has ro, nodev, noexec, nosuid, noatime, relatime,
+	// nodiratime flag...
+	fixMountOpts, err := getBindMountOptions(source, unix.Statfs)
+	if err != nil {
+		return &os.PathError{Op: "statfs", Path: source, Err: err}
+	}
+	// ... and retry the mount with flags found above.
+	bindRemountOpts = append(bindRemountOpts, fixMountOpts...)
+	return mounter.doMount(mounterPath, mountCmd, source, target, fstype, bindRemountOpts, bindRemountOptsSensitive, mountFlags, systemdMountRequired)
+}
+
+// Mount mounts source to target as fstype with given options. 'source' and 'fstype' must
+// be an empty string in case it's not required, e.g. for remount, or for auto filesystem
+// type, where kernel handles fstype for you. The mount 'options' is a list of options,
+// currently come from mount(8), e.g. "ro", "remount", "bind", etc. If no more option is
+// required, call Mount with an empty string list or nil.
+func (mounter *Mounter) Mount(source string, target string, fstype string, options []string) error {
+	return mounter.MountSensitive(source, target, fstype, options, nil)
+}
+
+// MountSensitive is the same as Mount() but this method allows
+// sensitiveOptions to be passed in a separate parameter from the normal
+// mount options and ensures the sensitiveOptions are never logged. This
+// method should be used by callers that pass sensitive material (like
+// passwords) as mount options.
+func (mounter *Mounter) MountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+	// Path to mounter binary if containerized mounter is needed. Otherwise, it is set to empty.
+	// All Linux distros are expected to be shipped with a mount utility that a support bind mounts.
+	mounterPath := ""
+	bind, bindOpts, bindRemountOpts, bindRemountOptsSensitive := MakeBindOptsSensitive(options, sensitiveOptions)
+	if bind {
+		return mounter.bindMountSensitive(mounterPath, defaultMountCommand, source, target, fstype, bindOpts, bindRemountOpts, bindRemountOptsSensitive, nil /* mountFlags */, mounter.trySystemd)
+	}
+	// The list of filesystems that require containerized mounter on GCI image cluster
+	fsTypesNeedMounter := map[string]struct{}{
+		"nfs":       {},
+		"glusterfs": {},
+		"ceph":      {},
+		"cifs":      {},
+	}
+	if _, ok := fsTypesNeedMounter[fstype]; ok {
+		mounterPath = mounter.mounterPath
+	}
+	return mounter.doMount(mounterPath, defaultMountCommand, source, target, fstype, options, sensitiveOptions, nil /* mountFlags */, mounter.trySystemd)
+}
+
+// MountSensitiveWithoutSystemd is the same as MountSensitive() but disable using systemd mount.
+func (mounter *Mounter) MountSensitiveWithoutSystemd(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+	return mounter.MountSensitiveWithoutSystemdWithMountFlags(source, target, fstype, options, sensitiveOptions, nil /* mountFlags */)
+}
+
+// MountSensitiveWithoutSystemdWithMountFlags is the same as MountSensitiveWithoutSystemd with additional mount flags.
+func (mounter *Mounter) MountSensitiveWithoutSystemdWithMountFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
+	mounterPath := ""
+	bind, bindOpts, bindRemountOpts, bindRemountOptsSensitive := MakeBindOptsSensitive(options, sensitiveOptions)
+	if bind {
+		return mounter.bindMountSensitive(mounterPath, defaultMountCommand, source, target, fstype, bindOpts, bindRemountOpts, bindRemountOptsSensitive, mountFlags, false)
+	}
+	// The list of filesystems that require containerized mounter on GCI image cluster
+	fsTypesNeedMounter := map[string]struct{}{
+		"nfs":       {},
+		"glusterfs": {},
+		"ceph":      {},
+		"cifs":      {},
+	}
+	if _, ok := fsTypesNeedMounter[fstype]; ok {
+		mounterPath = mounter.mounterPath
+	}
+	return mounter.doMount(mounterPath, defaultMountCommand, source, target, fstype, options, sensitiveOptions, mountFlags, false)
+}
+
+// doMount runs the mount command. mounterPath is the path to mounter binary if containerized mounter is used.
+// sensitiveOptions is an extension of options except they will not be logged (because they may contain sensitive material)
+// systemdMountRequired is an extension of option to decide whether uses systemd mount.
+func (mounter *Mounter) doMount(mounterPath string, mountCmd string, source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string, systemdMountRequired bool) error {
+	mountArgs, mountArgsLogStr := MakeMountArgsSensitiveWithMountFlags(source, target, fstype, options, sensitiveOptions, mountFlags)
+	if len(mounterPath) > 0 {
+		mountArgs = append([]string{mountCmd}, mountArgs...)
+		mountArgsLogStr = mountCmd + " " + mountArgsLogStr
+		mountCmd = mounterPath
+	}
+
+	if systemdMountRequired && mounter.hasSystemd() {
+		// Try to run mount via systemd-run --scope. This will escape the
+		// service where kubelet runs and any fuse daemons will be started in a
+		// specific scope. kubelet service than can be restarted without killing
+		// these fuse daemons.
+		//
+		// Complete command line (when mounterPath is not used):
+		// systemd-run --description=... --scope -- mount -t <type> <what> <where>
+		//
+		// Expected flow:
+		// * systemd-run creates a transient scope (=~ cgroup) and executes its
+		//   argument (/bin/mount) there.
+		// * mount does its job, forks a fuse daemon if necessary and finishes.
+		//   (systemd-run --scope finishes at this point, returning mount's exit
+		//   code and stdout/stderr - thats one of --scope benefits).
+		// * systemd keeps the fuse daemon running in the scope (i.e. in its own
+		//   cgroup) until the fuse daemon dies (another --scope benefit).
+		//   Kubelet service can be restarted and the fuse daemon survives.
+		// * When the fuse daemon dies (e.g. during unmount) systemd removes the
+		//   scope automatically.
+		//
+		// systemd-mount is not used because it's too new for older distros
+		// (CentOS 7, Debian Jessie).
+		mountCmd, mountArgs, mountArgsLogStr = AddSystemdScopeSensitive("systemd-run", target, mountCmd, mountArgs, mountArgsLogStr)
+		// } else {
+		// No systemd-run on the host (or we failed to check it), assume kubelet
+		// does not run as a systemd service.
+		// No code here, mountCmd and mountArgs are already populated.
+	}
+
+	// Logging with sensitive mount options removed.
+	klog.V(4).Infof("Mounting cmd (%s) with arguments (%s)", mountCmd, mountArgsLogStr)
+	command := exec.Command(mountCmd, mountArgs...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		if err.Error() == errNoChildProcesses {
+			if command.ProcessState.Success() {
+				// We don't consider errNoChildProcesses an error if the process itself succeeded (see - k/k issue #103753).
+				return nil
+			}
+			// Rewrite err with the actual exit error of the process.
+			err = &exec.ExitError{ProcessState: command.ProcessState}
+		}
+		klog.Errorf("Mount failed: %v\nMounting command: %s\nMounting arguments: %s\nOutput: %s\n", err, mountCmd, mountArgsLogStr, string(output))
+		return fmt.Errorf("mount failed: %v\nMounting command: %s\nMounting arguments: %s\nOutput: %s",
+			err, mountCmd, mountArgsLogStr, string(output))
+	}
+	return err
+}
+
+// detectSystemd returns true if OS runs with systemd as init. When not sure
+// (permission errors, ...), it returns false.
+// There may be different ways how to detect systemd, this one makes sure that
+// systemd-runs (needed by Mount()) works.
+func detectSystemd() bool {
+	if _, err := exec.LookPath("systemd-run"); err != nil {
+		klog.V(2).Infof("Detected OS without systemd")
+		return false
+	}
+	// Try to run systemd-run --scope /bin/true, that should be enough
+	// to make sure that systemd is really running and not just installed,
+	// which happens when running in a container with a systemd-based image
+	// but with different pid 1.
+	cmd := exec.Command("systemd-run", "--description=Kubernetes systemd probe", "--scope", "true")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		klog.V(2).Infof("Cannot run systemd-run, assuming non-systemd OS")
+		klog.V(4).Infof("systemd-run output: %s, failed with: %v", string(output), err)
+		return false
+	}
+	klog.V(2).Infof("Detected OS with systemd")
+	return true
+}
+
+// detectSafeNotMountedBehavior returns true if the umount implementation replies "not mounted"
+// when the specified path is not mounted. When not sure (permission errors, ...), it returns false.
+// When possible, we will trust umount's message and avoid doing our own mount point checks.
+// More info: https://github.com/util-linux/util-linux/blob/v2.2/mount/umount.c#L179
+func detectSafeNotMountedBehavior() bool {
+	return detectSafeNotMountedBehaviorWithExec(utilexec.New())
+}
+
+// detectSafeNotMountedBehaviorWithExec is for testing with FakeExec.
+func detectSafeNotMountedBehaviorWithExec(exec utilexec.Interface) bool {
+	// create a temp dir and try to umount it
+	path, err := os.MkdirTemp("", "kubelet-detect-safe-umount")
+	if err != nil {
+		klog.V(4).Infof("Cannot create temp dir to detect safe 'not mounted' behavior: %v", err)
+		return false
+	}
+	defer os.RemoveAll(path)
+	cmd := exec.Command("umount", path)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(output), errNotMounted) {
+			klog.V(4).Infof("Detected umount with safe 'not mounted' behavior")
+			return true
+		}
+		klog.V(4).Infof("'umount %s' failed with: %v, output: %s", path, err, string(output))
+	}
+	klog.V(4).Infof("Detected umount with unsafe 'not mounted' behavior")
+	return false
+}
+
+// MakeMountArgs makes the arguments to the mount(8) command.
+// options MUST not contain sensitive material (like passwords).
+func MakeMountArgs(source, target, fstype string, options []string) (mountArgs []string) {
+	mountArgs, _ = MakeMountArgsSensitive(source, target, fstype, options, nil /* sensitiveOptions */)
+	return mountArgs
+}
+
+// MakeMountArgsSensitive makes the arguments to the mount(8) command.
+// sensitiveOptions is an extension of options except they will not be logged (because they may contain sensitive material)
+func MakeMountArgsSensitive(source, target, fstype string, options []string, sensitiveOptions []string) (mountArgs []string, mountArgsLogStr string) {
+	return MakeMountArgsSensitiveWithMountFlags(source, target, fstype, options, sensitiveOptions, nil /* mountFlags */)
+}
+
+// MakeMountArgsSensitiveWithMountFlags makes the arguments to the mount(8) command.
+// sensitiveOptions is an extension of options except they will not be logged (because they may contain sensitive material)
+// mountFlags are additional mount flags that are not related with the fstype
+// and mount options
+func MakeMountArgsSensitiveWithMountFlags(source, target, fstype string, options []string, sensitiveOptions []string, mountFlags []string) (mountArgs []string, mountArgsLogStr string) {
+	// Build mount command as follows:
+	//   mount [$mountFlags] [-t $fstype] [-o $options] [$source] $target
+	mountArgs = []string{}
+	mountArgsLogStr = ""
+
+	mountArgs = append(mountArgs, mountFlags...)
+	mountArgsLogStr += strings.Join(mountFlags, " ")
+
+	if len(fstype) > 0 {
+		mountArgs = append(mountArgs, "-t", fstype)
+		mountArgsLogStr += strings.Join(mountArgs, " ")
+	}
+	if len(options) > 0 || len(sensitiveOptions) > 0 {
+		combinedOptions := []string{}
+		combinedOptions = append(combinedOptions, options...)
+		combinedOptions = append(combinedOptions, sensitiveOptions...)
+		mountArgs = append(mountArgs, "-o", strings.Join(combinedOptions, ","))
+		// exclude sensitiveOptions from log string
+		mountArgsLogStr += " -o " + sanitizedOptionsForLogging(options, sensitiveOptions)
+	}
+	if len(source) > 0 {
+		mountArgs = append(mountArgs, source)
+		mountArgsLogStr += " " + source
+	}
+	mountArgs = append(mountArgs, target)
+	mountArgsLogStr += " " + target
+
+	return mountArgs, mountArgsLogStr
+}
+
+// AddSystemdScope adds "system-run --scope" to given command line
+// If args contains sensitive material, use AddSystemdScopeSensitive to construct
+// a safe to log string.
+func AddSystemdScope(systemdRunPath, mountName, command string, args []string) (string, []string) {
+	descriptionArg := fmt.Sprintf("--description=Kubernetes transient mount for %s", mountName)
+	systemdRunArgs := []string{descriptionArg, "--scope", "--", command}
+	return systemdRunPath, append(systemdRunArgs, args...)
+}
+
+// AddSystemdScopeSensitive adds "system-run --scope" to given command line
+// It also accepts takes a sanitized string containing mount arguments, mountArgsLogStr,
+// and returns the string appended to the systemd command for logging.
+func AddSystemdScopeSensitive(systemdRunPath, mountName, command string, args []string, mountArgsLogStr string) (string, []string, string) {
+	descriptionArg := fmt.Sprintf("--description=Kubernetes transient mount for %s", mountName)
+	systemdRunArgs := []string{descriptionArg, "--scope", "--", command}
+	return systemdRunPath, append(systemdRunArgs, args...), strings.Join(systemdRunArgs, " ") + " " + mountArgsLogStr
+}
+
+// Unmount unmounts the target.
+// If the mounter has safe "not mounted" behavior, no error will be returned when the target is not a mount point.
+func (mounter *Mounter) Unmount(target string) error {
+	klog.V(4).Infof("Unmounting %s", target)
+	command := exec.Command("umount", target)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return checkUmountError(target, command, output, err, mounter.withSafeNotMountedBehavior)
+	}
+	return nil
+}
+
+// UnmountWithForce unmounts given target but will retry unmounting with force option
+// after given timeout.
+func (mounter *Mounter) UnmountWithForce(target string, umountTimeout time.Duration) error {
+	err := tryUnmount(target, mounter.withSafeNotMountedBehavior, umountTimeout)
+	if err != nil {
+		if err == context.DeadlineExceeded {
+			klog.V(2).Infof("Timed out waiting for unmount of %s, trying with -f", target)
+			err = forceUmount(target, mounter.withSafeNotMountedBehavior)
+		}
+		return err
+	}
+	return nil
+}
+
+// List returns a list of all mounted filesystems.
+func (*Mounter) List() ([]MountPoint, error) {
+	return ListProcMounts(procMountsPath)
+}
+
+func statx(file string) (unix.Statx_t, error) {
+	var stat unix.Statx_t
+	if err := unix.Statx(unix.AT_FDCWD, file, unix.AT_STATX_DONT_SYNC, 0, &stat); err != nil {
+		if err == unix.ENOSYS {
+			return stat, errStatxNotSupport
+		}
+
+		return stat, err
+	}
+
+	return stat, nil
+}
+
+func (mounter *Mounter) isLikelyNotMountPointStat(file string) (bool, error) {
+	stat, err := os.Stat(file)
+	if err != nil {
+		return true, err
+	}
+	rootStat, err := os.Stat(filepath.Dir(strings.TrimSuffix(file, "/")))
+	if err != nil {
+		return true, err
+	}
+	// If the directory has a different device as parent, then it is a mountpoint.
+	if stat.Sys().(*syscall.Stat_t).Dev != rootStat.Sys().(*syscall.Stat_t).Dev {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (mounter *Mounter) isLikelyNotMountPointStatx(file string) (bool, error) {
+	var stat, rootStat unix.Statx_t
+	var err error
+
+	if stat, err = statx(file); err != nil {
+		return true, err
+	}
+
+	if stat.Attributes_mask != 0 {
+		if stat.Attributes_mask&unix.STATX_ATTR_MOUNT_ROOT != 0 {
+			if stat.Attributes&unix.STATX_ATTR_MOUNT_ROOT != 0 {
+				// file is a mountpoint
+				return false, nil
+			} else {
+				// no need to check rootStat if unix.STATX_ATTR_MOUNT_ROOT supported
+				return true, nil
+			}
+		}
+	}
+
+	root := filepath.Dir(strings.TrimSuffix(file, "/"))
+	if rootStat, err = statx(root); err != nil {
+		return true, err
+	}
+
+	return (stat.Dev_major == rootStat.Dev_major && stat.Dev_minor == rootStat.Dev_minor), nil
+}
+
+// IsLikelyNotMountPoint determines if a directory is not a mountpoint.
+// It is fast but not necessarily ALWAYS correct. If the path is in fact
+// a bind mount from one part of a mount to another it will not be detected.
+// It also can not distinguish between mountpoints and symbolic links.
+// mkdir /tmp/a /tmp/b; mount --bind /tmp/a /tmp/b; IsLikelyNotMountPoint("/tmp/b")
+// will return true. When in fact /tmp/b is a mount point. If this situation
+// is of interest to you, don't use this function...
+func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
+	notMountPoint, err := mounter.isLikelyNotMountPointStatx(file)
+	if errors.Is(err, errStatxNotSupport) {
+		// fall back to isLikelyNotMountPointStat
+		return mounter.isLikelyNotMountPointStat(file)
+	}
+
+	return notMountPoint, err
+}
+
+// CanSafelySkipMountPointCheck relies on the detected behavior of umount when given a target that is not a mount point.
+func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+	return mounter.withSafeNotMountedBehavior
+}
+
+// GetMountRefs finds all mount references to pathname, returns a
+// list of paths. Path could be a mountpoint or a normal
+// directory (for bind mount).
+func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
+	pathExists, pathErr := PathExists(pathname)
+	if !pathExists {
+		return []string{}, nil
+	} else if IsCorruptedMnt(pathErr) {
+		klog.Warningf("GetMountRefs found corrupted mount at %s, treating as unmounted path", pathname)
+		return []string{}, nil
+	} else if pathErr != nil {
+		return nil, fmt.Errorf("error checking path %s: %v", pathname, pathErr)
+	}
+	realpath, err := filepath.EvalSymlinks(pathname)
+	if err != nil {
+		return nil, err
+	}
+	return SearchMountPoints(realpath, procMountInfoPath)
+}
+
+// checkAndRepairFileSystem checks and repairs filesystems using command fsck.
+func (mounter *SafeFormatAndMount) checkAndRepairFilesystem(source string) error {
+	klog.V(4).Infof("Checking for issues with fsck on disk: %s", source)
+	args := []string{"-a", source}
+	out, err := mounter.Exec.Command("fsck", args...).CombinedOutput()
+	if err != nil {
+		ee, isExitError := err.(utilexec.ExitError)
+		switch {
+		case err == utilexec.ErrExecutableNotFound:
+			klog.Warningf("'fsck' not found on system; continuing mount without running 'fsck'.")
+		case isExitError && ee.ExitStatus() == fsckErrorsCorrected:
+			klog.Infof("Device %s has errors which were corrected by fsck.", source)
+		case isExitError && ee.ExitStatus() == fsckErrorsUncorrected:
+			return NewMountError(HasFilesystemErrors, "'fsck' found errors on device %s but could not correct them: %s", source, string(out))
+		case isExitError && ee.ExitStatus() > fsckErrorsUncorrected:
+			klog.Infof("`fsck` error %s", string(out))
+		default:
+			klog.Warningf("fsck on device %s failed with error %v, output: %v", source, err, string(out))
+		}
+	}
+	return nil
+}
+
+// formatAndMount uses unix utils to format and mount the given disk
+func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string, formatOptions []string) error {
+	readOnly := false
+	for _, option := range options {
+		if option == "ro" {
+			readOnly = true
+			break
+		}
+	}
+	if !readOnly {
+		// Check sensitiveOptions for ro
+		for _, option := range sensitiveOptions {
+			if option == "ro" {
+				readOnly = true
+				break
+			}
+		}
+	}
+
+	options = append(options, "defaults")
+	mountErrorValue := UnknownMountError
+
+	// Check if the disk is already formatted
+	existingFormat, err := mounter.GetDiskFormat(source)
+	if err != nil {
+		return NewMountError(GetDiskFormatFailed, "failed to get disk format of disk %s: %v", source, err)
+	}
+
+	// Use 'ext4' as the default
+	if len(fstype) == 0 {
+		fstype = "ext4"
+	}
+
+	if existingFormat == "" {
+		// Do not attempt to format the disk if mounting as readonly, return an error to reflect this.
+		if readOnly {
+			return NewMountError(UnformattedReadOnly, "cannot mount unformatted disk %s as we are manipulating it in read-only mode", source)
+		}
+
+		// Disk is unformatted so format it.
+		args := []string{source}
+		if fstype == "ext4" || fstype == "ext3" {
+			args = []string{
+				"-F",  // Force flag
+				"-m0", // Zero blocks reserved for super-user
+				source,
+			}
+		} else if fstype == "xfs" {
+			args = []string{
+				"-f", // force flag
+				source,
+			}
+		}
+		args = append(formatOptions, args...)
+
+		klog.Infof("Disk %q appears to be unformatted, attempting to format as type: %q with options: %v", source, fstype, args)
+
+		output, err := mounter.format(fstype, args)
+		if err != nil {
+			// Do not log sensitiveOptions only options
+			sensitiveOptionsLog := sanitizedOptionsForLogging(options, sensitiveOptions)
+			detailedErr := fmt.Sprintf("format of disk %q failed: type:(%q) target:(%q) options:(%q) errcode:(%v) output:(%v) ", source, fstype, target, sensitiveOptionsLog, err, string(output))
+			klog.Error(detailedErr)
+			return NewMountError(FormatFailed, "%s", detailedErr)
+		}
+
+		klog.Infof("Disk successfully formatted (mkfs): %s - %s %s", fstype, source, target)
+	} else {
+		if fstype != existingFormat {
+			// Verify that the disk is formatted with filesystem type we are expecting
+			mountErrorValue = FilesystemMismatch
+			klog.Warningf("Configured to mount disk %s as %s but current format is %s, things might break", source, fstype, existingFormat)
+		}
+
+		if !readOnly {
+			// Run check tools on the disk to fix repairable issues, only do this for formatted volumes requested as rw.
+			err := mounter.checkAndRepairFilesystem(source)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Mount the disk
+	klog.V(4).Infof("Attempting to mount disk %s in %s format at %s", source, fstype, target)
+	if err := mounter.MountSensitive(source, target, fstype, options, sensitiveOptions); err != nil {
+		return NewMountError(mountErrorValue, "%s", err.Error())
+	}
+
+	return nil
+}
+
+func (mounter *SafeFormatAndMount) format(fstype string, args []string) ([]byte, error) {
+	if mounter.formatSem != nil {
+		done := make(chan struct{})
+		defer close(done)
+
+		mounter.formatSem <- struct{}{}
+
+		go func() {
+			defer func() { <-mounter.formatSem }()
+
+			timeout := time.NewTimer(mounter.formatTimeout)
+			defer timeout.Stop()
+
+			select {
+			case <-done:
+			case <-timeout.C:
+			}
+		}()
+	}
+
+	return mounter.Exec.Command("mkfs."+fstype, args...).CombinedOutput()
+}
+
+func getDiskFormat(exec utilexec.Interface, disk string) (string, error) {
+	args := []string{"-p", "-s", "TYPE", "-s", "PTTYPE", "-o", "export", disk}
+	klog.V(4).Infof("Attempting to determine if disk %q is formatted using blkid with args: (%v)", disk, args)
+	dataOut, err := exec.Command("blkid", args...).CombinedOutput()
+	output := string(dataOut)
+	klog.V(4).Infof("Output: %q", output)
+
+	if err != nil {
+		if exit, ok := err.(utilexec.ExitError); ok {
+			if exit.ExitStatus() == 2 {
+				// Disk device is unformatted.
+				// For `blkid`, if the specified token (TYPE/PTTYPE, etc) was
+				// not found, or no (specified) devices could be identified, an
+				// exit code of 2 is returned.
+				return "", nil
+			}
+		}
+		klog.Errorf("Could not determine if disk %q is formatted (%v)", disk, err)
+		return "", err
+	}
+
+	var fstype, pttype string
+
+	lines := strings.Split(output, "\n")
+	for _, l := range lines {
+		if len(l) <= 0 {
+			// Ignore empty line.
+			continue
+		}
+		cs := strings.Split(l, "=")
+		if len(cs) != 2 {
+			return "", fmt.Errorf("blkid returns invalid output: %s", output)
+		}
+		// TYPE is filesystem type, and PTTYPE is partition table type, according
+		// to https://www.kernel.org/pub/linux/utils/util-linux/v2.21/libblkid-docs/.
+		if cs[0] == "TYPE" {
+			fstype = cs[1]
+		} else if cs[0] == "PTTYPE" {
+			pttype = cs[1]
+		}
+	}
+
+	if len(pttype) > 0 {
+		klog.V(4).Infof("Disk %s detected partition table type: %s", disk, pttype)
+		// Returns a special non-empty string as filesystem type, then kubelet
+		// will not format it.
+		return "unknown data, probably partitions", nil
+	}
+
+	return fstype, nil
+}
+
+// GetDiskFormat uses 'blkid' to see if the given disk is unformatted
+func (mounter *SafeFormatAndMount) GetDiskFormat(disk string) (string, error) {
+	return getDiskFormat(mounter.Exec, disk)
+}
+
+// ListProcMounts returns a list of all mounted filesystems.
+func ListProcMounts(mountFilePath string) ([]MountPoint, error) {
+	content, err := readMountInfo(mountFilePath)
+	if err != nil {
+		return nil, err
+	}
+	return parseProcMounts(content)
+}
+
+func parseProcMounts(content []byte) ([]MountPoint, error) {
+	out := []MountPoint{}
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		if line == "" {
+			// the last split() item is empty string following the last \n
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != expectedNumFieldsPerLine {
+			// Do not log line in case it contains sensitive Mount options
+			return nil, fmt.Errorf("wrong number of fields (expected %d, got %d)", expectedNumFieldsPerLine, len(fields))
+		}
+
+		mp := MountPoint{
+			Device: fields[0],
+			Path:   fields[1],
+			Type:   fields[2],
+			Opts:   strings.Split(fields[3], ","),
+		}
+
+		freq, err := strconv.Atoi(fields[4])
+		if err != nil {
+			return nil, err
+		}
+		mp.Freq = freq
+
+		pass, err := strconv.Atoi(fields[5])
+		if err != nil {
+			return nil, err
+		}
+		mp.Pass = pass
+
+		out = append(out, mp)
+	}
+	return out, nil
+}
+
+// SearchMountPoints finds all mount references to the source, returns a list of
+// mountpoints.
+// The source can be a mount point or a normal directory (bind mount). We
+// didn't support device because there is no use case by now.
+// Some filesystems may share a source name, e.g. tmpfs. And for bind mounting,
+// it's possible to mount a non-root path of a filesystem, so we need to use
+// root path and major:minor to represent mount source uniquely.
+func SearchMountPoints(hostSource, mountInfoPath string) ([]string, error) {
+	mis, err := ParseMountInfo(mountInfoPath)
+	if err != nil {
+		return nil, err
+	}
+
+	mountID := 0
+	rootPath := ""
+	major := -1
+	minor := -1
+
+	// Finding the underlying root path and major:minor if possible.
+	// We need search in backward order because it's possible for later mounts
+	// to overlap earlier mounts.
+	for i := len(mis) - 1; i >= 0; i-- {
+		if hostSource == mis[i].MountPoint || PathWithinBase(hostSource, mis[i].MountPoint) {
+			// If it's a mount point or path under a mount point.
+			mountID = mis[i].ID
+			rootPath = filepath.Join(mis[i].Root, strings.TrimPrefix(hostSource, mis[i].MountPoint))
+			major = mis[i].Major
+			minor = mis[i].Minor
+			break
+		}
+	}
+
+	if rootPath == "" || major == -1 || minor == -1 {
+		return nil, fmt.Errorf("failed to get root path and major:minor for %s", hostSource)
+	}
+
+	var refs []string
+	for i := range mis {
+		if mis[i].ID == mountID {
+			// Ignore mount entry for mount source itself.
+			continue
+		}
+		if mis[i].Root == rootPath && mis[i].Major == major && mis[i].Minor == minor {
+			refs = append(refs, mis[i].MountPoint)
+		}
+	}
+
+	return refs, nil
+}
+
+// IsMountPoint determines if a file is a mountpoint.
+// It first detects bind & any other mountpoints using
+// MountedFast function. If the MountedFast function returns
+// sure as true and err as nil, then a mountpoint is detected
+// successfully. When an error is returned by MountedFast, the
+// following is true:
+// 1. All errors are returned with IsMountPoint as false
+// except os.IsPermission.
+// 2. When os.IsPermission is returned by MountedFast, List()
+// is called to confirm if the given file is a mountpoint are not.
+//
+// os.ErrNotExist should always be returned if a file does not exist
+// as callers have in past relied on this error and not fallback.
+//
+// When MountedFast returns sure as false and err as nil (eg: in
+// case of bindmounts on kernel version 5.10- ); mounter.List()
+// endpoint is called to enumerate all the mountpoints and check if
+// it is mountpoint match or not.
+func (mounter *Mounter) IsMountPoint(file string) (bool, error) {
+	isMnt, sure, isMntErr := mountinfo.MountedFast(file)
+	if sure && isMntErr == nil {
+		return isMnt, nil
+	}
+	if isMntErr != nil {
+		if errors.Is(isMntErr, fs.ErrNotExist) {
+			return false, fs.ErrNotExist
+		}
+		// We were not allowed to do the simple stat() check, e.g. on NFS with
+		// root_squash. Fall back to /proc/mounts check below when
+		// fs.ErrPermission is returned.
+		if !errors.Is(isMntErr, fs.ErrPermission) {
+			return false, isMntErr
+		}
+	}
+	// Resolve any symlinks in file, kernel would do the same and use the resolved path in /proc/mounts.
+	resolvedFile, err := filepath.EvalSymlinks(file)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, fs.ErrNotExist
+		}
+		return false, err
+	}
+
+	// check all mountpoints since MountedFast is not sure.
+	// is not reliable for some mountpoint types.
+	mountPoints, mountPointsErr := mounter.List()
+	if mountPointsErr != nil {
+		return false, mountPointsErr
+	}
+	for _, mp := range mountPoints {
+		if isMountPointMatch(mp, resolvedFile) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// tryUnmount calls plain "umount" and waits for unmountTimeout for it to finish.
+func tryUnmount(target string, withSafeNotMountedBehavior bool, unmountTimeout time.Duration) error {
+	klog.V(4).Infof("Unmounting %s", target)
+	ctx, cancel := context.WithTimeout(context.Background(), unmountTimeout)
+	defer cancel()
+
+	command := exec.CommandContext(ctx, "umount", target)
+	output, err := command.CombinedOutput()
+
+	// CombinedOutput() does not return DeadlineExceeded, make sure it's
+	// propagated on timeout.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	if err != nil {
+		return checkUmountError(target, command, output, err, withSafeNotMountedBehavior)
+	}
+	return nil
+}
+
+func forceUmount(target string, withSafeNotMountedBehavior bool) error {
+	command := exec.Command("umount", "-f", target)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return checkUmountError(target, command, output, err, withSafeNotMountedBehavior)
+	}
+	return nil
+}
+
+// checkUmountError checks a result of umount command and determine a return value.
+func checkUmountError(target string, command *exec.Cmd, output []byte, err error, withSafeNotMountedBehavior bool) error {
+	if err.Error() == errNoChildProcesses {
+		if command.ProcessState.Success() {
+			// We don't consider errNoChildProcesses an error if the process itself succeeded (see - k/k issue #103753).
+			return nil
+		}
+		// Rewrite err with the actual exit error of the process.
+		err = &exec.ExitError{ProcessState: command.ProcessState}
+	}
+	if withSafeNotMountedBehavior && strings.Contains(string(output), errNotMounted) {
+		klog.V(4).Infof("ignoring 'not mounted' error for %s", target)
+		return nil
+	}
+	return fmt.Errorf("unmount failed: %v\nUnmounting arguments: %s\nOutput: %s", err, target, string(output))
+}

--- a/vendor/k8s.io/mount-utils/mount_unsupported.go
+++ b/vendor/k8s.io/mount-utils/mount_unsupported.go
@@ -1,0 +1,105 @@
+//go:build !linux && !windows
+// +build !linux,!windows
+
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"errors"
+)
+
+// Mounter implements mount.Interface for unsupported platforms
+type Mounter struct {
+	mounterPath string
+}
+
+var errUnsupported = errors.New("util/mount on this platform is not supported")
+
+// New returns a mount.Interface for the current system.
+// It provides options to override the default mounter behavior.
+// mounterPath allows using an alternative to `/bin/mount` for mounting.
+func New(mounterPath string) Interface {
+	return &Mounter{
+		mounterPath: mounterPath,
+	}
+}
+
+// Mount always returns an error on unsupported platforms
+func (mounter *Mounter) Mount(source string, target string, fstype string, options []string) error {
+	return errUnsupported
+}
+
+// MountSensitive always returns an error on unsupported platforms
+func (mounter *Mounter) MountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+	return errUnsupported
+}
+
+// MountSensitiveWithoutSystemd always returns an error on unsupported platforms
+func (mounter *Mounter) MountSensitiveWithoutSystemd(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+	return errUnsupported
+}
+
+// MountSensitiveWithoutSystemdWithMountFlags always returns an error on unsupported platforms
+func (mounter *Mounter) MountSensitiveWithoutSystemdWithMountFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
+	return errUnsupported
+}
+
+// Unmount always returns an error on unsupported platforms
+func (mounter *Mounter) Unmount(target string) error {
+	return errUnsupported
+}
+
+// List always returns an error on unsupported platforms
+func (mounter *Mounter) List() ([]MountPoint, error) {
+	return []MountPoint{}, errUnsupported
+}
+
+// IsLikelyNotMountPoint always returns an error on unsupported platforms
+func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
+	return true, errUnsupported
+}
+
+// CanSafelySkipMountPointCheck always returns false on unsupported platforms
+func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+	return false
+}
+
+// IsMountPoint determines if a directory is a mountpoint.
+// It always returns an error on unsupported platforms.
+func (mounter *Mounter) IsMountPoint(file string) (bool, error) {
+	return false, errUnsupported
+}
+
+// GetMountRefs always returns an error on unsupported platforms
+func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
+	return nil, errUnsupported
+}
+
+func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string, formatOptions []string) error {
+	return mounter.Interface.Mount(source, target, fstype, options)
+}
+
+func (mounter *SafeFormatAndMount) diskLooksUnformatted(disk string) (bool, error) {
+	return true, errUnsupported
+}
+
+// IsMountPoint determines if a directory is a mountpoint.
+// It always returns an error on unsupported platforms.
+func (mounter *SafeFormatAndMount) IsMountPoint(file string) (bool, error) {
+	return false, errUnsupported
+}

--- a/vendor/k8s.io/mount-utils/mount_windows.go
+++ b/vendor/k8s.io/mount-utils/mount_windows.go
@@ -1,0 +1,335 @@
+//go:build windows
+// +build windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"k8s.io/utils/keymutex"
+)
+
+const (
+	accessDenied string = "access is denied"
+)
+
+// Mounter provides the default implementation of mount.Interface
+// for the windows platform.  This implementation assumes that the
+// kubelet is running in the host's root mount namespace.
+type Mounter struct {
+	mounterPath string
+}
+
+// New returns a mount.Interface for the current system.
+// It provides options to override the default mounter behavior.
+// mounterPath allows using an alternative to `/bin/mount` for mounting.
+func New(mounterPath string) Interface {
+	return &Mounter{
+		mounterPath: mounterPath,
+	}
+}
+
+// acquire lock for smb mount
+var getSMBMountMutex = keymutex.NewHashed(0)
+
+// Mount : mounts source to target with given options.
+// currently only supports cifs(smb), bind mount(for disk)
+func (mounter *Mounter) Mount(source string, target string, fstype string, options []string) error {
+	return mounter.MountSensitive(source, target, fstype, options, nil /* sensitiveOptions */)
+}
+
+// MountSensitiveWithoutSystemd is the same as MountSensitive() but disable using ssytemd mount.
+// Windows not supported systemd mount, this function degrades to MountSensitive().
+func (mounter *Mounter) MountSensitiveWithoutSystemd(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+	return mounter.MountSensitive(source, target, fstype, options, sensitiveOptions /* sensitiveOptions */)
+}
+
+// MountSensitiveWithoutSystemdWithMountFlags is the same as MountSensitiveWithoutSystemd with additional mount flags
+// Windows not supported systemd mount, this function degrades to MountSensitive().
+func (mounter *Mounter) MountSensitiveWithoutSystemdWithMountFlags(source string, target string, fstype string, options []string, sensitiveOptions []string, mountFlags []string) error {
+	return mounter.MountSensitive(source, target, fstype, options, sensitiveOptions /* sensitiveOptions */)
+}
+
+// MountSensitive is the same as Mount() but this method allows
+// sensitiveOptions to be passed in a separate parameter from the normal
+// mount options and ensures the sensitiveOptions are never logged. This
+// method should be used by callers that pass sensitive material (like
+// passwords) as mount options.
+func (mounter *Mounter) MountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string) error {
+	target = NormalizeWindowsPath(target)
+	sanitizedOptionsForLogging := sanitizedOptionsForLogging(options, sensitiveOptions)
+
+	if source == "tmpfs" {
+		klog.V(3).Infof("mounting source (%q), target (%q), with options (%q)", source, target, sanitizedOptionsForLogging)
+		return os.MkdirAll(target, 0o755)
+	}
+
+	parentDir := filepath.Dir(target)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return err
+	}
+
+	klog.V(4).Infof("mount options(%q) source:%q, target:%q, fstype:%q, begin to mount",
+		sanitizedOptionsForLogging, source, target, fstype)
+	bindSource := source
+
+	if bind, _, _, _ := MakeBindOptsSensitive(options, sensitiveOptions); bind {
+		bindSource = NormalizeWindowsPath(source)
+	} else {
+		allOptions := []string{}
+		allOptions = append(allOptions, options...)
+		allOptions = append(allOptions, sensitiveOptions...)
+		if len(allOptions) < 2 {
+			return fmt.Errorf("mount options(%q) should have at least 2 options, current number:%d, source:%q, target:%q",
+				sanitizedOptionsForLogging, len(allOptions), source, target)
+		}
+
+		// currently only cifs mount is supported
+		if strings.ToLower(fstype) != "cifs" {
+			return fmt.Errorf("only cifs mount is supported now, fstype: %q, mounting source (%q), target (%q), with options (%q)", fstype, source, target, sanitizedOptionsForLogging)
+		}
+
+		// lock smb mount for the same source
+		getSMBMountMutex.LockKey(source)
+		defer getSMBMountMutex.UnlockKey(source)
+
+		username := allOptions[0]
+		password := allOptions[1]
+		if output, err := newSMBMapping(username, password, source); err != nil {
+			klog.Warningf("SMB Mapping(%s) returned with error(%v), output(%s)", source, err, string(output))
+			if isSMBMappingExist(source) {
+				valid, err := isValidPath(source)
+				if !valid {
+					if err == nil || isAccessDeniedError(err) {
+						klog.V(2).Infof("SMB Mapping(%s) already exists while it's not valid, return error: %v, now begin to remove and remount", source, err)
+						if output, err = removeSMBMapping(source); err != nil {
+							return fmt.Errorf("Remove-SmbGlobalMapping failed: %v, output: %q", err, output)
+						}
+						if output, err := newSMBMapping(username, password, source); err != nil {
+							return fmt.Errorf("New-SmbGlobalMapping(%s) failed: %v, output: %q", source, err, output)
+						}
+					}
+				} else {
+					klog.V(2).Infof("SMB Mapping(%s) already exists and is still valid, skip error(%v)", source, err)
+				}
+			} else {
+				return fmt.Errorf("New-SmbGlobalMapping(%s) failed: %v, output: %q", source, err, output)
+			}
+		}
+	}
+
+	// There is an issue in golang where EvalSymlinks fails on Windows when passed a
+	// UNC share root path without a trailing backslash.
+	// Ex: \\SERVER\share will fail to resolve but \\SERVER\share\ will resolve
+	// containerD on Windows calls EvalSymlinks so we'll add the backslash when making the symlink if it is missing.
+	// https://github.com/golang/go/pull/42096 fixes this issue in golang but a fix will not be available until
+	// golang v1.16
+	mklinkSource := bindSource
+	if !strings.HasSuffix(mklinkSource, "\\") {
+		mklinkSource = mklinkSource + "\\"
+	}
+
+	err := os.Symlink(mklinkSource, target)
+	if err != nil {
+		klog.Errorf("symlink failed: %v, source(%q) target(%q)", err, mklinkSource, target)
+		return err
+	}
+	klog.V(2).Infof("symlink source(%q) on target(%q) successfully", mklinkSource, target)
+
+	return nil
+}
+
+// do the SMB mount with username, password, remotepath
+// return (output, error)
+func newSMBMapping(username, password, remotepath string) (string, error) {
+	if username == "" || password == "" || remotepath == "" {
+		return "", fmt.Errorf("invalid parameter(username: %s, password: %s, remotepath: %s)", username, sensitiveOptionsRemoved, remotepath)
+	}
+
+	// use PowerShell Environment Variables to store user input string to prevent command line injection
+	// https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-5.1
+	cmdLine := `$PWord = ConvertTo-SecureString -String $Env:smbpassword -AsPlainText -Force` +
+		`;$Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $Env:smbuser, $PWord` +
+		`;New-SmbGlobalMapping -RemotePath $Env:smbremotepath -Credential $Credential -RequirePrivacy $true`
+	cmd := exec.Command("powershell", "/c", cmdLine)
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("smbuser=%s", username),
+		fmt.Sprintf("smbpassword=%s", password),
+		fmt.Sprintf("smbremotepath=%s", remotepath))
+
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+// check whether remotepath is already mounted
+func isSMBMappingExist(remotepath string) bool {
+	cmd := exec.Command("powershell", "/c", `Get-SmbGlobalMapping -RemotePath $Env:smbremotepath`)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("smbremotepath=%s", remotepath))
+	_, err := cmd.CombinedOutput()
+	return err == nil
+}
+
+// check whether remotepath is valid
+// return (true, nil) if remotepath is valid
+func isValidPath(remotepath string) (bool, error) {
+	cmd := exec.Command("powershell", "/c", `Test-Path $Env:remotepath`)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("remotepath=%s", remotepath))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("returned output: %s, error: %v", string(output), err)
+	}
+
+	return strings.HasPrefix(strings.ToLower(string(output)), "true"), nil
+}
+
+func isAccessDeniedError(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), accessDenied)
+}
+
+// remove SMB mapping
+func removeSMBMapping(remotepath string) (string, error) {
+	cmd := exec.Command("powershell", "/c", `Remove-SmbGlobalMapping -RemotePath $Env:smbremotepath -Force`)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("smbremotepath=%s", remotepath))
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+// Unmount unmounts the target.
+func (mounter *Mounter) Unmount(target string) error {
+	klog.V(4).Infof("Unmount target (%q)", target)
+	target = NormalizeWindowsPath(target)
+
+	if err := os.Remove(target); err != nil {
+		klog.Errorf("removing directory %s failed: %v", target, err)
+		return err
+	}
+	return nil
+}
+
+// List returns a list of all mounted filesystems. todo
+func (mounter *Mounter) List() ([]MountPoint, error) {
+	return []MountPoint{}, nil
+}
+
+// IsLikelyNotMountPoint determines if a directory is not a mountpoint.
+func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
+	stat, err := os.Lstat(file)
+	if err != nil {
+		return true, err
+	}
+
+	if stat.Mode()&os.ModeSymlink != 0 {
+		return false, err
+	}
+	// go1.23 behavior change: https://github.com/golang/go/issues/63703#issuecomment-2535941458
+	if stat.Mode()&os.ModeIrregular != 0 {
+		return false, err
+	}
+	return true, nil
+}
+
+// CanSafelySkipMountPointCheck always returns false on Windows
+func (mounter *Mounter) CanSafelySkipMountPointCheck() bool {
+	return false
+}
+
+// IsMountPoint: determines if a directory is a mountpoint.
+func (mounter *Mounter) IsMountPoint(file string) (bool, error) {
+	isNotMnt, err := mounter.IsLikelyNotMountPoint(file)
+	if err != nil {
+		return false, err
+	}
+	return !isNotMnt, nil
+}
+
+// GetMountRefs : empty implementation here since there is no place to query all mount points on Windows
+func (mounter *Mounter) GetMountRefs(pathname string) ([]string, error) {
+	windowsPath := NormalizeWindowsPath(pathname)
+	pathExists, pathErr := PathExists(windowsPath)
+	if !pathExists {
+		return []string{}, nil
+	} else if IsCorruptedMnt(pathErr) {
+		klog.Warningf("GetMountRefs found corrupted mount at %s, treating as unmounted path", windowsPath)
+		return []string{}, nil
+	} else if pathErr != nil {
+		return nil, fmt.Errorf("error checking path %s: %v", windowsPath, pathErr)
+	}
+	return []string{pathname}, nil
+}
+
+func (mounter *SafeFormatAndMount) formatAndMountSensitive(source string, target string, fstype string, options []string, sensitiveOptions []string, formatOptions []string) error {
+	// Try to mount the disk
+	klog.V(4).Infof("Attempting to formatAndMount disk: %s %s %s", fstype, source, target)
+
+	if err := ValidateDiskNumber(source); err != nil {
+		klog.Errorf("diskMount: formatAndMount failed, err: %v", err)
+		return err
+	}
+
+	if len(fstype) == 0 {
+		// Use 'NTFS' as the default
+		fstype = "NTFS"
+	}
+
+	if len(formatOptions) > 0 {
+		return fmt.Errorf("diskMount: formatOptions are not supported on Windows")
+	}
+
+	cmdString := "Get-Disk -Number $env:source | Where partitionstyle -eq 'raw' | Initialize-Disk -PartitionStyle GPT -PassThru" +
+		" | New-Partition -UseMaximumSize | Format-Volume -FileSystem $env:fstype -Confirm:$false"
+	cmd := mounter.Exec.Command("powershell", "/c", cmdString)
+	env := append(os.Environ(),
+		fmt.Sprintf("source=%s", source),
+		fmt.Sprintf("fstype=%s", fstype),
+	)
+	cmd.SetEnv(env)
+	klog.V(8).Infof("Executing command: %q", cmdString)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("diskMount: format disk failed, error: %v, output: %q", err, string(output))
+	}
+	klog.V(4).Infof("diskMount: Disk successfully formatted, disk: %q, fstype: %q", source, fstype)
+
+	volumeIds, err := ListVolumesOnDisk(source)
+	if err != nil {
+		return err
+	}
+	driverPath := volumeIds[0]
+	return mounter.MountSensitive(driverPath, target, fstype, options, sensitiveOptions)
+}
+
+// ListVolumesOnDisk - returns back list of volumes(volumeIDs) in the disk (requested in diskID).
+func ListVolumesOnDisk(diskID string) (volumeIDs []string, err error) {
+	// If a Disk has multiple volumes, Get-Volume may not return items in the same order.
+	cmd := exec.Command("powershell", "/c", "(Get-Disk -DeviceId $env:diskID | Get-Partition | Get-Volume | Sort-Object -Property UniqueId).UniqueId")
+	cmd.Env = append(os.Environ(), fmt.Sprintf("diskID=%s", diskID))
+	klog.V(8).Infof("Executing command: %q", cmd.String())
+	output, err := cmd.CombinedOutput()
+	klog.V(4).Infof("ListVolumesOnDisk id from %s: %s", diskID, string(output))
+	if err != nil {
+		return []string{}, fmt.Errorf("error list volumes on disk. cmd: %s, output: %s, error: %v", cmd, string(output), err)
+	}
+
+	volumeIds := strings.Split(strings.TrimSpace(string(output)), "\r\n")
+	return volumeIds, nil
+}

--- a/vendor/k8s.io/mount-utils/resizefs_linux.go
+++ b/vendor/k8s.io/mount-utils/resizefs_linux.go
@@ -1,0 +1,228 @@
+//go:build linux
+// +build linux
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog/v2"
+	utilexec "k8s.io/utils/exec"
+)
+
+const (
+	blockDev = "blockdev"
+)
+
+// ResizeFs Provides support for resizing file systems
+type ResizeFs struct {
+	exec utilexec.Interface
+}
+
+// NewResizeFs returns new instance of resizer
+func NewResizeFs(exec utilexec.Interface) *ResizeFs {
+	return &ResizeFs{exec: exec}
+}
+
+// Resize perform resize of file system
+func (resizefs *ResizeFs) Resize(devicePath string, deviceMountPath string) (bool, error) {
+	format, err := getDiskFormat(resizefs.exec, devicePath)
+	if err != nil {
+		formatErr := fmt.Errorf("ResizeFS.Resize - error checking format for device %s: %v", devicePath, err)
+		return false, formatErr
+	}
+
+	// If disk has no format, there is no need to resize the disk because mkfs.*
+	// by default will use whole disk anyways.
+	if format == "" {
+		return false, nil
+	}
+
+	klog.V(3).Infof("ResizeFS.Resize - Expanding mounted volume %s", devicePath)
+	switch format {
+	case "ext3", "ext4":
+		return resizefs.extResize(devicePath)
+	case "xfs":
+		return resizefs.xfsResize(deviceMountPath)
+	case "btrfs":
+		return resizefs.btrfsResize(deviceMountPath)
+	}
+	return false, fmt.Errorf("ResizeFS.Resize - resize of format %s is not supported for device %s mounted at %s", format, devicePath, deviceMountPath)
+}
+
+func (resizefs *ResizeFs) extResize(devicePath string) (bool, error) {
+	output, err := resizefs.exec.Command("resize2fs", devicePath).CombinedOutput()
+	if err == nil {
+		klog.V(2).Infof("Device %s resized successfully", devicePath)
+		return true, nil
+	}
+
+	resizeError := fmt.Errorf("resize of device %s failed: %v. resize2fs output: %s", devicePath, err, string(output))
+	return false, resizeError
+}
+
+func (resizefs *ResizeFs) xfsResize(deviceMountPath string) (bool, error) {
+	args := []string{"-d", deviceMountPath}
+	output, err := resizefs.exec.Command("xfs_growfs", args...).CombinedOutput()
+
+	if err == nil {
+		klog.V(2).Infof("Device %s resized successfully", deviceMountPath)
+		return true, nil
+	}
+
+	resizeError := fmt.Errorf("resize of device %s failed: %v. xfs_growfs output: %s", deviceMountPath, err, string(output))
+	return false, resizeError
+}
+
+func (resizefs *ResizeFs) btrfsResize(deviceMountPath string) (bool, error) {
+	args := []string{"filesystem", "resize", "max", deviceMountPath}
+	output, err := resizefs.exec.Command("btrfs", args...).CombinedOutput()
+
+	if err == nil {
+		klog.V(2).Infof("Device %s resized successfully", deviceMountPath)
+		return true, nil
+	}
+
+	resizeError := fmt.Errorf("resize of device %s failed: %v. btrfs output: %s", deviceMountPath, err, string(output))
+	return false, resizeError
+}
+
+func (resizefs *ResizeFs) NeedResize(devicePath string, deviceMountPath string) (bool, error) {
+	// Do nothing if device is mounted as readonly
+	readonly, err := resizefs.getDeviceRO(devicePath)
+	if err != nil {
+		return false, err
+	}
+
+	if readonly {
+		klog.V(3).Infof("ResizeFs.needResize - no resize possible since filesystem %s is readonly", devicePath)
+		return false, nil
+	}
+
+	format, err := getDiskFormat(resizefs.exec, devicePath)
+	if err != nil {
+		formatErr := fmt.Errorf("ResizeFS.Resize - error checking format for device %s: %v", devicePath, err)
+		return false, formatErr
+	}
+
+	// If disk has no format, there is no need to resize the disk because mkfs.*
+	// by default will use whole disk anyways.
+	if format == "" {
+		return false, nil
+	}
+
+	switch format {
+	case "ext3", "ext4", "xfs":
+		// For ext3/ext4/xfs, recommendation received from linux filesystem folks is to let
+		// resize2fs/xfs_growfs do the check for us. So we will not do any check here.
+		return true, nil
+	case "btrfs":
+		deviceSize, err := resizefs.getDeviceSize(devicePath)
+		if err != nil {
+			return false, err
+		}
+		blockSize, fsSize, err := resizefs.getBtrfsSize(devicePath)
+		klog.V(5).Infof("Btrfs size: filesystem size=%d, block size=%d, err=%v", fsSize, blockSize, err)
+		if err != nil {
+			return false, err
+		}
+		if deviceSize <= fsSize+blockSize {
+			return false, nil
+		}
+		return true, nil
+	default:
+		return false, fmt.Errorf("could not parse fs info of given filesystem format: %s. Supported fs types are: xfs, ext3, ext4", format)
+	}
+}
+
+func (resizefs *ResizeFs) getDeviceSize(devicePath string) (uint64, error) {
+	output, err := resizefs.exec.Command(blockDev, "--getsize64", devicePath).CombinedOutput()
+	outStr := strings.TrimSpace(string(output))
+	if err != nil {
+		return 0, fmt.Errorf("failed to read size of device %s: %s: %s", devicePath, err, outStr)
+	}
+	size, err := strconv.ParseUint(outStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse size of device %s %s: %s", devicePath, outStr, err)
+	}
+	return size, nil
+}
+
+func (resizefs *ResizeFs) getBtrfsSize(devicePath string) (uint64, uint64, error) {
+	output, err := resizefs.exec.Command("btrfs", "inspect-internal", "dump-super", "-f", devicePath).CombinedOutput()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to read size of filesystem on %s: %s: %s", devicePath, err, string(output))
+	}
+
+	blockSize, totalBytes, _ := resizefs.parseBtrfsInfoOutput(string(output), "sectorsize", "total_bytes")
+
+	if blockSize == 0 {
+		return 0, 0, fmt.Errorf("could not find block size of device %s", devicePath)
+	}
+	if totalBytes == 0 {
+		return 0, 0, fmt.Errorf("could not find total size of device %s", devicePath)
+	}
+	return blockSize, totalBytes, nil
+}
+
+func (resizefs *ResizeFs) parseBtrfsInfoOutput(cmdOutput string, blockSizeKey string, totalBytesKey string) (uint64, uint64, error) {
+	lines := strings.Split(cmdOutput, "\n")
+	var blockSize, blockCount uint64
+	var err error
+
+	for _, line := range lines {
+		tokens := strings.Fields(line)
+		if len(tokens) != 2 {
+			continue
+		}
+		key, value := strings.ToLower(strings.TrimSpace(tokens[0])), strings.ToLower(strings.TrimSpace(tokens[1]))
+
+		if key == blockSizeKey {
+			blockSize, err = strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return 0, 0, fmt.Errorf("failed to parse block size %s: %s", value, err)
+			}
+		}
+		if key == totalBytesKey {
+			blockCount, err = strconv.ParseUint(value, 10, 64)
+			if err != nil {
+				return 0, 0, fmt.Errorf("failed to parse total size %s: %s", value, err)
+			}
+		}
+	}
+	return blockSize, blockCount, err
+}
+
+func (resizefs *ResizeFs) getDeviceRO(devicePath string) (bool, error) {
+	output, err := resizefs.exec.Command(blockDev, "--getro", devicePath).CombinedOutput()
+	outStr := strings.TrimSpace(string(output))
+	if err != nil {
+		return false, fmt.Errorf("failed to get readonly bit from device %s: %w: %s", devicePath, err, outStr)
+	}
+	switch outStr {
+	case "0":
+		return false, nil
+	case "1":
+		return true, nil
+	default:
+		return false, fmt.Errorf("failed readonly device check. Expected 1 or 0, got '%s'", outStr)
+	}
+}

--- a/vendor/k8s.io/mount-utils/resizefs_unsupported.go
+++ b/vendor/k8s.io/mount-utils/resizefs_unsupported.go
@@ -1,0 +1,46 @@
+//go:build !linux
+// +build !linux
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"fmt"
+
+	utilexec "k8s.io/utils/exec"
+)
+
+// ResizeFs Provides support for resizing file systems
+type ResizeFs struct {
+	exec utilexec.Interface
+}
+
+// NewResizeFs returns new instance of resizer
+func NewResizeFs(exec utilexec.Interface) *ResizeFs {
+	return &ResizeFs{exec: exec}
+}
+
+// Resize perform resize of file system
+func (resizefs *ResizeFs) Resize(devicePath string, deviceMountPath string) (bool, error) {
+	return false, fmt.Errorf("Resize is not supported for this build")
+}
+
+// NeedResize check whether mounted volume needs resize
+func (resizefs *ResizeFs) NeedResize(devicePath string, deviceMountPath string) (bool, error) {
+	return false, fmt.Errorf("NeedResize is not supported for this build")
+}

--- a/vendor/k8s.io/utils/exec/README.md
+++ b/vendor/k8s.io/utils/exec/README.md
@@ -1,0 +1,5 @@
+# Exec
+
+This package provides an interface for `os/exec`. It makes it easier to mock
+and replace in tests, especially with the [FakeExec](testing/fake_exec.go)
+struct.

--- a/vendor/k8s.io/utils/exec/doc.go
+++ b/vendor/k8s.io/utils/exec/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package exec provides an injectable interface and implementations for running commands.
+package exec // import "k8s.io/utils/exec"

--- a/vendor/k8s.io/utils/exec/exec.go
+++ b/vendor/k8s.io/utils/exec/exec.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"context"
+	"io"
+	"io/fs"
+	osexec "os/exec"
+	"syscall"
+	"time"
+)
+
+// ErrExecutableNotFound is returned if the executable is not found.
+var ErrExecutableNotFound = osexec.ErrNotFound
+
+// Interface is an interface that presents a subset of the os/exec API. Use this
+// when you want to inject fakeable/mockable exec behavior.
+type Interface interface {
+	// Command returns a Cmd instance which can be used to run a single command.
+	// This follows the pattern of package os/exec.
+	Command(cmd string, args ...string) Cmd
+
+	// CommandContext returns a Cmd instance which can be used to run a single command.
+	//
+	// The provided context is used to kill the process if the context becomes done
+	// before the command completes on its own. For example, a timeout can be set in
+	// the context.
+	CommandContext(ctx context.Context, cmd string, args ...string) Cmd
+
+	// LookPath wraps os/exec.LookPath
+	LookPath(file string) (string, error)
+}
+
+// Cmd is an interface that presents an API that is very similar to Cmd from os/exec.
+// As more functionality is needed, this can grow. Since Cmd is a struct, we will have
+// to replace fields with get/set method pairs.
+type Cmd interface {
+	// Run runs the command to the completion.
+	Run() error
+	// CombinedOutput runs the command and returns its combined standard output
+	// and standard error. This follows the pattern of package os/exec.
+	CombinedOutput() ([]byte, error)
+	// Output runs the command and returns standard output, but not standard err
+	Output() ([]byte, error)
+	SetDir(dir string)
+	SetStdin(in io.Reader)
+	SetStdout(out io.Writer)
+	SetStderr(out io.Writer)
+	SetEnv(env []string)
+
+	// StdoutPipe and StderrPipe for getting the process' Stdout and Stderr as
+	// Readers
+	StdoutPipe() (io.ReadCloser, error)
+	StderrPipe() (io.ReadCloser, error)
+
+	// Start and Wait are for running a process non-blocking
+	Start() error
+	Wait() error
+
+	// Stops the command by sending SIGTERM. It is not guaranteed the
+	// process will stop before this function returns. If the process is not
+	// responding, an internal timer function will send a SIGKILL to force
+	// terminate after 10 seconds.
+	Stop()
+}
+
+// ExitError is an interface that presents an API similar to os.ProcessState, which is
+// what ExitError from os/exec is. This is designed to make testing a bit easier and
+// probably loses some of the cross-platform properties of the underlying library.
+type ExitError interface {
+	String() string
+	Error() string
+	Exited() bool
+	ExitStatus() int
+}
+
+// Implements Interface in terms of really exec()ing.
+type executor struct{}
+
+// New returns a new Interface which will os/exec to run commands.
+func New() Interface {
+	return &executor{}
+}
+
+// Command is part of the Interface interface.
+func (executor *executor) Command(cmd string, args ...string) Cmd {
+	return (*cmdWrapper)(maskErrDotCmd(osexec.Command(cmd, args...)))
+}
+
+// CommandContext is part of the Interface interface.
+func (executor *executor) CommandContext(ctx context.Context, cmd string, args ...string) Cmd {
+	return (*cmdWrapper)(maskErrDotCmd(osexec.CommandContext(ctx, cmd, args...)))
+}
+
+// LookPath is part of the Interface interface
+func (executor *executor) LookPath(file string) (string, error) {
+	path, err := osexec.LookPath(file)
+	return path, handleError(maskErrDot(err))
+}
+
+// Wraps exec.Cmd so we can capture errors.
+type cmdWrapper osexec.Cmd
+
+var _ Cmd = &cmdWrapper{}
+
+func (cmd *cmdWrapper) SetDir(dir string) {
+	cmd.Dir = dir
+}
+
+func (cmd *cmdWrapper) SetStdin(in io.Reader) {
+	cmd.Stdin = in
+}
+
+func (cmd *cmdWrapper) SetStdout(out io.Writer) {
+	cmd.Stdout = out
+}
+
+func (cmd *cmdWrapper) SetStderr(out io.Writer) {
+	cmd.Stderr = out
+}
+
+func (cmd *cmdWrapper) SetEnv(env []string) {
+	cmd.Env = env
+}
+
+func (cmd *cmdWrapper) StdoutPipe() (io.ReadCloser, error) {
+	r, err := (*osexec.Cmd)(cmd).StdoutPipe()
+	return r, handleError(err)
+}
+
+func (cmd *cmdWrapper) StderrPipe() (io.ReadCloser, error) {
+	r, err := (*osexec.Cmd)(cmd).StderrPipe()
+	return r, handleError(err)
+}
+
+func (cmd *cmdWrapper) Start() error {
+	err := (*osexec.Cmd)(cmd).Start()
+	return handleError(err)
+}
+
+func (cmd *cmdWrapper) Wait() error {
+	err := (*osexec.Cmd)(cmd).Wait()
+	return handleError(err)
+}
+
+// Run is part of the Cmd interface.
+func (cmd *cmdWrapper) Run() error {
+	err := (*osexec.Cmd)(cmd).Run()
+	return handleError(err)
+}
+
+// CombinedOutput is part of the Cmd interface.
+func (cmd *cmdWrapper) CombinedOutput() ([]byte, error) {
+	out, err := (*osexec.Cmd)(cmd).CombinedOutput()
+	return out, handleError(err)
+}
+
+func (cmd *cmdWrapper) Output() ([]byte, error) {
+	out, err := (*osexec.Cmd)(cmd).Output()
+	return out, handleError(err)
+}
+
+// Stop is part of the Cmd interface.
+func (cmd *cmdWrapper) Stop() {
+	c := (*osexec.Cmd)(cmd)
+
+	if c.Process == nil {
+		return
+	}
+
+	c.Process.Signal(syscall.SIGTERM)
+
+	time.AfterFunc(10*time.Second, func() {
+		if !c.ProcessState.Exited() {
+			c.Process.Signal(syscall.SIGKILL)
+		}
+	})
+}
+
+func handleError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch e := err.(type) {
+	case *osexec.ExitError:
+		return &ExitErrorWrapper{e}
+	case *fs.PathError:
+		return ErrExecutableNotFound
+	case *osexec.Error:
+		if e.Err == osexec.ErrNotFound {
+			return ErrExecutableNotFound
+		}
+	}
+
+	return err
+}
+
+// ExitErrorWrapper is an implementation of ExitError in terms of os/exec ExitError.
+// Note: standard exec.ExitError is type *os.ProcessState, which already implements Exited().
+type ExitErrorWrapper struct {
+	*osexec.ExitError
+}
+
+var _ ExitError = &ExitErrorWrapper{}
+
+// ExitStatus is part of the ExitError interface.
+func (eew ExitErrorWrapper) ExitStatus() int {
+	ws, ok := eew.Sys().(syscall.WaitStatus)
+	if !ok {
+		panic("can't call ExitStatus() on a non-WaitStatus exitErrorWrapper")
+	}
+	return ws.ExitStatus()
+}
+
+// CodeExitError is an implementation of ExitError consisting of an error object
+// and an exit code (the upper bits of os.exec.ExitStatus).
+type CodeExitError struct {
+	Err  error
+	Code int
+}
+
+var _ ExitError = CodeExitError{}
+
+func (e CodeExitError) Error() string {
+	return e.Err.Error()
+}
+
+func (e CodeExitError) String() string {
+	return e.Err.Error()
+}
+
+// Exited is to check if the process has finished
+func (e CodeExitError) Exited() bool {
+	return true
+}
+
+// ExitStatus is for checking the error code
+func (e CodeExitError) ExitStatus() int {
+	return e.Code
+}

--- a/vendor/k8s.io/utils/exec/fixup_go118.go
+++ b/vendor/k8s.io/utils/exec/fixup_go118.go
@@ -1,0 +1,32 @@
+//go:build !go1.19
+// +build !go1.19
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	osexec "os/exec"
+)
+
+func maskErrDotCmd(cmd *osexec.Cmd) *osexec.Cmd {
+	return cmd
+}
+
+func maskErrDot(err error) error {
+	return err
+}

--- a/vendor/k8s.io/utils/exec/fixup_go119.go
+++ b/vendor/k8s.io/utils/exec/fixup_go119.go
@@ -1,0 +1,40 @@
+//go:build go1.19
+// +build go1.19
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"errors"
+	osexec "os/exec"
+)
+
+// maskErrDotCmd reverts the behavior of osexec.Cmd to what it was before go1.19
+// specifically set the Err field to nil (LookPath returns a new error when the file
+// is resolved to the current directory.
+func maskErrDotCmd(cmd *osexec.Cmd) *osexec.Cmd {
+	cmd.Err = maskErrDot(cmd.Err)
+	return cmd
+}
+
+func maskErrDot(err error) error {
+	if err != nil && errors.Is(err, osexec.ErrDot) {
+		return nil
+	}
+	return err
+}

--- a/vendor/k8s.io/utils/io/README.md
+++ b/vendor/k8s.io/utils/io/README.md
@@ -1,0 +1,4 @@
+# IO
+
+This package provides interfaces for working with file IO. Currently it
+provides functionality for consistently reading a file.

--- a/vendor/k8s.io/utils/io/read.go
+++ b/vendor/k8s.io/utils/io/read.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+// ErrLimitReached means that the read limit is reached.
+var ErrLimitReached = errors.New("the read limit is reached")
+
+// ConsistentRead repeatedly reads a file until it gets the same content twice.
+// This is useful when reading files in /proc that are larger than page size
+// and kernel may modify them between individual read() syscalls.
+// It returns InconsistentReadError when it cannot get a consistent read in
+// given nr. of attempts. Caller should retry, kernel is probably under heavy
+// mount/unmount load.
+func ConsistentRead(filename string, attempts int) ([]byte, error) {
+	return consistentReadSync(filename, attempts, nil)
+}
+
+// consistentReadSync is the main functionality of ConsistentRead but
+// introduces a sync callback that can be used by the tests to mutate the file
+// from which the test data is being read
+func consistentReadSync(filename string, attempts int, sync func(int)) ([]byte, error) {
+	oldContent, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < attempts; i++ {
+		if sync != nil {
+			sync(i)
+		}
+		newContent, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return nil, err
+		}
+		if bytes.Compare(oldContent, newContent) == 0 {
+			return newContent, nil
+		}
+		// Files are different, continue reading
+		oldContent = newContent
+	}
+	return nil, InconsistentReadError{filename, attempts}
+}
+
+// InconsistentReadError is returned from ConsistentRead when it cannot get
+// a consistent read in given nr. of attempts. Caller should retry, kernel is
+// probably under heavy mount/unmount load.
+type InconsistentReadError struct {
+	filename string
+	attempts int
+}
+
+func (i InconsistentReadError) Error() string {
+	return fmt.Sprintf("could not get consistent content of %s after %d attempts", i.filename, i.attempts)
+}
+
+var _ error = InconsistentReadError{}
+
+func IsInconsistentReadError(err error) bool {
+	if _, ok := err.(InconsistentReadError); ok {
+		return true
+	}
+	return false
+}
+
+// ReadAtMost reads up to `limit` bytes from `r`, and reports an error
+// when `limit` bytes are read.
+func ReadAtMost(r io.Reader, limit int64) ([]byte, error) {
+	limitedReader := &io.LimitedReader{R: r, N: limit}
+	data, err := ioutil.ReadAll(limitedReader)
+	if err != nil {
+		return data, err
+	}
+	if limitedReader.N <= 0 {
+		return data, ErrLimitReached
+	}
+	return data, nil
+}

--- a/vendor/k8s.io/utils/keymutex/hashed.go
+++ b/vendor/k8s.io/utils/keymutex/hashed.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keymutex
+
+import (
+	"hash/fnv"
+	"runtime"
+	"sync"
+)
+
+// NewHashed returns a new instance of KeyMutex which hashes arbitrary keys to
+// a fixed set of locks. `n` specifies number of locks, if n <= 0, we use
+// number of cpus.
+// Note that because it uses fixed set of locks, different keys may share same
+// lock, so it's possible to wait on same lock.
+func NewHashed(n int) KeyMutex {
+	if n <= 0 {
+		n = runtime.NumCPU()
+	}
+	return &hashedKeyMutex{
+		mutexes: make([]sync.Mutex, n),
+	}
+}
+
+type hashedKeyMutex struct {
+	mutexes []sync.Mutex
+}
+
+// Acquires a lock associated with the specified ID.
+func (km *hashedKeyMutex) LockKey(id string) {
+	km.mutexes[km.hash(id)%uint32(len(km.mutexes))].Lock()
+}
+
+// Releases the lock associated with the specified ID.
+func (km *hashedKeyMutex) UnlockKey(id string) error {
+	km.mutexes[km.hash(id)%uint32(len(km.mutexes))].Unlock()
+	return nil
+}
+
+func (km *hashedKeyMutex) hash(id string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(id))
+	return h.Sum32()
+}

--- a/vendor/k8s.io/utils/keymutex/keymutex.go
+++ b/vendor/k8s.io/utils/keymutex/keymutex.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keymutex
+
+// KeyMutex is a thread-safe interface for acquiring locks on arbitrary strings.
+type KeyMutex interface {
+	// Acquires a lock associated with the specified ID, creates the lock if one doesn't already exist.
+	LockKey(id string)
+
+	// Releases the lock associated with the specified ID.
+	// Returns an error if the specified ID doesn't exist.
+	UnlockKey(id string) error
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -152,6 +152,9 @@ github.com/kubernetes-csi/csi-lib-utils/standardflags
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
+# github.com/moby/sys/mountinfo v0.7.2
+## explicit; go 1.17
+github.com/moby/sys/mountinfo
 # github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 ## explicit
 github.com/modern-go/concurrent
@@ -1087,12 +1090,18 @@ k8s.io/kube-openapi/pkg/validation/errors
 k8s.io/kube-openapi/pkg/validation/spec
 k8s.io/kube-openapi/pkg/validation/strfmt
 k8s.io/kube-openapi/pkg/validation/strfmt/bson
+# k8s.io/mount-utils v0.33.2
+## explicit; go 1.24.0
+k8s.io/mount-utils
 # k8s.io/utils v0.0.0-20241210054802-24370beab758
 ## explicit; go 1.18
 k8s.io/utils/buffer
 k8s.io/utils/clock
+k8s.io/utils/exec
 k8s.io/utils/internal/third_party/forked/golang/golang-lru
 k8s.io/utils/internal/third_party/forked/golang/net
+k8s.io/utils/io
+k8s.io/utils/keymutex
 k8s.io/utils/lru
 k8s.io/utils/net
 k8s.io/utils/path


### PR DESCRIPTION
_**Note: this PR is a work in progress, posted for early comments**_

The Volume Condition Reporter uses the Container Storage Interface
Specification's `NodeGetVolumeStats` operation to detect
if a PersistentVolume has an _abnormal_ condition. CSI drivers can return the
condition of a volume in the `NodeVolumeStatsResponse` message.

The Volume Condition Reporter is disabled by default. Enabling the
`--enable-volume-condition` for the CSI-Addons sidecar starts the Volume
Condition Reporter.
