### PR TITLE
controller: remove the shim for GCing old resources

### DIFF
--- a/internal/controller/csiaddons/pvc_new_controller.go
+++ b/internal/controller/csiaddons/pvc_new_controller.go
@@ -115,17 +115,6 @@ func (r *PVCReconiler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 		},
 	}
 
-	// FIXME: This is a shim and should be removed in later releases
-	// along with the field indexers on child objects
-	if requeue, err := utils.CleanOldJobs(ctx,
-		r.Client,
-		logger,
-		req,
-		&csiaddonsv1alpha1.EncryptionKeyRotationCronJobList{},
-		keyRotationName); err != nil || requeue {
-		return ctrl.Result{Requeue: requeue}, err
-	}
-
 	if err := r.reconcileFeature(ctx, logger, pvc, keyRotationChild, keyRotationSched, keyRotationEnabled); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -138,17 +127,6 @@ func (r *PVCReconiler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 			Name:      reclaimSpaceName,
 			Namespace: pvc.Namespace,
 		},
-	}
-
-	// FIXME: This is a shim and should be removed in later releases
-	// along with the field indexers on child objects
-	if requeue, err := utils.CleanOldJobs(ctx,
-		r.Client,
-		logger,
-		req,
-		&csiaddonsv1alpha1.ReclaimSpaceCronJobList{},
-		reclaimSpaceName); err != nil || requeue {
-		return ctrl.Result{Requeue: requeue}, err
 	}
 
 	if err := r.reconcileFeature(ctx, logger, pvc, reclaimSpaceChild, reclaimSpaceSched, "true"); err != nil {

--- a/internal/controller/utils/predicates.go
+++ b/internal/controller/utils/predicates.go
@@ -19,8 +19,6 @@ package utils
 import (
 	"context"
 
-	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
-
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -107,18 +105,6 @@ func SetupPVCControllerIndexers(mgr ctrl.Manager) error {
 				}
 				return []string{*pvc.Spec.StorageClassName}
 			},
-		},
-		// FIXME: Remove this shim in later releases
-		{
-			obj:     &csiaddonsv1alpha1.ReclaimSpaceCronJob{},
-			field:   JobOwnerKey,
-			indexFn: ExtractOwnerNameFromPVCObj[*csiaddonsv1alpha1.ReclaimSpaceCronJob],
-		},
-		// FIXME: Remove this shim in later releases
-		{
-			obj:     &csiaddonsv1alpha1.EncryptionKeyRotationCronJob{},
-			field:   JobOwnerKey,
-			indexFn: ExtractOwnerNameFromPVCObj[*csiaddonsv1alpha1.EncryptionKeyRotationCronJob],
 		},
 	}
 


### PR DESCRIPTION
We can remove this shim which was used when upgrading from v0.13.0 to v0.14.0. 

We had a release of v0.14.0 a while ago and the next version does not require this shim.

Reverts (changes of): 0b93f399e3a660653bebd88a043f8af6a6b8f393