### PR TITLE
add support for agnostic storage vendor in VGR

### DIFF
--- a/PendingReleaseNotes.md
+++ b/PendingReleaseNotes.md
@@ -8,6 +8,9 @@
   using a ConfigMap key `schedule-precedence`. The default is `pvc` which reads the
   annotations in order of PVC > NS > SC. It can be set to `storageclass` to respect only
   the annotations found on the Storage Classes.
+- Allow VolumeGroupReplication to be managed by a storage vendor specific implementation
+  of the controller by specifying `external` as `true` in the VGR's `spec`. The default is
+  `false`, which means VolumeGroupReplication will be reconciled by the csi-addons controller.
 
 ## NOTE
 

--- a/api/replication.storage/v1alpha1/volumegroupreplication_types.go
+++ b/api/replication.storage/v1alpha1/volumegroupreplication_types.go
@@ -34,7 +34,7 @@ type VolumeGroupReplicationSpec struct {
 
 	// volumeReplicationClassName is the volumeReplicationClass name for the VolumeReplication object
 	// created for this volumeGroupReplication
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="volumeReplicationClassName is immutable"
 	VolumeReplicationClassName string `json:"volumeReplicationClassName"`
 
@@ -64,6 +64,12 @@ type VolumeGroupReplicationSpec struct {
 	// ReplicationState is "secondary"
 	// +kubebuilder:default:=false
 	AutoResync bool `json:"autoResync"`
+
+	// External represents if VolumeGroupReplication should be reconciled by the csi-addons controller
+	// or an external controller managed by the storage vendor.
+	// +kubebuilder:default:=false
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="source is immutable"
+	External bool `json:"external,omitempty"`
 }
 
 // VolumeGroupReplicationSource specifies the source for the the volumeGroupReplication

--- a/config/crd/bases/replication.storage.openshift.io_volumegroupreplications.yaml
+++ b/config/crd/bases/replication.storage.openshift.io_volumegroupreplications.yaml
@@ -46,6 +46,15 @@ spec:
                   AutoResync represents the group to be auto resynced when
                   ReplicationState is "secondary"
                 type: boolean
+              external:
+                default: false
+                description: |-
+                  External represents if VolumeGroupReplication should be reconciled by the csi-addons controller
+                  or an external controller managed by the storage vendor.
+                type: boolean
+                x-kubernetes-validations:
+                - message: source is immutable
+                  rule: self == oldSelf
               replicationState:
                 description: |-
                   ReplicationState represents the replication operation to be performed on the group.
@@ -152,7 +161,6 @@ spec:
             - replicationState
             - source
             - volumeGroupReplicationClassName
-            - volumeReplicationClassName
             type: object
           status:
             description: VolumeGroupReplicationStatus defines the observed state of

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -1596,6 +1596,15 @@ spec:
                   AutoResync represents the group to be auto resynced when
                   ReplicationState is "secondary"
                 type: boolean
+              external:
+                default: false
+                description: |-
+                  External represents if VolumeGroupReplication should be reconciled by the csi-addons controller
+                  or an external controller managed by the storage vendor.
+                type: boolean
+                x-kubernetes-validations:
+                - message: source is immutable
+                  rule: self == oldSelf
               replicationState:
                 description: |-
                   ReplicationState represents the replication operation to be performed on the group.
@@ -1702,7 +1711,6 @@ spec:
             - replicationState
             - source
             - volumeGroupReplicationClassName
-            - volumeReplicationClassName
             type: object
           status:
             description: VolumeGroupReplicationStatus defines the observed state of

--- a/docs/volumegroupreplication.md
+++ b/docs/volumegroupreplication.md
@@ -20,6 +20,9 @@ VolumeGroupReplication is a namespaced resource that contains references to stor
 
 - `selector` is a label selector to filter the pvcs that are to be included in the group replication
 
+`external` represents if the VolumeGroupReplication should be reconciled by the csi-addons controller
+or an external controller managed by the storage vendor.
+
 ```yaml
 apiVersion: replication.storage.openshift.io/v1alpha1
 kind: VolumeGroupReplication


### PR DESCRIPTION
add a new field named `External` which when set to `true` means the VGR won't be reconciled by csi-addons controller and instead it should be managed by the storage vendor specific controller.

Also, make VolumeReplicationClassName optional in VGR's spec such that external vendors are not tied up to VR specific implementation.