### PR TITLE
fix: crds shortnames and printcolumns

### DIFF
--- a/api/replication.storage/v1alpha1/volumegroupreplication_types.go
+++ b/api/replication.storage/v1alpha1/volumegroupreplication_types.go
@@ -90,9 +90,14 @@ type VolumeGroupReplicationStatus struct {
 	PersistentVolumeClaimsRefList []corev1.LocalObjectReference `json:"persistentVolumeClaimsRefList,omitempty"`
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=".spec.volumeGroupReplicationClassName",name=VolumeGroupReplicationClass,type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.volumeGroupReplicationContentName",name=VolumeGroupReplicationContent,type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.replicationState",name=desiredState,type=string
+// +kubebuilder:printcolumn:JSONPath=".status.state",name=currentState,type=string
+// +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
+// +kubebuilder:resource:shortName=vgr
 // VolumeGroupReplication is the Schema for the volumegroupreplications API
 type VolumeGroupReplication struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/replication.storage/v1alpha1/volumegroupreplicationclass_types.go
+++ b/api/replication.storage/v1alpha1/volumegroupreplicationclass_types.go
@@ -40,9 +40,11 @@ type VolumeGroupReplicationClassSpec struct {
 type VolumeGroupReplicationClassStatus struct {
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster,shortName=vgrc
+// +kubebuilder:printcolumn:JSONPath=".spec.provisioner",name=provisioner,type=string
+// +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
 
 // VolumeGroupReplicationClass is the Schema for the volumegroupreplicationclasses API
 type VolumeGroupReplicationClass struct {

--- a/api/replication.storage/v1alpha1/volumegroupreplicationcontent_types.go
+++ b/api/replication.storage/v1alpha1/volumegroupreplicationcontent_types.go
@@ -88,7 +88,10 @@ type VolumeGroupReplicationContentStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,shortName=vgrcontent
+// +kubebuilder:printcolumn:JSONPath=".spec.volumeGroupReplicationClassName",name=VolumeGroupReplicationClass,type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.volumeGroupReplicationRef.name",name=VolumeGroupReplication,type=string
+// +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
 
 // VolumeGroupReplicationContent is the Schema for the volumegroupreplicationcontents API
 type VolumeGroupReplicationContent struct {

--- a/api/replication.storage/v1alpha1/volumereplication_types.go
+++ b/api/replication.storage/v1alpha1/volumereplication_types.go
@@ -173,7 +173,8 @@ type VolumeReplicationStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
 // +kubebuilder:printcolumn:JSONPath=".spec.volumeReplicationClass",name=volumeReplicationClass,type=string
-// +kubebuilder:printcolumn:JSONPath=".spec.dataSource.name",name=pvcName,type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.dataSource.kind",name=SourceKind,type=string
+// +kubebuilder:printcolumn:JSONPath=".spec.dataSource.name",name=SourceName,type=string
 // +kubebuilder:printcolumn:JSONPath=".spec.replicationState",name=desiredState,type=string
 // +kubebuilder:printcolumn:JSONPath=".status.state",name=currentState,type=string
 // +kubebuilder:resource:shortName=vr

--- a/api/replication.storage/v1alpha1/volumereplicationclass_types.go
+++ b/api/replication.storage/v1alpha1/volumereplicationclass_types.go
@@ -43,6 +43,7 @@ type VolumeReplicationClassStatus struct{}
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=vrc
 // +kubebuilder:printcolumn:JSONPath=".spec.provisioner",name=provisioner,type=string
+// +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name=Age,type=date
 
 // VolumeReplicationClass is the Schema for the volumereplicationclasses API.
 type VolumeReplicationClass struct {

--- a/config/crd/bases/replication.storage.openshift.io_volumegroupreplicationclasses.yaml
+++ b/config/crd/bases/replication.storage.openshift.io_volumegroupreplicationclasses.yaml
@@ -11,10 +11,19 @@ spec:
     kind: VolumeGroupReplicationClass
     listKind: VolumeGroupReplicationClassList
     plural: volumegroupreplicationclasses
+    shortNames:
+    - vgrc
     singular: volumegroupreplicationclass
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provisioner
+      name: provisioner
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupReplicationClass is the Schema for the volumegroupreplicationclasses

--- a/config/crd/bases/replication.storage.openshift.io_volumegroupreplicationcontents.yaml
+++ b/config/crd/bases/replication.storage.openshift.io_volumegroupreplicationcontents.yaml
@@ -11,10 +11,22 @@ spec:
     kind: VolumeGroupReplicationContent
     listKind: VolumeGroupReplicationContentList
     plural: volumegroupreplicationcontents
+    shortNames:
+    - vgrcontent
     singular: volumegroupreplicationcontent
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.volumeGroupReplicationClassName
+      name: VolumeGroupReplicationClass
+      type: string
+    - jsonPath: .spec.volumeGroupReplicationRef.name
+      name: VolumeGroupReplication
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupReplicationContent is the Schema for the volumegroupreplicationcontents

--- a/config/crd/bases/replication.storage.openshift.io_volumegroupreplications.yaml
+++ b/config/crd/bases/replication.storage.openshift.io_volumegroupreplications.yaml
@@ -11,10 +11,28 @@ spec:
     kind: VolumeGroupReplication
     listKind: VolumeGroupReplicationList
     plural: volumegroupreplications
+    shortNames:
+    - vgr
     singular: volumegroupreplication
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.volumeGroupReplicationClassName
+      name: VolumeGroupReplicationClass
+      type: string
+    - jsonPath: .spec.volumeGroupReplicationContentName
+      name: VolumeGroupReplicationContent
+      type: string
+    - jsonPath: .spec.replicationState
+      name: desiredState
+      type: string
+    - jsonPath: .status.state
+      name: currentState
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupReplication is the Schema for the volumegroupreplications

--- a/config/crd/bases/replication.storage.openshift.io_volumereplicationclasses.yaml
+++ b/config/crd/bases/replication.storage.openshift.io_volumereplicationclasses.yaml
@@ -20,6 +20,9 @@ spec:
     - jsonPath: .spec.provisioner
       name: provisioner
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml
+++ b/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml
@@ -23,8 +23,11 @@ spec:
     - jsonPath: .spec.volumeReplicationClass
       name: volumeReplicationClass
       type: string
+    - jsonPath: .spec.dataSource.kind
+      name: SourceKind
+      type: string
     - jsonPath: .spec.dataSource.name
-      name: pvcName
+      name: SourceName
       type: string
     - jsonPath: .spec.replicationState
       name: desiredState

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -1305,10 +1305,19 @@ spec:
     kind: VolumeGroupReplicationClass
     listKind: VolumeGroupReplicationClassList
     plural: volumegroupreplicationclasses
+    shortNames:
+    - vgrc
     singular: volumegroupreplicationclass
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provisioner
+      name: provisioner
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupReplicationClass is the Schema for the volumegroupreplicationclasses
@@ -1381,10 +1390,22 @@ spec:
     kind: VolumeGroupReplicationContent
     listKind: VolumeGroupReplicationContentList
     plural: volumegroupreplicationcontents
+    shortNames:
+    - vgrcontent
     singular: volumegroupreplicationcontent
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.volumeGroupReplicationClassName
+      name: VolumeGroupReplicationClass
+      type: string
+    - jsonPath: .spec.volumeGroupReplicationRef.name
+      name: VolumeGroupReplication
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupReplicationContent is the Schema for the volumegroupreplicationcontents
@@ -1561,10 +1582,28 @@ spec:
     kind: VolumeGroupReplication
     listKind: VolumeGroupReplicationList
     plural: volumegroupreplications
+    shortNames:
+    - vgr
     singular: volumegroupreplication
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.volumeGroupReplicationClassName
+      name: VolumeGroupReplicationClass
+      type: string
+    - jsonPath: .spec.volumeGroupReplicationContentName
+      name: VolumeGroupReplicationContent
+      type: string
+    - jsonPath: .spec.replicationState
+      name: desiredState
+      type: string
+    - jsonPath: .status.state
+      name: currentState
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupReplication is the Schema for the volumegroupreplications

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -1846,6 +1846,9 @@ spec:
     - jsonPath: .spec.provisioner
       name: provisioner
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -1933,8 +1936,11 @@ spec:
     - jsonPath: .spec.volumeReplicationClass
       name: volumeReplicationClass
       type: string
+    - jsonPath: .spec.dataSource.kind
+      name: SourceKind
+      type: string
     - jsonPath: .spec.dataSource.name
-      name: pvcName
+      name: SourceName
       type: string
     - jsonPath: .spec.replicationState
       name: desiredState


### PR DESCRIPTION
## Describe PR changes - 

```
VolumeReplication now supports VolumeGroupReplication as a data source.
However, running 'kubectl get volumereplication' still displays a PVCNAME
column, which becomes misleading when the data source is a
VolumeGroupReplication.

This commit removes the PVCNAME column and introduces two new columns:
SOURCEKIND and SOURCENAME, which accurately reflect the source
information.

Also, adds additional column 'Age' for VolumeReplicationClass.
```

```
Adds shortNames for VolumeGroup related CRDs as below:
- VolumeGroupReplication: vgr
- VolumeGroupReplicationContent: vgrcontent
- VolumeGroupReplicatonClass: vgrc

Also, add additional printColumns to VolumeGroup CRDs as below:
- VolumeGroupReplication: className, contentName, desiredState, currentState, age
- VolumeGroupReplictionContent: clasName, replicationName, age
- VolumeGroupReplicationClass: provisioner, age
```


Output:
```
$ k get vrc
NAME         PROVISIONER                  AGE
vrc-sample   rook-ceph.rbd.csi.ceph.com   3d

$ k get vgrc
NAME          PROVISIONER                  AGE
vgrc-sample   rook-ceph.rbd.csi.ceph.com   2d23h

$ k get vr
NAME                       AGE   VOLUMEREPLICATIONCLASS          SOURCEKIND              SOURCENAME   DESIREDSTATE   CURRENTSTATE
volumereplication-sample   2s    volumereplicationclass-sample   PersistentVolumeClaim   rbd-pvc      primary        Unknown

$ k get vgr
NAME   VOLUMEGROUPREPLICATIONCLASS   VOLUMEGROUPREPLICATIONCONTENT                     DESIREDSTATE   CURRENTSTATE   AGE
vg     vgrc-sample                   vgrcontent-58e7b933-e3b6-4f2e-8df2-737be58a725b   primary        Unknown        3s

$ k get vgrcontent
NAME                                              VOLUMEGROUPREPLICATIONCLASS   VOLUMEGROUPREPLICATION   AGE
vgrcontent-58e7b933-e3b6-4f2e-8df2-737be58a725b   vgrc-sample                   vg                       10s

$ k get vr
NAME                                      AGE   VOLUMEREPLICATIONCLASS   SOURCEKIND               SOURCENAME   DESIREDSTATE   CURRENTSTATE
vr-58e7b933-e3b6-4f2e-8df2-737be58a725b   13s   vrc-sample               VolumeGroupReplication   vg           primary        Unknown
```