### PR TITLE
ci: wait for the controller pod creation before checking status

### DIFF
--- a/.github/workflows/kind-deploy.yaml
+++ b/.github/workflows/kind-deploy.yaml
@@ -42,6 +42,15 @@ jobs:
       - name: Deploy the controller and CRDs
         run: make deploy TAG=${{ env.TAG }}
 
+      - name: Wait for controller pod creation
+        run: >
+          kubectl
+          -n csi-addons-system
+          wait pods
+          -l app.kubernetes.io/name=csi-addons
+          --for=create
+          --timeout=5m
+
       - name: Wait for running controller pod
         run: >
           kubectl


### PR DESCRIPTION
Sometimes the CI job is running quickly, and the `kubectl wait` for the controller pod to become ready fails with

    error: no matching resources found

This can happen when the pod does not exist yet. There is a special `kubectl wait --for=create -l ...` that waits for the pod(s) to be created. After creation, it is possible to wait for the pod(s) to be Ready.

See-also: kubernetes/kubectl#1675