### PR TITLE
sidecar: add annotations to csiaddonsnode object

### DIFF
--- a/sidecar/internal/csiaddonsnode/csiaddonsnode.go
+++ b/sidecar/internal/csiaddonsnode/csiaddonsnode.go
@@ -147,6 +147,16 @@ func (mgr *Manager) newCSIAddonsNode(node *csiaddonsv1alpha1.CSIAddonsNode) erro
 		node.Spec.DeepCopyInto(&csiaddonNode.Spec)
 		// set the ownerReferences
 		csiaddonNode.OwnerReferences = node.OwnerReferences
+		if csiaddonNode.Annotations == nil {
+			csiaddonNode.Annotations = make(map[string]string)
+		}
+		// Set the createdByPodUID and lastUpdatedAt annotations
+		// to track which pod created this csiaddonsnode object,
+		// when it was created. It also triggers a reconcile
+		// for the controller to reconnect to the sidecar.
+		annotationPrefix := "sidecar." + csiaddonsv1alpha1.GroupVersion.Group
+		csiaddonNode.Annotations[annotationPrefix+"/createdByPodUID"] = mgr.PodUID
+		csiaddonNode.Annotations[annotationPrefix+"/lastUpdatedAt"] = time.Now().Format(time.RFC3339)
 		return nil
 	})
 


### PR DESCRIPTION
This commit modifies sidecar code to
set the createdByPodUID and createdAt annotations
to track which pod created this csiaddonsnode object, when it was created.
It also triggers a reconcile for the controller to reconnect to the sidecar.

This helps in triggering automatic re connection whenever the sidecar is restarted.

CSIAddonsNode controller has annotation change predicate:
https://github.com/csi-addons/kubernetes-csi-addons/blob/40a8a6c0bb54f52ed0003a924d1ea8aaf818e168/internal/controller/csiaddons/csiaddonsnode_controller.go#L286

```
apiVersion: csiaddons.openshift.io/v1alpha1
kind: CSIAddonsNode
metadata:
  annotations:
    sidecar.csiaddons.openshift.io/createdAt: "2025-12-03T07:38:19Z"
    sidecar.csiaddons.openshift.io/createdByPodUID: 94e28c3e-637d-4f6f-a64a-ccb7ba8a435f
  creationTimestamp: "2025-12-03T07:38:19Z"
  finalizers:
  - csiaddons.openshift.io/csiaddonsnode
  generation: 1
  name: compute-2-openshift-storage-deployment-openshift-storage.rbd.csi.ceph.com-ctrlplugin
  namespace: openshift-storage
  ownerReferences:
  - apiVersion: v1
    kind: Pod
    name: openshift-storage.rbd.csi.ceph.com-ctrlplugin-854f75695c-zr6b8
    uid: 94e28c3e-637d-4f6f-a64a-ccb7ba8a435f
  resourceVersion: "3595798"
  uid: b267091b-6bb2-4e4d-9b5e-b30e7cda10ee
spec:
  driver:
    endpoint: pod://openshift-storage.rbd.csi.ceph.com-ctrlplugin-854f75695c-zr6b8.openshift-storage:9070
    name: openshift-storage.rbd.csi.ceph.com
    nodeID: compute-2
status:
  capabilities:
  - service.CONTROLLER_SERVICE
  - reclaim_space.OFFLINE
  - network_fence.NETWORK_FENCE
  - volume_replication.VOLUME_REPLICATION
  - volume_group.VOLUME_GROUP
  - volume_group.DO_NOT_ALLOW_VG_TO_DELETE_VOLUMES
  - volume_group.LIMIT_VOLUME_TO_ONE_VOLUME_GROUP
  - volume_group.MODIFY_VOLUME_GROUP
  - volume_group.GET_VOLUME_GROUP
  message: Successfully established connection with sidecar
  state: Connected
```