### PR TITLE
fix: remove duplicate CEL rule for secrets

### DIFF
--- a/api/csiaddons/v1alpha1/networkfence_types.go
+++ b/api/csiaddons/v1alpha1/networkfence_types.go
@@ -92,7 +92,6 @@ type NetworkFenceSpec struct {
 	// Secret is a kubernetes secret, which is required to perform the fence/unfence operation.
 	// +kubebuilder:deprecatedversion:warning="specifying secrets in networkfence is deprecated, please use networkFenceClassName instead"
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="secrets are immutable"
 	Secret SecretSpec `json:"secret,omitempty"`
 
 	// Parameters is used to pass additional parameters to the CSI driver.

--- a/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
+++ b/config/crd/bases/csiaddons.openshift.io_networkfences.yaml
@@ -112,8 +112,6 @@ spec:
                       rule: self == oldSelf
                 type: object
                 x-kubernetes-validations:
-                - message: secrets are immutable
-                  rule: self == oldSelf
                 - message: secret is immutable
                   rule: self == oldSelf
             required:

--- a/deploy/controller/crds.yaml
+++ b/deploy/controller/crds.yaml
@@ -771,8 +771,6 @@ spec:
                       rule: self == oldSelf
                 type: object
                 x-kubernetes-validations:
-                - message: secrets are immutable
-                  rule: self == oldSelf
                 - message: secret is immutable
                   rule: self == oldSelf
             required:


### PR DESCRIPTION
we have 2 CEL rules for secrets, the rules is same but with two different messages, removing the duplicate one added recently

fixes: #879