### PR TITLE
config: add terminationMessagePolicy to csi-addons

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,6 +50,7 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
+          terminationMessagePolicy: FallbackToLogsOnError
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/controller/setup-controller.yaml
+++ b/deploy/controller/setup-controller.yaml
@@ -87,6 +87,7 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+        terminationMessagePolicy: FallbackToLogsOnError
       securityContext:
         runAsNonRoot: true
       serviceAccountName: csi-addons-controller-manager


### PR DESCRIPTION
In Kubernetes, termination messages allow containers to communicate the reason for termination, which might be useful for debugging.

#### By Default:
Unless explicitly configured, Kubernetes defaults to the following:
```
terminationMessagePath: /dev/termination-log
terminationMessagePolicy: File
```
This indicates that if a container exits with an error and the `/dev/termination-log` file is empty, the termination message in the Pod status will be blank.

#### By setting `terminationMessagePolicy` to `FallbackToLogsOnError`:
If `/dev/termination-log` is empty and the container exits with an error, Kubernetes will use the last few lines of the container’s logs as the termination message, thus providing information when the termination log file does not have any. 