### PR TITLE
Fix job deletion loop

### DIFF
--- a/internal/controller/csiaddons/encryptionkeyrotationcronjob_controller.go
+++ b/internal/controller/csiaddons/encryptionkeyrotationcronjob_controller.go
@@ -64,6 +64,12 @@ func (r *EncryptionKeyRotationCronJobReconciler) Reconcile(ctx context.Context, 
 		return ctrl.Result{}, err
 	}
 
+	// Check if resource is being deleted
+	if !krcJob.DeletionTimestamp.IsZero() {
+		logger.Info("EncryptionKeyRotationCronJob is being deleted, exiting reconcile", "namespace", krcJob.Namespace, "name", krcJob.Name)
+		return ctrl.Result{}, nil
+	}
+
 	// Set default values for the optionals
 	if krcJob.Spec.FailedJobsHistoryLimit == nil {
 		*krcJob.Spec.FailedJobsHistoryLimit = defaultFailedJobsHistoryLimit

--- a/internal/controller/csiaddons/persistentvolumeclaim_controller.go
+++ b/internal/controller/csiaddons/persistentvolumeclaim_controller.go
@@ -118,6 +118,13 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, err
 	}
 
+	// Check if the PVC is being deleted
+	if !pvc.DeletionTimestamp.IsZero() {
+		logger.Info("PVC is being deleted, exiting reconcile", "namespace", pvc.Namespace, "name", pvc.Name)
+		// requeue the request
+		return ctrl.Result{}, nil
+	}
+
 	// Validate PVC in bound state
 	if pvc.Status.Phase != corev1.ClaimBound {
 		logger.Info("PVC is not in bound state", "PVCPhase", pvc.Status.Phase)

--- a/internal/controller/csiaddons/reclaimspacecronjob_controller.go
+++ b/internal/controller/csiaddons/reclaimspacecronjob_controller.go
@@ -80,6 +80,12 @@ func (r *ReclaimSpaceCronJobReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
+	// Check if resource is being deleted
+	if !rsCronJob.DeletionTimestamp.IsZero() {
+		logger.Info("ReclaimSpaceCronJob is being deleted, exiting reconcile", "namespace", rsCronJob.Namespace, "name", rsCronJob.Name)
+		return ctrl.Result{}, nil
+	}
+
 	// set history limit defaults, if not specified.
 	if rsCronJob.Spec.FailedJobsHistoryLimit == nil {
 		*rsCronJob.Spec.FailedJobsHistoryLimit = defaultFailedJobsHistoryLimit


### PR DESCRIPTION
This pull request introduces validation checks to ensure that resources in the process of being deleted are handled gracefully during reconciliation. These changes prevent unnecessary processing and potential errors by exiting early when a resource is marked for deletion.

Resource deletion handling:

* Added a check in `persistentvolumeclaim_controller.go` to detect if a `PersistentVolumeClaim` (`pvc`) is in the deletion phase and exit reconciliation early if so.
* Added a check in `reclaimspacecronjob_controller.go` to detect if a `ReclaimSpaceCronJob` resource is being deleted and exit reconciliation early if so.

NB: I stumbled across this issue as i was de/provisioning PVCs using gitops operator. In some cases, it was no longer possible to delete PVCs annotated with a reclaim space annotation. This was because the gitops operator always tried to deleted the PCVs reclaim jobs while the controller tried to recreate them.