### PR TITLE
controller: consider managed state annotation in new pvc controller

### DIFF
--- a/internal/controller/csiaddons/pvc_new_controller.go
+++ b/internal/controller/csiaddons/pvc_new_controller.go
@@ -185,6 +185,15 @@ func (r *PVCReconiler) reconcileFeature(
 	}
 	logger.Info("determined the state to reconcile with", "shouldExist", shouldExist, "exists", exists)
 
+	// We allow the user to mark a feature as unmanged by editing an existing resource
+	// and setting the CSIAddonsStateAnnotation to: unmanaged
+	// Return and do nothing in such cases
+	if exists && !utils.IsManagedByController(existingObj) {
+		logger.Info("The existing object is not managed by the controller, doing nothing for it.", "objName", existingObj.GetName(), "objNamespace", existingObj.GetNamespace())
+
+		return nil
+	}
+
 	// Object should not be present in the cluster, garbage collect or return
 	if !shouldExist {
 		if exists {

--- a/internal/controller/utils/annotations.go
+++ b/internal/controller/utils/annotations.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -52,4 +53,14 @@ func AnnotationValueChanged(oldAnnotations, newAnnotations map[string]string, ke
 		}
 	}
 	return false
+}
+
+// IsManagedByController checks whether an object is managed by the controller.
+// It returns false if the object has the CSIAddonsStateAnnotation set to a value
+// other than CSIAddonsStateManaged. If the annotation is missing it returns true.
+func IsManagedByController(obj client.Object) bool {
+	if v, ok := obj.GetAnnotations()[CSIAddonsStateAnnotation]; ok && v != CSIAddonsStateManaged {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
This patch adds the missing logic to ignore reconciles for unmanaged resources.