### PR TITLE
remove replicating condition when state is secondary

### DIFF
--- a/internal/controller/replication.storage/status.go
+++ b/internal/controller/replication.storage/status.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
@@ -317,4 +318,11 @@ func findCondition(existingConditions []metav1.Condition, conditionType string) 
 	}
 
 	return nil
+}
+
+// removes the given condition from Conditions slice.
+func removeCondition(conditions *[]metav1.Condition, conditionType string) []metav1.Condition {
+	return slices.DeleteFunc(*conditions, func(condition metav1.Condition) bool {
+		return condition.Type == conditionType
+	})
 }

--- a/internal/controller/replication.storage/volumereplication_controller.go
+++ b/internal/controller/replication.storage/volumereplication_controller.go
@@ -410,6 +410,9 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if requeueForResync {
 		logger.Info("volume is not ready to use, requeuing for resync")
+		// Remove replicating condition if it exists for secondary state
+		updatedConditions := removeCondition(&vr.instance.Status.Conditions, replicationv1alpha1.ConditionReplicating)
+		vr.instance.Status.Conditions = updatedConditions
 
 		err = r.updateReplicationStatus(instance, logger, GetCurrentReplicationState(instance.Status.State), "volume is degraded")
 		if err != nil {
@@ -474,6 +477,9 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	if instance.Spec.ReplicationState == replicationv1alpha1.Secondary {
 		instance.Status.LastSyncTime = nil
+		// Remove replicating condition if it exists for secondary state
+		updatedConditions := removeCondition(&vr.instance.Status.Conditions, replicationv1alpha1.ConditionReplicating)
+		vr.instance.Status.Conditions = updatedConditions
 	}
 	err = r.updateReplicationStatus(instance, logger, GetReplicationState(instance.Spec.ReplicationState), msg)
 	if err != nil {


### PR DESCRIPTION
When a VR/VGR is demoted to secondary, we don't call the `VolumeInfo` on the volume/group anymore, so the older conditions are not updated and will show stale data. We should instead remove replicating condition from VR/VGR status when the image/group is demoted to secondary state.
