### PR TITLE
Fixups for volume condition reporter

### DIFF
--- a/sidecar/internal/volume-condition/reporter.go
+++ b/sidecar/internal/volume-condition/reporter.go
@@ -188,7 +188,7 @@ func (cvr *volumeConditionReporter) recordVolumeCondition(ctx context.Context, v
 	for _, recorder := range cvr.recorders {
 		err = recorder.record(ctx, pv, vc)
 		if err != nil {
-			klog.Warningf(
+			klog.Errorf(
 				"%T failed to record volume condition for persistent volume %q: %v",
 				recorder,
 				pv.Name,

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -164,7 +164,7 @@ func main() {
 				case volumeConditionPVCEventRecorder:
 					recorderOptions = append(recorderOptions, condition.WithEventRecorder())
 				default:
-					klog.Infof("condition recorder %q is unknown, skipping", vcr)
+					klog.Fatalf("condition recorder %q is unknown", vcr)
 				}
 			}
 

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -41,6 +41,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
+var (
+	// available recorders for the --volume-condition-recorders flag
+	volumeConditionLogRecorder      = "log"
+	volumeConditionPVCEventRecorder = "pvcEvent"
+
+	defaultVolumeConditionRecorders = strings.Join([]string{
+		volumeConditionLogRecorder,
+		volumeConditionPVCEventRecorder,
+	}, ",")
+)
+
 func main() {
 	var (
 		defaultTimeout     = time.Minute * 3
@@ -67,7 +78,7 @@ func main() {
 		// volume condition reporting
 		enableVolumeCondition    = flag.Bool("enable-volume-condition", false, "Enable reporting of the volume condition")
 		volumeConditionInterval  = flag.Duration("volume-condition-interval", 1*time.Minute, "Interval between volume condition checks")
-		volumeConditionRecorders = flag.String("volume-condition-recorders", "log,pvcEvent", "location(s) to report volume condition to")
+		volumeConditionRecorders = flag.String("volume-condition-recorders", defaultVolumeConditionRecorders, "location(s) to report volume condition to")
 	)
 	klog.InitFlags(nil)
 
@@ -148,9 +159,9 @@ func main() {
 			recorderOptions := make([]condition.RecorderOption, 0)
 			for _, vcr := range strings.Split(*volumeConditionRecorders, ",") {
 				switch vcr {
-				case "log":
+				case volumeConditionLogRecorder:
 					recorderOptions = append(recorderOptions, condition.WithLogRecorder())
-				case "pvcEvent":
+				case volumeConditionPVCEventRecorder:
 					recorderOptions = append(recorderOptions, condition.WithEventRecorder())
 				default:
 					klog.Infof("condition recorder %q is unknown, skipping", vcr)


### PR DESCRIPTION
Follow-up on several comments that were made in #831 for improving:

- fail when passing an unknown recorder
- log an error when recording a condition fails
- use constants for flag values for recorders
