### PR TITLE
csiaddonsnode: Add retry with exponential backoff for connections

### DIFF
--- a/api/csiaddons/v1alpha1/csiaddonsnode_types.go
+++ b/api/csiaddons/v1alpha1/csiaddonsnode_types.go
@@ -29,6 +29,11 @@ const (
 
 	// Failed represents the Connection Failed state.
 	CSIAddonsNodeStateFailed CSIAddonsNodeState = "Failed"
+
+	// Retrying represents the Connection Retrying state.
+	CSIAddonsNodeStateRetrying CSIAddonsNodeState = "Retrying"
+
+	CSIAddonsNodeStateRetryingFmtStr = "currentAttempt: %d"
 )
 
 type CSIAddonsNodeDriver struct {

--- a/internal/controller/csiaddons/csiaddonsnode_controller_test.go
+++ b/internal/controller/csiaddons/csiaddonsnode_controller_test.go
@@ -124,3 +124,66 @@ func TestParseCapabilities(t *testing.T) {
 		})
 	}
 }
+func TestGetRetryCountFromReason(t *testing.T) {
+	tests := []struct {
+		name    string
+		reason  string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "empty reason",
+			reason:  "",
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name:    "valid reason",
+			reason:  "retry: 2",
+			want:    2,
+			wantErr: false,
+		},
+		{
+			name:    "valid with extra spaces",
+			reason:  "retry:    5",
+			want:    5,
+			wantErr: false,
+		},
+		{
+			name:    "valid with trailing spaces",
+			reason:  "something:  10  ",
+			want:    10,
+			wantErr: false,
+		},
+		{
+			name:    "no colon",
+			reason:  "retry 3",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "non-integer value",
+			reason:  "retry: abc",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "multiple colons",
+			reason:  "prefix: 7:extra",
+			want:    0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getRetryCountFromReason(tt.reason)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This patch adds the functionality to retry for a maximum of
`maxRetries` to connect to the sidecar.

If the connection attempt is not successful, the object is considered
obsolete and is deleted.

The retry is tracked inside an annotation(`connRetryAnnotation`) and also
reflected in object's status.

These transient artifacts are cleaned up once a connection is
established.