### PR TITLE
bundle: add ability to inject priorityClassName

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,9 @@ gen-csv-base:
 
 .PHONY: bundle
 bundle: gen-csv-base manifests operator-sdk
+	cd config/manifests && $(KUSTOMIZE) edit add patch --path manager_priority_patch.yaml
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle --manifests --metadata --package=$(PACKAGE_NAME) $(BUNDLE_VERSION)
+	cd config/manifests && $(KUSTOMIZE) edit remove patch --path manager_priority_patch.yaml
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,6 +1,7 @@
----
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-  - ../default
-  - ../scorecard
+- ../default
+- ../scorecard
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/config/manifests/manager_priority_patch.yaml
+++ b/config/manifests/manager_priority_patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      priorityClassName: openshift-user-critical


### PR DESCRIPTION
This patch adds the ability to inject a `priorityClassName` to the generated bundle.

Ref: https://issues.redhat.com/browse/DFBUGS-394