### PR TITLE
ci: wait up to 5 minutes for the controller pod to become ready

### DIFF
--- a/.github/workflows/kind-deploy.yaml
+++ b/.github/workflows/kind-deploy.yaml
@@ -49,6 +49,7 @@ jobs:
           wait pods
           -l app.kubernetes.io/name=csi-addons
           --for=condition=Ready=True
+          --timeout=5m
 
       - name: Log the status of the failed controller pod
         if: ${{ failure() }}


### PR DESCRIPTION
The Kind deploy GitHub Workflow fails on occasion, most likely that
happens due to a (too) short defails timeout. Setting the timeout to 5
minutes should make the job more stable.