### PR TITLE
fix typo in NetworkFenceClass sample config

### DIFF
--- a/config/samples/csiaddons_v1alpha1_networkfenceclass.yaml
+++ b/config/samples/csiaddons_v1alpha1_networkfenceclass.yaml
@@ -9,4 +9,4 @@ spec:
   provisioner: driver.example.com
   parameters:
     csiaddons.openshift.io/networkfence-secret-name: secret
-    csiaddons.openshift.io/network-secret-namespace: default
+    csiaddons.openshift.io/networkfence-secret-namespace: default


### PR DESCRIPTION
```
Change parameter name from 'network-secret-namespace' to 'networkfence-secret-namespace'
to match the correct parameter naming convention used elsewhere in the configuration.
```