### PR TITLE
doc: update networkfence docs for explicit fenceState field

### DIFF
--- a/docs/networkfence.md
+++ b/docs/networkfence.md
@@ -11,7 +11,9 @@ When both `networkFenceClassName` and `driver` are specified `networkFenceClassN
 > **Note:** Specifying `driver`, `secret` and `parameters` inside `NetworkFence` is deprecated, users are encouraged
 > to use `networkFenceClassName` along with a `NetworkFenceClass` instead.
 
-The creation of NetworkFence CR will add a network fence, and its deletion will undo the operation.
+The `fenceState` field in the NetworkFence spec explicitly specifies the desired state for the CIDRs either
+`Fenced` or `Unfenced`. Setting `fenceState` to `Fenced` blocks access to the corresponding CIDR blocks, while
+setting it to `Unfenced` unblocks them.
 
 ## Fence Operation
 
@@ -21,6 +23,7 @@ kind: NetworkFence
 metadata:
   name: network-fence-sample
 spec:
+  fenceState: Fenced
   networkFenceClassName: network-fence-class
   cidrs:
     - 10.90.89.66/32
@@ -36,8 +39,24 @@ spec:
     key: value
 ```
 
-> **Note**: Creation of a NetworkFence CR blocks access to the corresponding CIDR block; which is then unblocked the CR deletion.
+## Unfence Operation
 
+To unfence the CIDRs, update the `fenceState` field to `Unfenced`:
+
+```yaml
+apiVersion: csiaddons.openshift.io/v1alpha1
+kind: NetworkFence
+metadata:
+  name: network-fence-sample
+spec:
+  fenceState: Unfenced
+  networkFenceClassName: network-fence-class
+  cidrs:
+    - 10.90.89.66/32
+    - 11.67.12.42/24
+```
+
+- `fenceState`: specifies the desired state for the CIDRs. Accepted values are `Fenced` and `Unfenced`. Defaults to `Fenced`.
 - `networkFenceClassName`: specifies the name of the NetworkFenceClass.
 - `driver`: specifies the name of storage provisioner.
 - `cidrs`: refers to the CIDR blocks on which the mentioned fence/unfence operation is to be performed.


### PR DESCRIPTION
```
Updated the NetworkFence documentation to reflect the addition of the `fenceState`
field which explicitly specifies the desired state (Fenced or Unfenced) for the CIDRs in
the spec. Added an Unfence Operation section with a YAML example and documented
the new field in the field definitions.
```