### PR TITLE
Add csi-volume-device-exporter: Prometheus exporter for CSI volume-to-device mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # Image URL to use all building/pushing image targets
 CONTROLLER_IMG ?= quay.io/csiaddons/k8s-controller
 SIDECAR_IMG ?= quay.io/csiaddons/k8s-sidecar
+EXPORTER_IMG ?= quay.io/csiaddons/k8s-volume-device-exporter
 BUNDLE_IMG ?= quay.io/csiaddons/k8s-bundle
 TOOLS_IMG ?= quay.io/csiaddons/tools
 
@@ -22,6 +23,10 @@ endif
 
 ifneq (findstring $(BUNDLE_IMG),:)
 BUNDLE_IMG := $(BUNDLE_IMG):$(TAG)
+endif
+
+ifneq (findstring $(EXPORTER_IMG),:)
+EXPORTER_IMG := $(EXPORTER_IMG):$(TAG)
 endif
 
 ifneq (findstring $(TOOLS_IMG),:)
@@ -164,6 +169,7 @@ build: generate fmt vet ## Build manager binary.
 	go build -ldflags '$(LDFLAGS)' -a -o bin/csi-addons-manager cmd/manager/main.go
 	go build -ldflags '$(LDFLAGS)' -a -o bin/csi-addons-sidecar sidecar/main.go
 	go build -ldflags '$(LDFLAGS)' -a -o bin/csi-addons ./cmd/csi-addons
+	go build -ldflags '$(LDFLAGS)' -a -o bin/csi-volume-device-exporter ./cmd/csi-volume-device-exporter
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
@@ -184,6 +190,14 @@ docker-build-sidecar: container-cmd
 .PHONY: docker-push-sidecar
 docker-push-sidecar: container-cmd
 	$(CONTAINER_CMD) push ${SIDECAR_IMG}
+
+.PHONY: docker-build-exporter
+docker-build-exporter: container-cmd
+	$(CONTAINER_CMD) build -f ./build/Containerfile.exporter -t ${EXPORTER_IMG} .
+
+.PHONY: docker-push-exporter
+docker-push-exporter: container-cmd
+	$(CONTAINER_CMD) push ${EXPORTER_IMG}
 
 .PHONY: docker-build-bundle
 docker-build-bundle: container-cmd bundle
@@ -219,6 +233,15 @@ deploy: manifests ## Deploy controller to the K8s cluster specified in ~/.kube/c
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	cd deploy/controller && kubectl delete -f setup-controller.yaml -f rbac.yaml -f crds.yaml --ignore-not-found=$(ignore-not-found)
+
+.PHONY: deploy-exporter
+deploy-exporter: ## Deploy csi-volume-device-exporter DaemonSet.
+	kubectl apply -f deploy/exporter/daemonset.yaml -f deploy/exporter/podmonitor.yaml
+
+.PHONY: test-exporter-alerts
+test-exporter-alerts: ## Test exporter Prometheus alert rules.
+	go test -race -count=1 ./internal/exporter/monitoring/...
+	hack/prom-rule-ci/verify-rules.sh
 
 # controller-gen gets installed from the vendor/ directory.
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen

--- a/build/Containerfile.exporter
+++ b/build/Containerfile.exporter
@@ -1,0 +1,16 @@
+# Build the exporter binary
+FROM golang:1.25 AS builder
+
+COPY . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons
+
+ENV GOPATH=/workspace/go CGO_ENABLED=0
+WORKDIR /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons
+
+RUN go build -ldflags="-s -w" -o /csi-volume-device-exporter ./cmd/csi-volume-device-exporter
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /csi-volume-device-exporter /csi-volume-device-exporter
+USER 65532:65532
+
+ENTRYPOINT ["/csi-volume-device-exporter"]

--- a/cmd/csi-volume-device-exporter/main.go
+++ b/cmd/csi-volume-device-exporter/main.go
@@ -1,0 +1,262 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package main provides the csi-volume-device-exporter entrypoint.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/csi-addons/kubernetes-csi-addons/internal/exporter/discovery"
+	"github.com/csi-addons/kubernetes-csi-addons/internal/exporter/monitoring/metrics"
+)
+
+var (
+	version = "dev"
+	commit  = "unknown"
+)
+
+func main() {
+	var (
+		listenAddr      = flag.String("listen-address", ":9091", "Address to listen on for metrics and healthz")
+		pollInterval    = flag.Duration("poll-interval", 30*time.Second, "Interval between discovery cycles")
+		logLevel        = flag.String("log-level", "info", "Log level (debug, info, warn, error)")
+		hostProc        = flag.String("host-proc", "/host/proc", "Path to host /proc mount inside container")
+		hostSys         = flag.String("host-sys", "/host/sys", "Path to host /sys mount inside container")
+		hostKubelet     = flag.String("host-kubelet", "/host/kubelet", "Path to host kubelet root mount inside container")
+		realKubeletRoot = flag.String("kubelet-root", "/var/lib/kubelet", "Actual kubelet root path on the host (for mountinfo matching)")
+		hostTrident     = flag.String("host-trident-tracking", "/host/trident/tracking", "Path to host Trident tracking dir inside container")
+		showVersion     = flag.Bool("version", false, "Print version and exit")
+	)
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("csi-volume-device-exporter %s (commit: %s)\n", version, commit)
+		os.Exit(0)
+	}
+
+	logger := setupLogger(*logLevel)
+	logger.Info("starting csi-volume-device-exporter",
+		"version", version, "commit", commit)
+
+	nodeName := os.Getenv("NODE_NAME")
+	if nodeName == "" {
+		logger.Error("NODE_NAME environment variable is required")
+		os.Exit(1)
+	}
+
+	for _, p := range []struct{ name, val string }{
+		{"host-proc", *hostProc},
+		{"host-sys", *hostSys},
+		{"host-kubelet", *hostKubelet},
+		{"kubelet-root", *realKubeletRoot},
+		{"host-trident-tracking", *hostTrident},
+	} {
+		clean := filepath.Clean(p.val)
+		if !filepath.IsAbs(clean) || strings.Contains(clean, "..") {
+			logger.Error("path must be absolute and must not escape via ..",
+				"flag", p.name, "value", p.val)
+			os.Exit(1)
+		}
+	}
+
+	discoverers := []discovery.Discoverer{
+		discovery.NewTridentDiscoverer(*hostTrident, *hostSys, nodeName, logger),
+		discovery.NewHPEDiscoverer(*hostKubelet, *hostSys, nodeName, logger),
+		discovery.NewKubeletDiscoverer(*hostKubelet, *realKubeletRoot, *hostProc, *hostSys, nodeName, logger),
+	}
+
+	m := metrics.New()
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(m.Registry(), promhttp.HandlerOpts{}))
+
+	var (
+		lastSuccessTime time.Time
+		lastSuccessMu   sync.RWMutex
+	)
+
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		lastSuccessMu.RLock()
+		t := lastSuccessTime
+		lastSuccessMu.RUnlock()
+
+		if t.IsZero() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = fmt.Fprint(w, "no successful discovery yet\n")
+			return
+		}
+		if time.Since(t) > 2*(*pollInterval) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = fmt.Fprintf(w, "last successful discovery: %s ago\n", time.Since(t))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, "ok\n")
+	})
+
+	server := &http.Server{
+		Addr:              *listenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+
+	go func() {
+		<-sigCh
+		logger.Info("received shutdown signal")
+		cancel()
+	}()
+
+	go func() {
+		logger.Info("starting HTTP server", "address", *listenAddr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error("HTTP server error, initiating shutdown", "error", err)
+			cancel()
+		}
+	}()
+
+	logger.Info("starting discovery loop",
+		"poll_interval", pollInterval.String(),
+		"node", nodeName)
+
+	run(ctx, discoverers, m, logger, &lastSuccessTime, &lastSuccessMu, *pollInterval)
+
+	shutdown(server, logger)
+}
+
+func run(ctx context.Context, discoverers []discovery.Discoverer, m *metrics.Metrics, logger *slog.Logger, lastSuccess *time.Time, mu *sync.RWMutex, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	runDiscovery(ctx, discoverers, m, logger, lastSuccess, mu)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			runDiscovery(ctx, discoverers, m, logger, lastSuccess, mu)
+		}
+	}
+}
+
+func runDiscovery(ctx context.Context, discoverers []discovery.Discoverer, m *metrics.Metrics, logger *slog.Logger, lastSuccess *time.Time, mu *sync.RWMutex) {
+	if ctx.Err() != nil {
+		return
+	}
+
+	volumes := make(map[string]discovery.VolumeDevice)
+	totalErrors := 0
+	totalSuccesses := 0
+
+	for _, d := range discoverers {
+		start := time.Now()
+		results, err := d.Discover(ctx)
+		duration := time.Since(start)
+
+		m.ObserveDiscoveryDuration(d.Name(), duration.Seconds())
+
+		if err != nil {
+			totalErrors++
+			m.IncDiscoveryErrors(d.Name())
+			logger.Warn("discovery error", "discoverer", d.Name(), "error", err)
+			continue
+		}
+
+		totalSuccesses++
+		for _, v := range results {
+			if v.VolumeHandle == "" || v.Device == "" {
+				continue
+			}
+			if existing, exists := volumes[v.VolumeHandle]; exists {
+				if existing.Device != v.Device {
+					logger.Warn("conflicting device for volume_handle, keeping first",
+						"volume_handle", v.VolumeHandle,
+						"kept_device", existing.Device,
+						"kept_discoverer", existing.Driver,
+						"ignored_device", v.Device,
+						"ignored_discoverer", v.Driver,
+					)
+				}
+				continue
+			}
+			volumes[v.VolumeHandle] = v
+		}
+	}
+
+	if totalSuccesses > 0 {
+		m.Reconcile(volumes)
+		mu.Lock()
+		m.SetLastSuccessfulNow()
+		*lastSuccess = time.Now()
+		mu.Unlock()
+	} else {
+		logger.Error("all discoverers failed, skipping reconcile and health update",
+			"discoverer_count", len(discoverers))
+	}
+
+	logger.Debug("discovery cycle complete",
+		"volumes_found", len(volumes), "errors", totalErrors, "successes", totalSuccesses)
+}
+
+func shutdown(server *http.Server, logger *slog.Logger) {
+	logger.Info("shutting down HTTP server")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		logger.Error("HTTP server shutdown error", "error", err)
+	}
+}
+
+func setupLogger(level string) *slog.Logger {
+	var lvl slog.Level
+	switch level {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "info":
+		lvl = slog.LevelInfo
+	case "warn":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+		logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: lvl}))
+		logger.Warn("unknown log level, defaulting to info", "level", level)
+		return logger
+	}
+	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: lvl}))
+}

--- a/deploy/exporter/daemonset.yaml
+++ b/deploy/exporter/daemonset.yaml
@@ -1,0 +1,106 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-volume-device-exporter
+  labels:
+    app.kubernetes.io/name: csi-volume-device-exporter
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: csi-volume-device-exporter
+  labels:
+    app.kubernetes.io/name: csi-volume-device-exporter
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: csi-volume-device-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: csi-volume-device-exporter
+    spec:
+      serviceAccountName: csi-volume-device-exporter
+      automountServiceAccountToken: false
+      hostPID: true
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: exporter
+          image: quay.io/csiaddons/k8s-volume-device-exporter:latest
+          args:
+            - --listen-address=:9091
+            - --poll-interval=30s
+            - --log-level=info
+            - --kubelet-root=/var/lib/kubelet
+          ports:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsUser: 0
+            runAsGroup: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            seLinuxOptions:
+              level: "s0"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - name: kubelet-csi-plugins
+              mountPath: /host/kubelet/plugins/kubernetes.io/csi
+              readOnly: true
+            - name: kubelet-pods
+              mountPath: /host/kubelet/pods
+              readOnly: true
+            - name: trident-tracking
+              mountPath: /host/trident/tracking
+              readOnly: true
+            - name: host-proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: host-sys
+              mountPath: /host/sys
+              readOnly: true
+      volumes:
+        - name: kubelet-csi-plugins
+          hostPath:
+            path: /var/lib/kubelet/plugins/kubernetes.io/csi
+        - name: kubelet-pods
+          hostPath:
+            path: /var/lib/kubelet/pods
+        - name: trident-tracking
+          hostPath:
+            path: /var/lib/trident/tracking
+            type: DirectoryOrCreate
+        - name: host-proc
+          hostPath:
+            path: /proc
+        - name: host-sys
+          hostPath:
+            path: /sys

--- a/deploy/exporter/podmonitor.yaml
+++ b/deploy/exporter/podmonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: csi-volume-device-exporter
+  labels:
+    app.kubernetes.io/name: csi-volume-device-exporter
+spec:
+  # jobLabel causes Prometheus Operator to set the `job` label on scraped
+  # metrics to the value of this pod label. This must produce the string
+  # "csi-volume-device-exporter" so that the CSIVolumeDeviceExporterDown alert
+  # selector (job="csi-volume-device-exporter") matches.
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: csi-volume-device-exporter
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s

--- a/deploy/exporter/scc.yaml
+++ b/deploy/exporter/scc.yaml
@@ -1,0 +1,35 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: csi-volume-device-exporter
+# A custom SCC is used instead of the built-in 'privileged' SCC to follow
+# the principle of least privilege. The exporter requires:
+#   - hostPID: to read /proc/1/mountinfo from the host PID namespace
+#   - hostPath volumes (read-only): /var/lib/kubelet, /proc, /sys
+# It explicitly does NOT need: privileged containers, host networking,
+# host ports, host IPC, or any Linux capabilities.
+# Using 'privileged' would grant all of the above unnecessarily.
+allowPrivilegedContainer: false
+allowHostDirVolumePlugin: true
+allowHostPID: true
+allowHostIPC: false
+allowHostPorts: false
+allowHostNetwork: false
+readOnlyRootFilesystem: true
+runAsUser:
+  type: MustRunAs
+  uid: 0
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - hostPath
+  - emptyDir
+  - projected
+# Replace <NAMESPACE> below with the namespace where the DaemonSet is deployed,
+# or bind via: oc adm policy add-scc-to-user csi-volume-device-exporter \
+#              -z csi-volume-device-exporter -n <NAMESPACE>
+users: []

--- a/docs/csi-volume-device-exporter.md
+++ b/docs/csi-volume-device-exporter.md
@@ -1,0 +1,97 @@
+# CSI Volume Device Exporter
+
+The CSI Volume Device Exporter is a Prometheus exporter that maps CSI
+PersistentVolumes to their underlying block devices on each node. This mapping
+enables cross-referencing storage path health metrics (e.g., DM-multipath path
+state, NVMe-oF subsystem health) with Kubernetes PersistentVolumes.
+
+## Usage
+
+The exporter is deployed as a **DaemonSet** that runs on every node:
+
+```bash
+kubectl apply -f deploy/exporter/daemonset.yaml
+kubectl apply -f deploy/exporter/podmonitor.yaml
+```
+
+### Building
+
+```bash
+# Build the binary
+go build -o bin/csi-volume-device-exporter ./cmd/csi-volume-device-exporter
+
+# Build the container image
+make docker-build-exporter
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--listen-address` | `:9091` | Address to listen on for metrics and healthz |
+| `--poll-interval` | `30s` | Interval between discovery cycles |
+| `--log-level` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
+| `--host-proc` | `/host/proc` | Path to host `/proc` mount inside container |
+| `--host-sys` | `/host/sys` | Path to host `/sys` mount inside container |
+| `--host-kubelet` | `/host/kubelet` | Path to host kubelet root mount inside container |
+| `--kubelet-root` | `/var/lib/kubelet` | Actual kubelet root path on the host (for mountinfo matching) |
+| `--host-trident-tracking` | `/host/trident/tracking` | Path to host Trident tracking dir inside container |
+
+The `NODE_NAME` environment variable is **required** and should be set via the
+Kubernetes downward API (`spec.nodeName`).
+
+## Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `csi_volume_node_device_info` | Gauge | Maps CSI volumes to node block devices (value always 1) |
+| `csi_volume_device_exporter_discovery_duration_seconds` | Histogram | Duration of volume discovery by discoverer |
+| `csi_volume_device_exporter_discovery_errors_total` | Counter | Total discovery errors by discoverer |
+| `csi_volume_device_exporter_volumes_discovered` | Gauge | Number of volumes discovered per driver |
+| `csi_volume_device_exporter_last_successful_discovery_timestamp_seconds` | Gauge | Unix timestamp of last successful discovery cycle |
+
+## Alert Rules
+
+The exporter ships with 5 Prometheus alert rules:
+
+| Alert | Severity | Description |
+|-------|----------|-------------|
+| `CSIVolumeMultipathDegraded` | warning | At least one multipath path is down |
+| `CSIVolumeMultipathLost` | critical | All multipath paths are down |
+| `CSIVolumeNVMeSubsystemDegraded` | warning | At least one NVMe-oF controller is not live |
+| `CSIVolumeNVMeSubsystemLost` | critical | All NVMe-oF controllers are dead |
+| `CSIVolumeDeviceExporterDown` | warning | Exporter is not being scraped by Prometheus |
+
+Runbooks for each alert are in
+[docs/csi-volume-device-exporter/runbooks/](csi-volume-device-exporter/runbooks/).
+
+## Discovery Engines
+
+The exporter uses multiple discovery engines that run in parallel:
+
+1. **Kubelet Discoverer** — Parses `vol_data.json` from kubelet's CSI plugin
+   directory and correlates with `/proc/1/mountinfo` to resolve block devices
+   via `/sys/dev/block/`.
+
+2. **Trident Discoverer** — Reads NetApp Trident tracking JSON files for direct
+   device path mapping.
+
+3. **HPE Discoverer** — Reads HPE CSI driver `deviceInfo.json` files.
+
+All discoverers resolve LUKS-over-multipath stacks, returning the underlying
+multipath device rather than the LUKS dm device.
+
+## OpenShift Deployment
+
+On OpenShift, deploy the exporter with the custom SCC:
+
+```bash
+NAMESPACE=openshift-cnv
+kubectl apply -n $NAMESPACE -f deploy/exporter/scc.yaml
+kubectl apply -n $NAMESPACE -f deploy/exporter/daemonset.yaml
+kubectl apply -n $NAMESPACE -f deploy/exporter/podmonitor.yaml
+```
+
+The `openshift-cnv` namespace carries `openshift.io/cluster-monitoring=true` so
+the platform Prometheus scrapes the exporter alongside node-exporter, enabling
+the PromQL join with `node_dmmultipath_path_state`.

--- a/docs/csi-volume-device-exporter/runbooks/CSIVolumeDeviceExporterDown.md
+++ b/docs/csi-volume-device-exporter/runbooks/CSIVolumeDeviceExporterDown.md
@@ -1,0 +1,72 @@
+# CSIVolumeDeviceExporterDown
+
+## Meaning
+
+No `csi-volume-device-exporter` targets have been scraped by Prometheus for at
+least 5 minutes. The exporter DaemonSet has either been removed from the cluster
+or all of its pods are failing to start or stay running.
+
+## Impact
+
+Storage path health for CSI volumes cannot be reported. The
+`CSIVolumeMultipathDegraded` alert will not fire even if multipath paths are
+faulty, creating a blind spot in storage observability.
+
+## Diagnosis
+
+1. Check the DaemonSet status:
+
+   ```bash
+   kubectl get daemonset csi-volume-device-exporter -n <namespace>
+   ```
+
+   Look for pods that are not in the `Running` state.
+
+2. Identify failing pods and inspect their logs:
+
+   ```bash
+   kubectl get pods -n <namespace> -l app.kubernetes.io/name=csi-volume-device-exporter
+   kubectl logs -n <namespace> <pod-name> --previous
+   ```
+
+3. Check pod events for scheduling or mount failures:
+
+   ```bash
+   kubectl describe pod -n <namespace> <pod-name>
+   ```
+
+4. Verify the DaemonSet is present and not accidentally deleted:
+
+   ```bash
+   kubectl get daemonset -n <namespace>
+   ```
+
+5. Confirm Prometheus can reach the exporter endpoint:
+
+   ```bash
+   kubectl get podmonitor -n <namespace> csi-volume-device-exporter
+   ```
+
+## Mitigation
+
+- If pods are crashlooping, review the logs from step 2 above for startup
+  errors (missing `NODE_NAME`, inaccessible host paths, permission errors).
+
+- If pods are in `Pending` state, a node may lack resources or have a taint
+  that prevents scheduling. Review `kubectl describe node <node>`.
+
+- If the DaemonSet was deleted, redeploy it:
+
+  ```bash
+  kubectl apply -f deploy/exporter/daemonset.yaml
+  ```
+
+- On OpenShift, also verify the SecurityContextConstraint is still bound:
+
+  ```bash
+  oc get scc csi-volume-device-exporter
+  oc adm policy who-can use scc csi-volume-device-exporter
+  ```
+
+The alert will clear automatically once Prometheus successfully scrapes at least
+one exporter target.

--- a/docs/csi-volume-device-exporter/runbooks/CSIVolumeMultipathDegraded.md
+++ b/docs/csi-volume-device-exporter/runbooks/CSIVolumeMultipathDegraded.md
@@ -1,0 +1,97 @@
+# CSIVolumeMultipathDegraded
+
+## Meaning
+
+A Kubernetes PersistentVolume backed by a DM-multipath block device has at
+least one faulty path on the node where it is currently attached.
+
+The device is still accessible as long as at least one active path remains, but
+redundancy is reduced and a second path failure will cause I/O errors for any
+workload using this volume.
+
+## Impact
+
+Workloads (including VMs) using the affected PersistentVolume are running with
+degraded storage redundancy. If the remaining paths also fail, the workload will
+experience I/O errors and may become unavailable.
+
+## Diagnosis
+
+The alert labels identify the affected resources. Set shell variables from the
+firing alert before running the commands below:
+
+```bash
+NODE=<node label from alert>
+DEVICE=<device label from alert, e.g. dm-0>
+PV=<persistentvolume label from alert>
+```
+
+1. Check the overall multipath state on the affected node:
+
+   ```bash
+   oc debug node/$NODE -- chroot /host multipath -ll $DEVICE
+   ```
+
+   Look for paths in `faulty`, `failed`, or `shaky` state.
+
+2. Identify which physical paths are down:
+
+   ```bash
+   oc debug node/$NODE -- chroot /host multipathd show paths format "%d %t %T %s"
+   ```
+
+3. Check which workload is using the PV:
+
+   ```bash
+   kubectl get pv $PV -o jsonpath='{.spec.claimRef.namespace}/{.spec.claimRef.name}'
+   ```
+
+   Then find the pod or VM consuming that PVC:
+
+   ```bash
+   PVC=<output from above>
+   kubectl get pods -A -o json | \
+     jq -r '.items[] | select(.spec.volumes[]?.persistentVolumeClaim.claimName == "'${PVC#*/}'" ) | .metadata.namespace + "/" + .metadata.name'
+   ```
+
+4. Check the host HBA or NIC state for the failing path:
+
+   ```bash
+   oc debug node/$NODE -- chroot /host dmesg | grep -i "scsi\|fc\|iscsi\|nvme" | tail -50
+   ```
+
+## Mitigation
+
+The correct action depends on the storage protocol and the root cause identified
+in the Diagnosis section.
+
+**Physical connectivity failure (FC/iSCSI/NVMe-oF):**
+
+- Inspect and reseat any cables or SFPs on the host HBA/NIC.
+- Check the switch port and zoning configuration.
+- Contact your storage administrator to verify the storage array port state.
+
+**Transient path error (path is recovering):**
+
+- Reinstate the path manually if `multipathd` has not already done so:
+
+  ```bash
+  oc debug node/$NODE -- chroot /host multipathd reinstate path <path_device>
+  ```
+
+**`multipathd` daemon issue:**
+
+- Restart `multipathd` on the node (only if no active I/O is in critical section):
+
+  ```bash
+  oc debug node/$NODE -- chroot /host systemctl restart multipathd
+  ```
+
+After remediation, confirm all paths are active:
+
+```bash
+oc debug node/$NODE -- chroot /host multipath -ll $DEVICE
+```
+
+The alert will clear automatically once no faulty paths are reported for the
+device.

--- a/docs/csi-volume-device-exporter/runbooks/CSIVolumeMultipathLost.md
+++ b/docs/csi-volume-device-exporter/runbooks/CSIVolumeMultipathLost.md
@@ -1,0 +1,69 @@
+# CSIVolumeMultipathLost
+
+## Meaning
+
+All paths to a DM-multipath block device backing a Kubernetes PersistentVolume
+are down. The device has no remaining active paths and I/O is likely failing.
+
+## Impact
+
+Workloads (including VMs) using the affected PersistentVolume are experiencing
+I/O errors or are hung waiting for I/O. This is a critical condition that
+requires immediate attention.
+
+## Diagnosis
+
+The alert labels identify the affected resources:
+
+```bash
+NODE=<node label from alert>
+DEVICE=<device label from alert, e.g. mpathA>
+PV=<persistentvolume label from alert>
+```
+
+1. Check the multipath device state:
+
+   ```bash
+   oc debug node/$NODE -- chroot /host multipath -ll $DEVICE
+   ```
+
+   All paths should show as failed/offline/dead.
+
+2. Check kernel messages for storage errors:
+
+   ```bash
+   oc debug node/$NODE -- chroot /host dmesg | grep -i "scsi\|fc\|iscsi\|nvme\|multipath" | tail -50
+   ```
+
+3. Identify affected workloads:
+
+   ```bash
+   kubectl get pv $PV -o jsonpath='{.spec.claimRef.namespace}/{.spec.claimRef.name}'
+   ```
+
+## Mitigation
+
+This is a critical condition. All storage paths are down simultaneously, which
+typically indicates:
+
+- Complete loss of network connectivity to the storage array
+- Storage array failure or maintenance
+- Multiple simultaneous fabric/switch failures
+
+**Immediate actions:**
+
+1. Contact your storage administrator to verify the storage array is healthy.
+2. Check all network paths between the node and the storage array (switches, HBAs, cables).
+3. If the workload is a VM, consider live-migrating it to a node with working storage paths (if the VM's storage is accessible from other nodes).
+
+**After storage connectivity is restored:**
+
+- Paths should recover automatically via `multipathd`.
+- If paths do not recover, restart `multipathd`:
+
+  ```bash
+  oc debug node/$NODE -- chroot /host systemctl restart multipathd
+  ```
+
+The alert will clear once at least one path returns to active state. The
+CSIVolumeMultipathDegraded alert may remain until all paths are restored.

--- a/docs/csi-volume-device-exporter/runbooks/CSIVolumeNVMeSubsystemDegraded.md
+++ b/docs/csi-volume-device-exporter/runbooks/CSIVolumeNVMeSubsystemDegraded.md
@@ -1,0 +1,62 @@
+# CSIVolumeNVMeSubsystemDegraded
+
+## Meaning
+
+A Kubernetes PersistentVolume backed by an NVMe-oF (NVMe over Fabrics) subsystem
+has at least one controller path that is not in the `live` state.
+
+The subsystem is still accessible via remaining live controllers, but redundancy
+is reduced.
+
+## Impact
+
+Workloads (including VMs) using the affected PersistentVolume are running with
+degraded NVMe-oF path redundancy. If the remaining controllers also fail, the
+workload will experience I/O errors.
+
+## Diagnosis
+
+```bash
+NODE=<node label from alert>
+SUBSYSTEM=<subsystem label from alert>
+PV=<persistentvolume label from alert>
+```
+
+1. Check the NVMe subsystem controller states:
+
+   ```bash
+   oc debug node/$NODE -- chroot /host nvme list-subsys /dev/$SUBSYSTEM
+   ```
+
+2. Check for NVMe errors in kernel logs:
+
+   ```bash
+   oc debug node/$NODE -- chroot /host dmesg | grep -i nvme | tail -30
+   ```
+
+3. Identify the affected workload:
+
+   ```bash
+   kubectl get pv $PV -o jsonpath='{.spec.claimRef.namespace}/{.spec.claimRef.name}'
+   ```
+
+## Mitigation
+
+**Network connectivity issue (NVMe/TCP or NVMe/RDMA):**
+
+- Check network connectivity between the node and the storage target.
+- Verify the NVMe-oF target portal is reachable from the node.
+
+**Controller failure on the storage array:**
+
+- Contact your storage administrator to check the health of the NVMe target controllers.
+
+**Reconnection:**
+
+- The NVMe-oF driver should automatically reconnect. If it does not:
+
+  ```bash
+  oc debug node/$NODE -- chroot /host nvme connect-all
+  ```
+
+The alert will clear once all controllers return to `live` state.

--- a/docs/csi-volume-device-exporter/runbooks/CSIVolumeNVMeSubsystemLost.md
+++ b/docs/csi-volume-device-exporter/runbooks/CSIVolumeNVMeSubsystemLost.md
@@ -1,0 +1,65 @@
+# CSIVolumeNVMeSubsystemLost
+
+## Meaning
+
+All NVMe-oF controller paths for a subsystem backing a Kubernetes
+PersistentVolume are dead. The subsystem has no live controllers and I/O is
+likely failing.
+
+## Impact
+
+Workloads (including VMs) using the affected PersistentVolume are experiencing
+I/O errors or are hung. This is a critical condition requiring immediate action.
+
+## Diagnosis
+
+```bash
+NODE=<node label from alert>
+SUBSYSTEM=<subsystem label from alert>
+PV=<persistentvolume label from alert>
+```
+
+1. Check NVMe subsystem state:
+
+   ```bash
+   oc debug node/$NODE -- chroot /host nvme list-subsys /dev/$SUBSYSTEM
+   ```
+
+   All controllers should show as `dead` or `connecting`.
+
+2. Check kernel messages:
+
+   ```bash
+   oc debug node/$NODE -- chroot /host dmesg | grep -i nvme | tail -50
+   ```
+
+3. Identify affected workloads:
+
+   ```bash
+   kubectl get pv $PV -o jsonpath='{.spec.claimRef.namespace}/{.spec.claimRef.name}'
+   ```
+
+## Mitigation
+
+All NVMe-oF controllers are down simultaneously, which typically indicates:
+
+- Complete loss of network connectivity to the NVMe-oF target
+- Storage array failure or maintenance
+- Network fabric failure
+
+**Immediate actions:**
+
+1. Contact your storage administrator to verify the NVMe-oF target is healthy.
+2. Check network connectivity between the node and all target portals.
+3. If the workload is a VM, consider live-migrating it to a node with working connectivity (if the storage is reachable from other nodes).
+
+**After connectivity is restored:**
+
+- The NVMe-oF driver should reconnect automatically.
+- If it does not, attempt manual reconnection:
+
+  ```bash
+  oc debug node/$NODE -- chroot /host nvme connect-all
+  ```
+
+The alert will clear once at least one controller returns to `live` state.

--- a/go.mod
+++ b/go.mod
@@ -8,11 +8,14 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0
 	github.com/kubernetes-csi/csi-lib-utils v0.23.2
+	github.com/moby/sys/mountinfo v0.7.2
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.28.0
+	golang.org/x/sys v0.43.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
@@ -54,13 +57,12 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
-	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
@@ -87,7 +89,6 @@ require (
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.9.0 // indirect

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -1,0 +1,304 @@
+---
+rule_files:
+  - /tmp/rules.verify
+
+# information about this format can be found in:
+# https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/
+tests:
+  # -----------------------------------------------------------------------
+  # CSIVolumeMultipathDegraded
+  # -----------------------------------------------------------------------
+
+  # Alert must not fire when all paths are healthy, and must fire after 5m
+  # when a path goes offline, then clear once the fault is resolved.
+  - interval: 1m
+    input_series:
+      - series: 'kube_persistentvolume_info{persistentvolume="pvc-abc",csi_volume_handle="vol-handle-1"}'
+        values: "1x17"
+      - series: 'csi_volume_node_device_info{node="node-1",volume_handle="vol-handle-1",driver="csi.example.com",device="dm-0"}'
+        values: "1x17"
+      - series: 'node_dmmultipath_device_info{sysfs_name="dm-0",device="mpathA",node="node-1",uuid="mpath-123"}'
+        values: "1x17"
+      # healthy for first 2 minutes, offline from minute 2, recovers at minute 10
+      - series: 'node_dmmultipath_path_state{device="mpathA",path="sda",node="node-1",state="offline"}'
+        values: "_ _ 1 1 1 1 1 1 1 1 _ _ _ _ _ _ _"
+
+    alert_rule_test:
+      # must not fire before the 5m `for:` duration elapses (fault started at minute 2)
+      - eval_time: 6m
+        alertname: CSIVolumeMultipathDegraded
+        exp_alerts: []
+      # must fire after 5m of continuous offline path
+      - eval_time: 7m
+        alertname: CSIVolumeMultipathDegraded
+        exp_alerts:
+          - exp_annotations:
+              summary: "PV pvc-abc on node-1 has degraded multipath (device mpathA)"
+              description: "At least one path to the multipath device has failed. Storage is still accessible via remaining paths but redundancy is lost."
+              runbook_url: "https://github.com/csi-addons/kubernetes-csi-addons/blob/main/docs/csi-volume-device-exporter/runbooks/CSIVolumeMultipathDegraded.md"
+            exp_labels:
+              severity: warning
+              alertname: CSIVolumeMultipathDegraded
+              persistentvolume: pvc-abc
+              csi_volume_handle: "vol-handle-1"
+              volume_handle: "vol-handle-1"
+              sysfs_name: dm-0
+              node: node-1
+              device: mpathA
+              driver: csi.example.com
+      # must clear once the offline path recovers (series goes stale after minute 10)
+      - eval_time: 16m
+        alertname: CSIVolumeMultipathDegraded
+        exp_alerts: []
+
+  # Alert must not fire when all paths are active (running)
+  - interval: 1m
+    input_series:
+      - series: 'kube_persistentvolume_info{persistentvolume="pvc-abc",csi_volume_handle="vol-handle-1"}'
+        values: "1x10"
+      - series: 'csi_volume_node_device_info{node="node-1",volume_handle="vol-handle-1",driver="csi.example.com",device="dm-0"}'
+        values: "1x10"
+      - series: 'node_dmmultipath_device_info{sysfs_name="dm-0",device="mpathA",node="node-1",uuid="mpath-123"}'
+        values: "1x10"
+      - series: 'node_dmmultipath_path_state{device="mpathA",path="sda",node="node-1",state="running"}'
+        values: "1x10"
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: CSIVolumeMultipathDegraded
+        exp_alerts: []
+
+  # Alert must not fire for a non-CSI PV (empty csi_volume_handle — (.+) guard)
+  - interval: 1m
+    input_series:
+      - series: 'kube_persistentvolume_info{persistentvolume="pvc-nfs",csi_volume_handle=""}'
+        values: "1x10"
+      - series: 'node_dmmultipath_device_info{sysfs_name="dm-0",device="mpathA",node="node-1",uuid="mpath-123"}'
+        values: "1x10"
+      - series: 'node_dmmultipath_path_state{device="mpathA",path="sda",node="node-1",state="offline"}'
+        values: "1x10"
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: CSIVolumeMultipathDegraded
+        exp_alerts: []
+
+  # Alert must not fire when the offline path is on a different node than the PV
+  - interval: 1m
+    input_series:
+      - series: 'kube_persistentvolume_info{persistentvolume="pvc-abc",csi_volume_handle="vol-handle-1"}'
+        values: "1x10"
+      - series: 'csi_volume_node_device_info{node="node-1",volume_handle="vol-handle-1",driver="csi.example.com",device="dm-0"}'
+        values: "1x10"
+      - series: 'node_dmmultipath_device_info{sysfs_name="dm-0",device="mpathA",node="node-1",uuid="mpath-123"}'
+        values: "1x10"
+      # offline path is on node-2, PV is attached to node-1 — no match
+      - series: 'node_dmmultipath_path_state{device="mpathA",path="sda",node="node-2",state="offline"}'
+        values: "1x10"
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: CSIVolumeMultipathDegraded
+        exp_alerts: []
+
+  # -----------------------------------------------------------------------
+  # CSIVolumeMultipathLost
+  # -----------------------------------------------------------------------
+
+  # Alert must fire after 1m when all paths are down
+  - interval: 1m
+    input_series:
+      - series: 'kube_persistentvolume_info{persistentvolume="pvc-abc",csi_volume_handle="vol-handle-1"}'
+        values: "1x10"
+      - series: 'csi_volume_node_device_info{node="node-1",volume_handle="vol-handle-1",driver="csi.example.com",device="dm-0"}'
+        values: "1x10"
+      - series: 'node_dmmultipath_device_info{sysfs_name="dm-0",device="mpathA",node="node-1",uuid="mpath-123"}'
+        values: "1x10"
+      - series: 'node_dmmultipath_device_paths_active{device="mpathA",sysfs_name="dm-0",node="node-1"}'
+        values: "0x10"
+
+    alert_rule_test:
+      # must not fire before 1m for: duration
+      - eval_time: 0m
+        alertname: CSIVolumeMultipathLost
+        exp_alerts: []
+      # must fire after 1m
+      - eval_time: 2m
+        alertname: CSIVolumeMultipathLost
+        exp_alerts:
+          - exp_annotations:
+              summary: "PV pvc-abc on node-1 has lost all multipath paths (device mpathA)"
+              description: "All paths to the multipath device are down. I/O is likely failing. Immediate investigation of storage connectivity on node node-1 is required."
+              runbook_url: "https://github.com/csi-addons/kubernetes-csi-addons/blob/main/docs/csi-volume-device-exporter/runbooks/CSIVolumeMultipathLost.md"
+            exp_labels:
+              severity: critical
+              alertname: CSIVolumeMultipathLost
+              persistentvolume: pvc-abc
+              csi_volume_handle: "vol-handle-1"
+              volume_handle: "vol-handle-1"
+              sysfs_name: dm-0
+              node: node-1
+              device: mpathA
+              driver: csi.example.com
+
+  # Alert must not fire when at least one path is active
+  - interval: 1m
+    input_series:
+      - series: 'kube_persistentvolume_info{persistentvolume="pvc-abc",csi_volume_handle="vol-handle-1"}'
+        values: "1x10"
+      - series: 'csi_volume_node_device_info{node="node-1",volume_handle="vol-handle-1",driver="csi.example.com",device="dm-0"}'
+        values: "1x10"
+      - series: 'node_dmmultipath_device_info{sysfs_name="dm-0",device="mpathA",node="node-1",uuid="mpath-123"}'
+        values: "1x10"
+      - series: 'node_dmmultipath_device_paths_active{device="mpathA",sysfs_name="dm-0",node="node-1"}'
+        values: "1x10"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: CSIVolumeMultipathLost
+        exp_alerts: []
+
+  # -----------------------------------------------------------------------
+  # CSIVolumeNVMeSubsystemDegraded
+  # -----------------------------------------------------------------------
+
+  # Alert must fire after 5m when one NVMe controller is not live
+  - interval: 1m
+    input_series:
+      - series: 'kube_persistentvolume_info{persistentvolume="pvc-nvme",csi_volume_handle="vol-nvme-1"}'
+        values: "1x12"
+      - series: 'csi_volume_node_device_info{node="node-1",volume_handle="vol-nvme-1",driver="nvme.csi.example.com",device="nvme0n1"}'
+        values: "1x12"
+      - series: 'node_nvmesubsystem_namespace_info{subsystem="nvme-subsys0",device="nvme0n1",node="node-1"}'
+        values: "1x12"
+      - series: 'node_nvmesubsystem_paths{subsystem="nvme-subsys0"}'
+        values: "2x12"
+      - series: 'node_nvmesubsystem_paths_live{subsystem="nvme-subsys0"}'
+        values: "2 2 1 1 1 1 1 1 1 1 1 1"
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: CSIVolumeNVMeSubsystemDegraded
+        exp_alerts: []
+      - eval_time: 7m
+        alertname: CSIVolumeNVMeSubsystemDegraded
+        exp_alerts:
+          - exp_annotations:
+              summary: "PV pvc-nvme on node-1 has degraded NVMe-oF subsystem (nvme-subsys0)"
+              description: "At least one NVMe-oF controller path is not live. Storage is still accessible via remaining controllers but redundancy is lost."
+              runbook_url: "https://github.com/csi-addons/kubernetes-csi-addons/blob/main/docs/csi-volume-device-exporter/runbooks/CSIVolumeNVMeSubsystemDegraded.md"
+            exp_labels:
+              severity: warning
+              alertname: CSIVolumeNVMeSubsystemDegraded
+              persistentvolume: pvc-nvme
+              csi_volume_handle: "vol-nvme-1"
+              volume_handle: "vol-nvme-1"
+              node: node-1
+              device: nvme0n1
+              driver: nvme.csi.example.com
+              subsystem: nvme-subsys0
+
+  # -----------------------------------------------------------------------
+  # CSIVolumeNVMeSubsystemLost
+  # -----------------------------------------------------------------------
+
+  # Alert must fire after 1m when all NVMe controllers are dead
+  - interval: 1m
+    input_series:
+      - series: 'kube_persistentvolume_info{persistentvolume="pvc-nvme",csi_volume_handle="vol-nvme-1"}'
+        values: "1x10"
+      - series: 'csi_volume_node_device_info{node="node-1",volume_handle="vol-nvme-1",driver="nvme.csi.example.com",device="nvme0n1"}'
+        values: "1x10"
+      - series: 'node_nvmesubsystem_namespace_info{subsystem="nvme-subsys0",device="nvme0n1",node="node-1"}'
+        values: "1x10"
+      - series: 'node_nvmesubsystem_paths{subsystem="nvme-subsys0"}'
+        values: "2x10"
+      - series: 'node_nvmesubsystem_paths_live{subsystem="nvme-subsys0"}'
+        values: "0x10"
+
+    alert_rule_test:
+      - eval_time: 0m
+        alertname: CSIVolumeNVMeSubsystemLost
+        exp_alerts: []
+      - eval_time: 2m
+        alertname: CSIVolumeNVMeSubsystemLost
+        exp_alerts:
+          - exp_annotations:
+              summary: "PV pvc-nvme on node-1 has lost all NVMe-oF controller paths (nvme-subsys0)"
+              description: "All NVMe-oF controller paths are dead. I/O is likely failing. Immediate investigation of storage connectivity on node node-1 is required."
+              runbook_url: "https://github.com/csi-addons/kubernetes-csi-addons/blob/main/docs/csi-volume-device-exporter/runbooks/CSIVolumeNVMeSubsystemLost.md"
+            exp_labels:
+              severity: critical
+              alertname: CSIVolumeNVMeSubsystemLost
+              persistentvolume: pvc-nvme
+              csi_volume_handle: "vol-nvme-1"
+              volume_handle: "vol-nvme-1"
+              node: node-1
+              device: nvme0n1
+              driver: nvme.csi.example.com
+              subsystem: nvme-subsys0
+
+  # Alert must not fire when at least one controller is live
+  - interval: 1m
+    input_series:
+      - series: 'kube_persistentvolume_info{persistentvolume="pvc-nvme",csi_volume_handle="vol-nvme-1"}'
+        values: "1x10"
+      - series: 'csi_volume_node_device_info{node="node-1",volume_handle="vol-nvme-1",driver="nvme.csi.example.com",device="nvme0n1"}'
+        values: "1x10"
+      - series: 'node_nvmesubsystem_namespace_info{subsystem="nvme-subsys0",device="nvme0n1",node="node-1"}'
+        values: "1x10"
+      - series: 'node_nvmesubsystem_paths{subsystem="nvme-subsys0"}'
+        values: "2x10"
+      - series: 'node_nvmesubsystem_paths_live{subsystem="nvme-subsys0"}'
+        values: "1x10"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: CSIVolumeNVMeSubsystemLost
+        exp_alerts: []
+
+  # -----------------------------------------------------------------------
+  # CSIVolumeDeviceExporterDown
+  # -----------------------------------------------------------------------
+
+  # Alert must not fire when targets are being scraped successfully
+  - interval: 1m
+    input_series:
+      - series: 'up{job="csi-volume-device-exporter",instance="node-1:9091"}'
+        values: "1x10"
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: CSIVolumeDeviceExporterDown
+        exp_alerts: []
+
+  # Alert must not fire before the 5m `for:` duration elapses, must fire
+  # once 5m of absent targets have elapsed, and must clear when targets return.
+  - interval: 1m
+    input_series:
+      # no targets for first 7 minutes, then a target reappears
+      - series: 'up{job="csi-volume-device-exporter",instance="node-1:9091"}'
+        values: "_ _ _ _ _ _ _ 1 1 1 1"
+
+    alert_rule_test:
+      # must not fire before 5m of absence
+      - eval_time: 4m
+        alertname: CSIVolumeDeviceExporterDown
+        exp_alerts: []
+      # must fire after 5m of no targets
+      - eval_time: 6m
+        alertname: CSIVolumeDeviceExporterDown
+        exp_alerts:
+          - exp_annotations:
+              summary: "CSI volume device exporter is not running"
+              description: "No csi-volume-device-exporter targets have been scraped for 5 minutes. Storage path health for CSI volumes cannot be reported."
+              runbook_url: "https://github.com/csi-addons/kubernetes-csi-addons/blob/main/docs/csi-volume-device-exporter/runbooks/CSIVolumeDeviceExporterDown.md"
+            exp_labels:
+              severity: warning
+              operator_health_impact: warning
+              alertname: CSIVolumeDeviceExporterDown
+              job: csi-volume-device-exporter
+      # must clear once a target reappears (absent() becomes false immediately)
+      - eval_time: 8m
+        alertname: CSIVolumeDeviceExporterDown
+        exp_alerts: []

--- a/hack/prom-rule-ci/rule-spec-dumper.go
+++ b/hack/prom-rule-ci/rule-spec-dumper.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// rule-spec-dumper writes the Prometheus rule groups to a file so that
+// verify-rules.sh can pass them to promtool for linting and unit testing.
+//
+// Usage: rule-spec-dumper <output-file>
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/csi-addons/kubernetes-csi-addons/internal/exporter/monitoring/rules"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: rule-spec-dumper <output-file>\n")
+		os.Exit(1)
+	}
+	if err := rules.WritePrometheusRulesFile(os.Args[1]); err != nil {
+		fmt.Fprintf(os.Stderr, "rule-spec-dumper: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/hack/prom-rule-ci/verify-rules.sh
+++ b/hack/prom-rule-ci/verify-rules.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+CRI="${CRI:-podman}"
+PROM_IMAGE="${PROM_IMAGE:-quay.io/prometheus/prometheus:v2.53.0}"
+TESTS_FILE="${SCRIPT_DIR}/prom-rules-tests.yaml"
+
+function cleanup() {
+    rm -f "${target_file}"
+}
+
+function lint() {
+    local target_file="${1}"
+    ${CRI} run --rm --entrypoint=/bin/promtool \
+        -v "${target_file}":/tmp/rules.verify:ro,Z \
+        "${PROM_IMAGE}" \
+        check rules /tmp/rules.verify
+}
+
+function unit_test() {
+    local target_file="${1}"
+    ${CRI} run --rm --entrypoint=/bin/promtool \
+        -v "${TESTS_FILE}":/tmp/rules.test:ro,Z \
+        -v "${target_file}":/tmp/rules.verify:ro,Z \
+        "${PROM_IMAGE}" \
+        test rules /tmp/rules.test
+}
+
+target_file="$(mktemp --tmpdir -u tmp.prom_rules.XXXXX)"
+trap cleanup EXIT INT TERM
+
+go run "${SCRIPT_DIR}/rule-spec-dumper.go" "${target_file}"
+
+echo "INFO: generated rules written to ${target_file}"
+lint "${target_file}"
+unit_test "${target_file}"

--- a/internal/exporter/discovery/discovery.go
+++ b/internal/exporter/discovery/discovery.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package discovery implements CSI volume-to-device mapping discovery.
+package discovery
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrMissingFields indicates a file was parsed but required fields were empty.
+var ErrMissingFields = errors.New("missing required fields")
+
+// VolumeDevice represents a discovered CSI volume mapped to a node block device.
+type VolumeDevice struct {
+	VolumeHandle string
+	Driver       string
+	Device       string
+	Node         string
+}
+
+// Discoverer discovers CSI volume-to-device mappings on the local node.
+type Discoverer interface {
+	Name() string
+	Discover(ctx context.Context) ([]VolumeDevice, error)
+}

--- a/internal/exporter/discovery/hpe.go
+++ b/internal/exporter/discovery/hpe.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// HPEDiscoverer implements discovery by reading HPE's deviceInfo.json files.
+type HPEDiscoverer struct {
+	kubeletRoot string
+	sysPath     string
+	nodeName    string
+	logger      *slog.Logger
+}
+
+// NewHPEDiscoverer creates an HPE discoverer.
+func NewHPEDiscoverer(kubeletRoot, sysPath, nodeName string, logger *slog.Logger) *HPEDiscoverer {
+	return &HPEDiscoverer{
+		kubeletRoot: kubeletRoot,
+		sysPath:     sysPath,
+		nodeName:    nodeName,
+		logger:      logger,
+	}
+}
+
+// Name implements Discoverer.
+func (d *HPEDiscoverer) Name() string { return "hpe" }
+
+// Discover implements Discoverer.
+func (d *HPEDiscoverer) Discover(ctx context.Context) ([]VolumeDevice, error) {
+	csiPluginDir := filepath.Join(d.kubeletRoot, "plugins", "kubernetes.io", "csi")
+	entries, err := os.ReadDir(csiPluginDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			d.logger.Debug("kubelet CSI plugin dir not found, no HPE volumes to discover",
+				"path", csiPluginDir)
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var results []VolumeDevice
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return results, ctx.Err()
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		pvDir := filepath.Join(csiPluginDir, entry.Name())
+		deviceInfoPath := filepath.Join(pvDir, "globalmount", "deviceInfo.json")
+
+		vd, err := d.parseDeviceInfo(deviceInfoPath)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				d.logger.Warn("failed to parse HPE deviceInfo",
+					"path", deviceInfoPath, "error", err)
+			}
+			continue
+		}
+
+		results = append(results, *vd)
+	}
+	return results, nil
+}
+
+type hpeDeviceInfo struct {
+	VolumeID string `json:"volume_id"`
+	Device   struct {
+		AltFullPathName string `json:"alt_full_path_name"`
+	} `json:"device"`
+}
+
+func (d *HPEDiscoverer) parseDeviceInfo(path string) (*VolumeDevice, error) {
+	data, err := readFileLimited(path, maxJSONFileSize)
+	if err != nil {
+		return nil, err
+	}
+
+	var info hpeDeviceInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, err
+	}
+
+	if info.VolumeID == "" || info.Device.AltFullPathName == "" {
+		return nil, ErrMissingFields
+	}
+
+	device := filepath.Base(info.Device.AltFullPathName)
+	if strings.HasPrefix(device, "dm-") {
+		device = ResolveLUKSUnderlyingDevice(d.sysPath, device)
+	}
+
+	return &VolumeDevice{
+		VolumeHandle: info.VolumeID,
+		Driver:       "csi.hpe.com",
+		Device:       device,
+		Node:         d.nodeName,
+	}, nil
+}

--- a/internal/exporter/discovery/hpe_test.go
+++ b/internal/exporter/discovery/hpe_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHPEDiscoverer_NoDirReturnsEmpty(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	d := NewHPEDiscoverer("/nonexistent", "/fake/sys", "node1", logger)
+
+	results, err := d.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results, got %d", len(results))
+	}
+}
+
+func TestHPEDiscoverer_ParsesDeviceInfo(t *testing.T) {
+	kubeletRoot := t.TempDir()
+	sysPath := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	pvDir := filepath.Join(kubeletRoot, "plugins", "kubernetes.io", "csi", "pvc-hpe-001", "globalmount")
+	if err := os.MkdirAll(pvDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := `{
+  "volume_id": "hpe-vol-123",
+  "device": {
+    "alt_full_path_name": "/dev/dm-7"
+  }
+}`
+	if err := os.WriteFile(filepath.Join(pvDir, "deviceInfo.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	setupSysForDM(t, sysPath, "dm-7", "mpath-hpe")
+
+	d := NewHPEDiscoverer(kubeletRoot, sysPath, "node1", logger)
+	results, err := d.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].VolumeHandle != "hpe-vol-123" {
+		t.Errorf("expected volume handle hpe-vol-123, got %s", results[0].VolumeHandle)
+	}
+	if results[0].Device != "dm-7" {
+		t.Errorf("expected device dm-7, got %s", results[0].Device)
+	}
+	if results[0].Driver != "csi.hpe.com" {
+		t.Errorf("expected driver csi.hpe.com, got %s", results[0].Driver)
+	}
+}
+
+func TestHPEDiscoverer_SkipsMissingFields(t *testing.T) {
+	kubeletRoot := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	pvDir := filepath.Join(kubeletRoot, "plugins", "kubernetes.io", "csi", "pvc-empty", "globalmount")
+	if err := os.MkdirAll(pvDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := `{"volume_id": "", "device": {"alt_full_path_name": ""}}`
+	if err := os.WriteFile(filepath.Join(pvDir, "deviceInfo.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewHPEDiscoverer(kubeletRoot, "/fake/sys", "node1", logger)
+	results, err := d.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}

--- a/internal/exporter/discovery/kubelet.go
+++ b/internal/exporter/discovery/kubelet.go
@@ -1,0 +1,339 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/moby/sys/mountinfo"
+	"golang.org/x/sys/unix"
+)
+
+// KubeletDiscoverer implements universal discovery using vol_data.json + mountinfo.
+type KubeletDiscoverer struct {
+	// containerKubeletRoot is the path where host kubelet root is mounted inside the container
+	// (e.g., /host/kubelet). Used for reading files.
+	containerKubeletRoot string
+	// hostKubeletRoot is the actual kubelet root path on the host
+	// (e.g., /var/lib/kubelet). Used for matching mountinfo entries.
+	hostKubeletRoot string
+	procPath        string
+	sysPath         string
+	nodeName        string
+	logger          *slog.Logger
+	publishPattern  *regexp.Regexp
+}
+
+type volDataIndex struct {
+	byDir       map[string]*volData
+	bySpecVolID map[string]*volData
+}
+
+// NewKubeletDiscoverer creates a universal kubelet discoverer.
+// containerKubeletRoot is where kubelet data is accessible inside the container.
+// hostKubeletRoot is the real path on the host (for matching mountinfo).
+func NewKubeletDiscoverer(containerKubeletRoot, hostKubeletRoot, procPath, sysPath, nodeName string, logger *slog.Logger) *KubeletDiscoverer {
+	pattern := regexp.MustCompile(
+		regexp.QuoteMeta(hostKubeletRoot) + `/pods/[^/]+/volumes/kubernetes\.io~csi/([^/]+)/mount`,
+	)
+	return &KubeletDiscoverer{
+		containerKubeletRoot: containerKubeletRoot,
+		hostKubeletRoot:      hostKubeletRoot,
+		procPath:             procPath,
+		sysPath:              sysPath,
+		nodeName:             nodeName,
+		logger:               logger,
+		publishPattern:       pattern,
+	}
+}
+
+// Name implements Discoverer.
+func (d *KubeletDiscoverer) Name() string { return "kubelet" }
+
+// Discover implements Discoverer.
+func (d *KubeletDiscoverer) Discover(ctx context.Context) ([]VolumeDevice, error) {
+	mounts, err := ParseMountInfo(d.procPath)
+	if err != nil {
+		return nil, fmt.Errorf("parse mountinfo: %w", err)
+	}
+
+	idx, parseErrors := d.buildVolDataIndex()
+	if parseErrors > 0 {
+		d.logger.Warn("some vol_data.json files could not be parsed; those volumes will be missing from metrics",
+			"count", parseErrors)
+	}
+	if idx == nil {
+		idx = &volDataIndex{
+			byDir:       make(map[string]*volData),
+			bySpecVolID: make(map[string]*volData),
+		}
+	}
+
+	// seen deduplicates across all sub-discoverers: globalmount, block-device,
+	// and pod publish-mount can all match the same VolumeHandle.
+	seen := make(map[string]struct{})
+	var results []VolumeDevice
+
+	appendUnique := func(vds []VolumeDevice) {
+		for _, v := range vds {
+			if _, ok := seen[v.VolumeHandle]; ok {
+				continue
+			}
+			seen[v.VolumeHandle] = struct{}{}
+			results = append(results, v)
+		}
+	}
+
+	appendUnique(d.discoverFilesystemVolumes(ctx, mounts, idx))
+
+	if ctx.Err() != nil {
+		return results, ctx.Err()
+	}
+
+	appendUnique(d.discoverBlockVolumes(ctx))
+
+	if ctx.Err() != nil {
+		return results, ctx.Err()
+	}
+
+	appendUnique(d.discoverPublishMountVolumes(ctx, mounts, idx))
+
+	if ctx.Err() != nil && len(results) == 0 {
+		return nil, ctx.Err()
+	}
+	return results, nil
+}
+
+type volData struct {
+	VolumeHandle        string `json:"volumeHandle"`
+	DriverName          string `json:"driverName"`
+	SpecVolID           string `json:"specVolID"`
+	VolumeLifecycleMode string `json:"volumeLifecycleMode"`
+}
+
+// buildVolDataIndex reads all vol_data.json files once and indexes by directory name and specVolID.
+// Uses containerKubeletRoot for file access.
+func (d *KubeletDiscoverer) buildVolDataIndex() (*volDataIndex, int) {
+	csiPluginDir := filepath.Join(d.containerKubeletRoot, "plugins", "kubernetes.io", "csi")
+	driverEntries, err := os.ReadDir(csiPluginDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0
+		}
+		d.logger.Warn("failed to read kubelet CSI plugin dir", "path", csiPluginDir, "error", err)
+		return nil, 0
+	}
+
+	idx := &volDataIndex{
+		byDir:       make(map[string]*volData),
+		bySpecVolID: make(map[string]*volData),
+	}
+	parseErrors := 0
+
+	for _, driverEntry := range driverEntries {
+		if !driverEntry.IsDir() {
+			continue
+		}
+		driverDir := filepath.Join(csiPluginDir, driverEntry.Name())
+		volumeEntries, err := os.ReadDir(driverDir)
+		if err != nil {
+			continue
+		}
+		for _, volEntry := range volumeEntries {
+			if !volEntry.IsDir() {
+				continue
+			}
+			pvDir := filepath.Join(driverDir, volEntry.Name())
+			vd, err := readVolData(pvDir)
+			if err != nil {
+				parseErrors++
+				d.logger.Warn("failed to parse vol_data.json", "dir", pvDir, "error", err)
+				continue
+			}
+			key := filepath.Join(driverEntry.Name(), volEntry.Name())
+			idx.byDir[key] = vd
+			if vd.SpecVolID != "" {
+				idx.bySpecVolID[vd.SpecVolID] = vd
+			}
+		}
+	}
+	return idx, parseErrors
+}
+
+// discoverFilesystemVolumes uses hostKubeletRoot for mountinfo matching.
+func (d *KubeletDiscoverer) discoverFilesystemVolumes(ctx context.Context, mounts []*mountinfo.Info, idx *volDataIndex) []VolumeDevice {
+	hostCSIDir := filepath.Join(d.hostKubeletRoot, "plugins", "kubernetes.io", "csi")
+
+	var results []VolumeDevice
+	for dirName, vd := range idx.byDir {
+		if ctx.Err() != nil {
+			return results
+		}
+		if vd.VolumeLifecycleMode == "Ephemeral" {
+			continue
+		}
+
+		hostGlobalMount := filepath.Join(hostCSIDir, dirName, "globalmount")
+		mount := FindMountUnder(mounts, hostGlobalMount)
+		if mount == nil {
+			continue
+		}
+		if IsNetworkFS(mount.FSType) {
+			continue
+		}
+
+		device, err := d.resolveDevice(mount.Major, mount.Minor)
+		if err != nil {
+			d.logger.Warn("device resolution failed",
+				"volume_handle", vd.VolumeHandle,
+				"major", mount.Major,
+				"minor", mount.Minor,
+				"error", err)
+			continue
+		}
+
+		results = append(results, VolumeDevice{
+			VolumeHandle: vd.VolumeHandle,
+			Driver:       vd.DriverName,
+			Device:       device,
+			Node:         d.nodeName,
+		})
+	}
+	return results
+}
+
+// discoverBlockVolumes uses containerKubeletRoot for file access.
+func (d *KubeletDiscoverer) discoverBlockVolumes(ctx context.Context) []VolumeDevice {
+	blockDir := filepath.Join(d.containerKubeletRoot, "plugins", "kubernetes.io", "csi", "volumeDevices")
+	entries, err := os.ReadDir(blockDir)
+	if err != nil {
+		return nil
+	}
+
+	var results []VolumeDevice
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return results
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		pvDir := filepath.Join(blockDir, entry.Name())
+		vd, err := readVolData(pvDir)
+		if err != nil {
+			continue
+		}
+		if vd.VolumeLifecycleMode == "Ephemeral" {
+			continue
+		}
+
+		devFile := filepath.Join(pvDir, "dev", vd.SpecVolID)
+		var stat unix.Stat_t
+		if err := unix.Stat(devFile, &stat); err != nil {
+			continue
+		}
+		major := unix.Major(stat.Rdev)
+		minor := unix.Minor(stat.Rdev)
+
+		device, err := d.resolveDevice(int(major), int(minor))
+		if err != nil {
+			continue
+		}
+
+		results = append(results, VolumeDevice{
+			VolumeHandle: vd.VolumeHandle,
+			Driver:       vd.DriverName,
+			Device:       device,
+			Node:         d.nodeName,
+		})
+	}
+	return results
+}
+
+// discoverPublishMountVolumes uses hostKubeletRoot for mountinfo matching (via publishPattern).
+func (d *KubeletDiscoverer) discoverPublishMountVolumes(ctx context.Context, mounts []*mountinfo.Info, idx *volDataIndex) []VolumeDevice {
+	var results []VolumeDevice
+
+	for _, m := range mounts {
+		if ctx.Err() != nil {
+			return results
+		}
+		matches := d.publishPattern.FindStringSubmatch(m.Mountpoint)
+		if matches == nil {
+			continue
+		}
+		if IsNetworkFS(m.FSType) {
+			continue
+		}
+
+		specVolID := matches[1]
+		vd := idx.bySpecVolID[specVolID]
+		if vd == nil {
+			vd = idx.byDir[specVolID]
+		}
+		if vd == nil {
+			continue
+		}
+
+		device, err := d.resolveDevice(m.Major, m.Minor)
+		if err != nil {
+			continue
+		}
+
+		results = append(results, VolumeDevice{
+			VolumeHandle: vd.VolumeHandle,
+			Driver:       vd.DriverName,
+			Device:       device,
+			Node:         d.nodeName,
+		})
+	}
+	return results
+}
+
+func readVolData(pvDir string) (*volData, error) {
+	data, err := readFileLimited(filepath.Join(pvDir, "vol_data.json"), maxJSONFileSize)
+	if err != nil {
+		return nil, err
+	}
+	var vd volData
+	if err := json.Unmarshal(data, &vd); err != nil {
+		return nil, err
+	}
+	if vd.VolumeHandle == "" || vd.DriverName == "" {
+		return nil, ErrMissingFields
+	}
+	return &vd, nil
+}
+
+func (d *KubeletDiscoverer) resolveDevice(major, minor int) (string, error) {
+	device, err := ResolveDeviceName(d.sysPath, uint32(major), uint32(minor))
+	if err != nil {
+		return "", err
+	}
+	if strings.HasPrefix(device, "dm-") {
+		resolved := ResolveLUKSUnderlyingDevice(d.sysPath, device)
+		return resolved, nil
+	}
+	return device, nil
+}

--- a/internal/exporter/discovery/kubelet_test.go
+++ b/internal/exporter/discovery/kubelet_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKubeletDiscoverer_FilesystemVolume(t *testing.T) {
+	tmpDir := t.TempDir()
+	kubeletRoot := filepath.Join(tmpDir, "kubelet")
+	procDir := filepath.Join(tmpDir, "proc")
+	sysDir := filepath.Join(tmpDir, "sys")
+
+	driverName := "csi-powerstore.dellemc.com"
+	pvName := "pvc-vol-001"
+	pvDir := filepath.Join(kubeletRoot, "plugins", "kubernetes.io", "csi", driverName, pvName)
+	globalMount := filepath.Join(pvDir, "globalmount")
+	if err := os.MkdirAll(globalMount, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	vd := volData{
+		VolumeHandle:        "csi-vol-handle-001",
+		DriverName:          driverName,
+		SpecVolID:           pvName,
+		VolumeLifecycleMode: "Persistent",
+	}
+	data, _ := json.Marshal(vd)
+	if err := os.WriteFile(filepath.Join(pvDir, "vol_data.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(procDir, "1"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	mountinfoContent := fmt.Sprintf(
+		"36 35 253:5 / %s rw,relatime shared:1 - ext4 /dev/dm-5 rw\n",
+		globalMount,
+	)
+	if err := os.WriteFile(filepath.Join(procDir, "1", "mountinfo"), []byte(mountinfoContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	devBlockDir := filepath.Join(sysDir, "dev", "block")
+	if err := os.MkdirAll(devBlockDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../../devices/virtual/block/dm-5", filepath.Join(devBlockDir, "253:5")); err != nil {
+		t.Fatal(err)
+	}
+	dmUUIDDir := filepath.Join(sysDir, "block", "dm-5", "dm")
+	if err := os.MkdirAll(dmUUIDDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dmUUIDDir, "uuid"), []byte("mpath-abc\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	d := NewKubeletDiscoverer(kubeletRoot, kubeletRoot, procDir, sysDir, "worker-1", logger)
+
+	results, err := d.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	r := results[0]
+	if r.VolumeHandle != "csi-vol-handle-001" {
+		t.Errorf("expected volume_handle csi-vol-handle-001, got %s", r.VolumeHandle)
+	}
+	if r.Driver != "csi-powerstore.dellemc.com" {
+		t.Errorf("expected driver csi-powerstore.dellemc.com, got %s", r.Driver)
+	}
+	if r.Device != "dm-5" {
+		t.Errorf("expected device dm-5, got %s", r.Device)
+	}
+	if r.Node != "worker-1" {
+		t.Errorf("expected node worker-1, got %s", r.Node)
+	}
+}
+
+func TestKubeletDiscoverer_SkipsEphemeral(t *testing.T) {
+	tmpDir := t.TempDir()
+	kubeletRoot := filepath.Join(tmpDir, "kubelet")
+	procDir := filepath.Join(tmpDir, "proc")
+	sysDir := filepath.Join(tmpDir, "sys")
+
+	pvDir := filepath.Join(kubeletRoot, "plugins", "kubernetes.io", "csi", "csi.example.com", "ephemeral-vol")
+	if err := os.MkdirAll(filepath.Join(pvDir, "globalmount"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	vd := volData{
+		VolumeHandle:        "pod-uid-123",
+		DriverName:          "csi.example.com",
+		SpecVolID:           "ephemeral-vol",
+		VolumeLifecycleMode: "Ephemeral",
+	}
+	data, _ := json.Marshal(vd)
+	if err := os.WriteFile(filepath.Join(pvDir, "vol_data.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(procDir, "1"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(procDir, "1", "mountinfo"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	d := NewKubeletDiscoverer(kubeletRoot, kubeletRoot, procDir, sysDir, "worker-1", logger)
+
+	results, err := d.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for ephemeral volume, got %d", len(results))
+	}
+}
+
+func TestKubeletDiscoverer_SkipsNFS(t *testing.T) {
+	tmpDir := t.TempDir()
+	kubeletRoot := filepath.Join(tmpDir, "kubelet")
+	procDir := filepath.Join(tmpDir, "proc")
+	sysDir := filepath.Join(tmpDir, "sys")
+
+	pvDir := filepath.Join(kubeletRoot, "plugins", "kubernetes.io", "csi", "nfs.csi.k8s.io", "nfs-vol")
+	globalMount := filepath.Join(pvDir, "globalmount")
+	if err := os.MkdirAll(globalMount, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	vd := volData{
+		VolumeHandle: "nfs-handle",
+		DriverName:   "nfs.csi.k8s.io",
+		SpecVolID:    "nfs-vol",
+	}
+	data, _ := json.Marshal(vd)
+	if err := os.WriteFile(filepath.Join(pvDir, "vol_data.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(procDir, "1"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	mountinfoContent := fmt.Sprintf(
+		"36 35 0:0 / %s rw,relatime shared:1 - nfs4 server:/export rw\n",
+		globalMount,
+	)
+	if err := os.WriteFile(filepath.Join(procDir, "1", "mountinfo"), []byte(mountinfoContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	d := NewKubeletDiscoverer(kubeletRoot, kubeletRoot, procDir, sysDir, "worker-1", logger)
+
+	results, err := d.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for NFS volume, got %d", len(results))
+	}
+}
+
+func TestKubeletDiscoverer_SeparateContainerAndHostPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	containerRoot := filepath.Join(tmpDir, "container-kubelet")
+	hostRoot := filepath.Join(tmpDir, "host-kubelet")
+
+	procDir := filepath.Join(tmpDir, "proc")
+	sysDir := filepath.Join(tmpDir, "sys")
+
+	driverName := "csi.example.com"
+	pvName := "pvc-split-test"
+
+	pvDir := filepath.Join(containerRoot, "plugins", "kubernetes.io", "csi", driverName, pvName)
+	if err := os.MkdirAll(filepath.Join(pvDir, "globalmount"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	vd := volData{
+		VolumeHandle:        "split-vol-handle",
+		DriverName:          driverName,
+		SpecVolID:           pvName,
+		VolumeLifecycleMode: "Persistent",
+	}
+	data, _ := json.Marshal(vd)
+	if err := os.WriteFile(filepath.Join(pvDir, "vol_data.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hostGlobalMount := filepath.Join(hostRoot, "plugins", "kubernetes.io", "csi", driverName, pvName, "globalmount")
+	if err := os.MkdirAll(filepath.Join(procDir, "1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mountinfoContent := fmt.Sprintf(
+		"36 35 8:16 / %s rw,relatime shared:1 - ext4 /dev/sdb rw\n",
+		hostGlobalMount,
+	)
+	if err := os.WriteFile(filepath.Join(procDir, "1", "mountinfo"), []byte(mountinfoContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	devBlockDir := filepath.Join(sysDir, "dev", "block")
+	if err := os.MkdirAll(devBlockDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../../block/sdb", filepath.Join(devBlockDir, "8:16")); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	d := NewKubeletDiscoverer(containerRoot, hostRoot, procDir, sysDir, "node-split", logger)
+
+	results, err := d.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result with separate container/host paths, got %d", len(results))
+	}
+	if results[0].Device != "sdb" {
+		t.Errorf("expected device sdb, got %s", results[0].Device)
+	}
+	if results[0].Node != "node-split" {
+		t.Errorf("expected node node-split, got %s", results[0].Node)
+	}
+}

--- a/internal/exporter/discovery/mountinfo.go
+++ b/internal/exporter/discovery/mountinfo.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/moby/sys/mountinfo"
+)
+
+// ParseMountInfo reads and parses /proc/1/mountinfo from the given procfs path.
+func ParseMountInfo(procPath string) ([]*mountinfo.Info, error) {
+	f, err := os.Open(filepath.Join(procPath, "1", "mountinfo"))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return mountinfo.GetMountsFromReader(f, nil)
+}
+
+// FindMountByMountpoint returns the mount entry matching the given mountpoint exactly.
+func FindMountByMountpoint(mounts []*mountinfo.Info, mountpoint string) *mountinfo.Info {
+	for _, m := range mounts {
+		if m.Mountpoint == mountpoint {
+			return m
+		}
+	}
+	return nil
+}
+
+// FindMountUnder returns the first mount whose mountpoint is exactly dir or
+// is a direct child of dir. This handles CSI drivers (e.g. Ceph RBD) that
+// stage the block device under a subdirectory of the globalmount path, such
+// as: .../globalmount/<volumeHandle>
+func FindMountUnder(mounts []*mountinfo.Info, dir string) *mountinfo.Info {
+	prefix := dir + "/"
+	for _, m := range mounts {
+		if m.Mountpoint == dir || (len(m.Mountpoint) > len(prefix) &&
+			m.Mountpoint[:len(prefix)] == prefix &&
+			!strings.Contains(m.Mountpoint[len(prefix):], "/")) {
+			return m
+		}
+	}
+	return nil
+}
+
+// IsNetworkFS returns true if the filesystem type is a network filesystem (NFS, CIFS, etc.).
+func IsNetworkFS(fsType string) bool {
+	switch fsType {
+	case "nfs", "nfs4", "cifs", "smbfs", "glusterfs", "ceph", "lustre", "9p":
+		return true
+	}
+	return false
+}

--- a/internal/exporter/discovery/mountinfo_test.go
+++ b/internal/exporter/discovery/mountinfo_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const testMountInfo = `22 1 8:1 / / rw,relatime - ext4 /dev/sda1 rw
+30 22 0:26 / /sys rw,nosuid,nodev,noexec,relatime - sysfs sysfs rw
+50 22 253:5 / /var/lib/kubelet/plugins/kubernetes.io/csi/pvc-abc/globalmount rw,relatime - ext4 /dev/dm-5 rw
+60 22 0:60 / /var/lib/kubelet/pods/pod-123/volumes/kubernetes.io~csi/pvc-def/mount rw - nfs4 10.0.0.1:/export rw
+70 22 253:6 / /var/lib/kubelet/pods/pod-456/volumes/kubernetes.io~csi/pvc-ghi/mount rw,relatime - xfs /dev/dm-6 rw
+`
+
+func TestParseMountInfo(t *testing.T) {
+	procPath := t.TempDir()
+	pid1Dir := filepath.Join(procPath, "1")
+	if err := os.MkdirAll(pid1Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pid1Dir, "mountinfo"), []byte(testMountInfo), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mounts, err := ParseMountInfo(procPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mounts) == 0 {
+		t.Fatal("expected mounts, got none")
+	}
+}
+
+func TestFindMountByMountpoint(t *testing.T) {
+	procPath := t.TempDir()
+	pid1Dir := filepath.Join(procPath, "1")
+	if err := os.MkdirAll(pid1Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pid1Dir, "mountinfo"), []byte(testMountInfo), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mounts, err := ParseMountInfo(procPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := FindMountByMountpoint(mounts, "/var/lib/kubelet/plugins/kubernetes.io/csi/pvc-abc/globalmount")
+	if m == nil {
+		t.Fatal("expected to find mount")
+	}
+	if m.Major != 253 || m.Minor != 5 {
+		t.Errorf("expected 253:5, got %d:%d", m.Major, m.Minor)
+	}
+
+	m2 := FindMountByMountpoint(mounts, "/nonexistent")
+	if m2 != nil {
+		t.Error("expected nil for non-existent mountpoint")
+	}
+}
+
+func TestIsNetworkFS(t *testing.T) {
+	tests := []struct {
+		fsType string
+		want   bool
+	}{
+		{"nfs", true},
+		{"nfs4", true},
+		{"cifs", true},
+		{"ext4", false},
+		{"xfs", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := IsNetworkFS(tt.fsType); got != tt.want {
+			t.Errorf("IsNetworkFS(%q) = %v, want %v", tt.fsType, got, tt.want)
+		}
+	}
+}

--- a/internal/exporter/discovery/sysfs.go
+++ b/internal/exporter/discovery/sysfs.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// maxSysfsFileSize limits reads from sysfs pseudo-files (e.g. dm/uuid).
+const maxSysfsFileSize = 256
+
+// ResolveDeviceName resolves a major:minor pair to a kernel block device name
+// by reading the symlink at /sys/dev/block/{major}:{minor}.
+func ResolveDeviceName(sysPath string, major, minor uint32) (string, error) {
+	link := filepath.Join(sysPath, "dev", "block", fmt.Sprintf("%d:%d", major, minor))
+	target, err := os.Readlink(link)
+	if err != nil {
+		return "", fmt.Errorf("readlink %s: %w", link, err)
+	}
+	return filepath.Base(target), nil
+}
+
+// maxDMDepth limits recursion depth to prevent stack overflow from circular sysfs links.
+const maxDMDepth = 16
+
+// ResolveLUKSUnderlyingDevice walks the DM slave chain to find the storage
+// device that should be reported in the metric. The walk stops (returns the
+// device as-is) when it encounters:
+//   - a multipath device (dm/uuid starts with "mpath-") — this is the
+//     correct device to report because node_dmmultipath_path_state tracks it
+//   - a physical block device (any non-dm- slave)
+//   - the recursion depth limit
+//
+// This is intended for LUKS-over-multipath stacks where the CSI driver
+// stages a LUKS dm device on top of a multipath dm device. Passing a plain
+// multipath dm-X returns it unchanged.
+// If resolution fails at any point, the input device is returned as-is.
+func ResolveLUKSUnderlyingDevice(sysPath string, device string) string {
+	return resolveLUKSDepth(sysPath, device, 0)
+}
+
+func resolveLUKSDepth(sysPath string, device string, depth int) string {
+	if depth >= maxDMDepth {
+		return device
+	}
+	if !strings.HasPrefix(device, "dm-") {
+		return device
+	}
+
+	isMpath, err := isMultipathDevice(sysPath, device)
+	if err != nil {
+		return device
+	}
+	if isMpath {
+		return device
+	}
+
+	slavesDir := filepath.Join(sysPath, "block", device, "slaves")
+	entries, err := os.ReadDir(slavesDir)
+	if err != nil {
+		return device
+	}
+
+	for _, entry := range entries {
+		slave := entry.Name()
+		if isPhysicalBlockDevice(slave) {
+			return slave
+		}
+		if strings.HasPrefix(slave, "dm-") {
+			slaveIsMpath, err := isMultipathDevice(sysPath, slave)
+			if err != nil {
+				continue
+			}
+			if slaveIsMpath {
+				return slave
+			}
+			resolved := resolveLUKSDepth(sysPath, slave, depth+1)
+			if resolved != slave {
+				return resolved
+			}
+		}
+	}
+
+	return device
+}
+
+// isPhysicalBlockDevice returns true if the device name matches a known
+// physical or virtual block device naming convention.
+func isPhysicalBlockDevice(name string) bool {
+	for _, prefix := range []string{
+		"sd",     // SCSI / SAS / iSCSI / FC
+		"nvme",   // NVMe
+		"vd",     // virtio (KVM/QEMU)
+		"xvd",    // Xen paravirt
+		"hd",     // legacy IDE
+		"mmcblk", // eMMC / SD card
+		"sr",     // optical (edge case)
+		"md",     // Linux software RAID
+		"loop",   // loop device
+		"nbd",    // network block device
+	} {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isMultipathDevice(sysPath string, device string) (bool, error) {
+	uuidPath := filepath.Join(sysPath, "block", device, "dm", "uuid")
+	data, err := readFileLimited(uuidPath, maxSysfsFileSize)
+	if err != nil {
+		return false, err
+	}
+	return strings.HasPrefix(strings.TrimSpace(string(data)), "mpath-"), nil
+}

--- a/internal/exporter/discovery/sysfs_test.go
+++ b/internal/exporter/discovery/sysfs_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveDeviceName(t *testing.T) {
+	sysPath := t.TempDir()
+
+	blockDir := filepath.Join(sysPath, "dev", "block")
+	if err := os.MkdirAll(blockDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../../block/dm-5", filepath.Join(blockDir, "253:5")); err != nil {
+		t.Fatal(err)
+	}
+
+	device, err := ResolveDeviceName(sysPath, 253, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if device != "dm-5" {
+		t.Errorf("expected dm-5, got %s", device)
+	}
+}
+
+func TestResolveDeviceName_NotFound(t *testing.T) {
+	sysPath := t.TempDir()
+	_, err := ResolveDeviceName(sysPath, 999, 999)
+	if err == nil {
+		t.Fatal("expected error for non-existent device")
+	}
+}
+
+func TestResolveLUKSUnderlyingDevice_NotDM(t *testing.T) {
+	device := ResolveLUKSUnderlyingDevice("/fake", "sda")
+	if device != "sda" {
+		t.Errorf("expected sda, got %s", device)
+	}
+}
+
+func TestResolveLUKSUnderlyingDevice_MultipathDevice(t *testing.T) {
+	sysPath := t.TempDir()
+
+	dmDir := filepath.Join(sysPath, "block", "dm-0", "dm")
+	if err := os.MkdirAll(dmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dmDir, "uuid"), []byte("mpath-12345\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	device := ResolveLUKSUnderlyingDevice(sysPath, "dm-0")
+	if device != "dm-0" {
+		t.Errorf("expected dm-0 (multipath returned as-is), got %s", device)
+	}
+}
+
+func TestResolveLUKSUnderlyingDevice_LUKSOverMultipath(t *testing.T) {
+	sysPath := t.TempDir()
+
+	luksDir := filepath.Join(sysPath, "block", "dm-1", "dm")
+	if err := os.MkdirAll(luksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(luksDir, "uuid"), []byte("CRYPT-LUKS2-xxx\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	luksSlavesDir := filepath.Join(sysPath, "block", "dm-1", "slaves")
+	if err := os.MkdirAll(luksSlavesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(luksSlavesDir, "dm-0"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mpathDir := filepath.Join(sysPath, "block", "dm-0", "dm")
+	if err := os.MkdirAll(mpathDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mpathDir, "uuid"), []byte("mpath-abcdef\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	device := ResolveLUKSUnderlyingDevice(sysPath, "dm-1")
+	if device != "dm-0" {
+		t.Errorf("expected dm-0 (underlying multipath), got %s", device)
+	}
+}
+
+func TestResolveLUKSUnderlyingDevice_PhysicalSlave(t *testing.T) {
+	sysPath := t.TempDir()
+
+	dmDir := filepath.Join(sysPath, "block", "dm-2", "dm")
+	if err := os.MkdirAll(dmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dmDir, "uuid"), []byte("LVM-xxx\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	slavesDir := filepath.Join(sysPath, "block", "dm-2", "slaves")
+	if err := os.MkdirAll(slavesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(slavesDir, "sda1"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	device := ResolveLUKSUnderlyingDevice(sysPath, "dm-2")
+	if device != "sda1" {
+		t.Errorf("expected sda1, got %s", device)
+	}
+}
+
+func TestResolveLUKSUnderlyingDevice_VirtioSlave(t *testing.T) {
+	sysPath := t.TempDir()
+
+	dmDir := filepath.Join(sysPath, "block", "dm-3", "dm")
+	if err := os.MkdirAll(dmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dmDir, "uuid"), []byte("LVM-virtio\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	slavesDir := filepath.Join(sysPath, "block", "dm-3", "slaves")
+	if err := os.MkdirAll(slavesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(slavesDir, "vda"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	device := ResolveLUKSUnderlyingDevice(sysPath, "dm-3")
+	if device != "vda" {
+		t.Errorf("expected vda (virtio), got %s", device)
+	}
+}

--- a/internal/exporter/discovery/trident.go
+++ b/internal/exporter/discovery/trident.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// TridentDiscoverer implements discovery by reading Trident's tracking JSON files.
+type TridentDiscoverer struct {
+	trackingDir string
+	sysPath     string
+	nodeName    string
+	logger      *slog.Logger
+	disabled    bool
+}
+
+// NewTridentDiscoverer creates a Trident discoverer.
+// The tracking directory is checked once at construction time. If it does not
+// exist, the discoverer is permanently disabled for the lifetime of the process
+// — it will not re-enable if Trident is installed later. Restart the exporter
+// after installing Trident to activate this discoverer.
+func NewTridentDiscoverer(trackingDir, sysPath, nodeName string, logger *slog.Logger) *TridentDiscoverer {
+	d := &TridentDiscoverer{
+		trackingDir: trackingDir,
+		sysPath:     sysPath,
+		nodeName:    nodeName,
+		logger:      logger,
+	}
+	if _, err := os.Stat(trackingDir); os.IsNotExist(err) {
+		logger.Info("trident tracking directory not found, disabling discoverer (restart exporter after installing Trident)", "path", trackingDir)
+		d.disabled = true
+	}
+	return d
+}
+
+// Name implements Discoverer.
+func (d *TridentDiscoverer) Name() string { return "trident" }
+
+// Discover implements Discoverer.
+func (d *TridentDiscoverer) Discover(ctx context.Context) ([]VolumeDevice, error) {
+	if d.disabled {
+		return nil, nil
+	}
+
+	entries, err := os.ReadDir(d.trackingDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var results []VolumeDevice
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			return results, ctx.Err()
+		}
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		volumeID := strings.TrimSuffix(entry.Name(), ".json")
+		filePath := filepath.Join(d.trackingDir, entry.Name())
+
+		device, driver, err := d.parseTrackingFile(filePath)
+		if err != nil {
+			d.logger.Warn("failed to parse trident tracking file",
+				"file", filePath, "error", err)
+			continue
+		}
+
+		results = append(results, VolumeDevice{
+			VolumeHandle: volumeID,
+			Driver:       driver,
+			Device:       device,
+			Node:         d.nodeName,
+		})
+	}
+	return results, nil
+}
+
+type tridentTrackingInfo struct {
+	VolumePublishInfo struct {
+		DevicePath    string `json:"devicePath"`
+		RawDevicePath string `json:"rawDevicePath"`
+	} `json:"volumePublishInfo"`
+	StagingTargetPath string `json:"stagingTargetPath"`
+}
+
+func (d *TridentDiscoverer) parseTrackingFile(filePath string) (device, driver string, err error) {
+	data, err := readFileLimited(filePath, maxJSONFileSize)
+	if err != nil {
+		return "", "", err
+	}
+
+	var info tridentTrackingInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return "", "", err
+	}
+
+	devicePath := info.VolumePublishInfo.DevicePath
+	if devicePath == "" {
+		devicePath = info.VolumePublishInfo.RawDevicePath
+	}
+	if devicePath == "" {
+		return "", "", ErrMissingFields
+	}
+
+	device = filepath.Base(devicePath)
+	if strings.HasPrefix(device, "dm-") {
+		device = ResolveLUKSUnderlyingDevice(d.sysPath, device)
+	}
+
+	return device, "csi.trident.netapp.io", nil
+}

--- a/internal/exporter/discovery/trident_test.go
+++ b/internal/exporter/discovery/trident_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTridentDiscoverer_DisabledWhenDirMissing(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	d := NewTridentDiscoverer("/nonexistent", "/fake/sys", "node1", logger)
+
+	if !d.disabled {
+		t.Fatal("expected discoverer to be disabled when dir is missing")
+	}
+
+	results, err := d.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results, got %d", len(results))
+	}
+}
+
+func TestTridentDiscoverer_ParsesTrackingFile(t *testing.T) {
+	trackingDir := t.TempDir()
+	sysPath := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	content := `{
+  "volumePublishInfo": {
+    "devicePath": "/dev/dm-3"
+  },
+  "stagingTargetPath": "/var/lib/kubelet/plugins/kubernetes.io/csi/pvc-123/globalmount"
+}`
+	if err := os.WriteFile(filepath.Join(trackingDir, "vol-001.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	setupSysForDM(t, sysPath, "dm-3", "mpath-xyz")
+
+	d := NewTridentDiscoverer(trackingDir, sysPath, "node1", logger)
+	results, err := d.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].VolumeHandle != "vol-001" {
+		t.Errorf("expected volume handle vol-001, got %s", results[0].VolumeHandle)
+	}
+	if results[0].Device != "dm-3" {
+		t.Errorf("expected device dm-3, got %s", results[0].Device)
+	}
+	if results[0].Driver != "csi.trident.netapp.io" {
+		t.Errorf("expected driver csi.trident.netapp.io, got %s", results[0].Driver)
+	}
+}
+
+func TestTridentDiscoverer_SkipsEmptyDevicePath(t *testing.T) {
+	trackingDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	content := `{"volumePublishInfo": {}, "stagingTargetPath": "/mnt"}`
+	if err := os.WriteFile(filepath.Join(trackingDir, "vol-empty.json"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	d := NewTridentDiscoverer(trackingDir, "/fake/sys", "node1", logger)
+	results, err := d.Discover(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for empty device, got %d", len(results))
+	}
+}
+
+func TestTridentDiscoverer_ContextCancelled(t *testing.T) {
+	trackingDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	for i := 0; i < 5; i++ {
+		content := `{"volumePublishInfo": {"devicePath": "/dev/sda"}, "stagingTargetPath": "/mnt"}`
+		name := filepath.Join(trackingDir, "vol-"+string(rune('a'+i))+".json")
+		if err := os.WriteFile(name, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	d := NewTridentDiscoverer(trackingDir, "/fake/sys", "node1", logger)
+	_, err := d.Discover(ctx)
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+func setupSysForDM(t *testing.T, sysPath, device, uuid string) {
+	t.Helper()
+	dmDir := filepath.Join(sysPath, "block", device, "dm")
+	if err := os.MkdirAll(dmDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dmDir, "uuid"), []byte(uuid+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/exporter/discovery/util.go
+++ b/internal/exporter/discovery/util.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// maxJSONFileSize limits the size of JSON files we read to prevent memory exhaustion.
+const maxJSONFileSize = 1 << 20 // 1 MiB
+
+// readFileLimited opens path and reads at most maxBytes bytes.
+// It uses io.LimitReader to bound the read without a separate stat call.
+// Returns an error if the file exceeds maxBytes.
+func readFileLimited(path string, maxBytes int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Read maxBytes+1 so we can detect truncation without a second stat.
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("file %s exceeds size limit of %d bytes", path, maxBytes)
+	}
+	return data, nil
+}

--- a/internal/exporter/monitoring/metrics/metrics.go
+++ b/internal/exporter/monitoring/metrics/metrics.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package metrics provides Prometheus metrics for the CSI volume device exporter.
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/csi-addons/kubernetes-csi-addons/internal/exporter/discovery"
+)
+
+type Metrics struct {
+	volumeDeviceInfo  *prometheus.GaugeVec
+	discoveryDuration *prometheus.HistogramVec
+	discoveryErrors   *prometheus.CounterVec
+	volumesDiscovered *prometheus.GaugeVec
+	lastSuccessful    prometheus.Gauge
+
+	registry *prometheus.Registry
+
+	mu              sync.Mutex
+	previous        map[string]prometheus.Labels
+	previousDrivers map[string]struct{}
+}
+
+func New() *Metrics {
+	reg := prometheus.NewRegistry()
+
+	m := &Metrics{
+		volumeDeviceInfo: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "csi_volume_node_device_info",
+			Help: "Maps CSI volumes to node block devices. Value is always 1.",
+		}, []string{"node", "volume_handle", "driver", "device"}),
+
+		discoveryDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "csi_volume_device_exporter_discovery_duration_seconds",
+			Help:    "Duration of volume discovery by discoverer.",
+			Buckets: prometheus.DefBuckets,
+		}, []string{"discoverer"}),
+
+		discoveryErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "csi_volume_device_exporter_discovery_errors_total",
+			Help: "Total number of discovery errors by discoverer.",
+		}, []string{"discoverer"}),
+
+		volumesDiscovered: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "csi_volume_device_exporter_volumes_discovered",
+			Help: "Number of volumes discovered per driver.",
+		}, []string{"driver"}),
+
+		lastSuccessful: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "csi_volume_device_exporter_last_successful_discovery_timestamp_seconds",
+			Help: "Unix timestamp of last successful discovery cycle.",
+		}),
+
+		registry:        reg,
+		previous:        make(map[string]prometheus.Labels),
+		previousDrivers: make(map[string]struct{}),
+	}
+
+	reg.MustRegister(m.volumeDeviceInfo)
+	reg.MustRegister(m.discoveryDuration)
+	reg.MustRegister(m.discoveryErrors)
+	reg.MustRegister(m.volumesDiscovered)
+	reg.MustRegister(m.lastSuccessful)
+
+	return m
+}
+
+func (m *Metrics) Registry() *prometheus.Registry {
+	return m.registry
+}
+
+func (m *Metrics) ObserveDiscoveryDuration(discoverer string, seconds float64) {
+	m.discoveryDuration.WithLabelValues(discoverer).Observe(seconds)
+}
+
+func (m *Metrics) IncDiscoveryErrors(discoverer string) {
+	m.discoveryErrors.WithLabelValues(discoverer).Inc()
+}
+
+func (m *Metrics) SetLastSuccessfulNow() {
+	m.lastSuccessful.SetToCurrentTime()
+}
+
+func (m *Metrics) Reconcile(volumes map[string]discovery.VolumeDevice) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	current := make(map[string]prometheus.Labels, len(volumes))
+
+	for key, v := range volumes {
+		labels := prometheus.Labels{
+			"node":          v.Node,
+			"volume_handle": v.VolumeHandle,
+			"driver":        v.Driver,
+			"device":        v.Device,
+		}
+		m.volumeDeviceInfo.With(labels).Set(1)
+		current[key] = labels
+	}
+
+	for key, labels := range m.previous {
+		if _, exists := current[key]; !exists {
+			m.volumeDeviceInfo.Delete(labels)
+		}
+	}
+
+	m.previous = current
+
+	driverCounts := make(map[string]float64)
+	for _, v := range volumes {
+		driverCounts[v.Driver]++
+	}
+
+	for driver := range m.previousDrivers {
+		if _, exists := driverCounts[driver]; !exists {
+			m.volumesDiscovered.Delete(prometheus.Labels{"driver": driver})
+		}
+	}
+
+	currentDrivers := make(map[string]struct{}, len(driverCounts))
+	for driver, count := range driverCounts {
+		m.volumesDiscovered.With(prometheus.Labels{"driver": driver}).Set(count)
+		currentDrivers[driver] = struct{}{}
+	}
+	m.previousDrivers = currentDrivers
+}

--- a/internal/exporter/monitoring/metrics/metrics_test.go
+++ b/internal/exporter/monitoring/metrics/metrics_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/csi-addons/kubernetes-csi-addons/internal/exporter/discovery"
+)
+
+func TestReconcile_AddsNewMetrics(t *testing.T) {
+	m := New()
+
+	volumes := map[string]discovery.VolumeDevice{
+		"vol-1": {VolumeHandle: "vol-1", Driver: "csi.trident.netapp.io", Device: "dm-0", Node: "node1"},
+		"vol-2": {VolumeHandle: "vol-2", Driver: "csi.hpe.com", Device: "dm-1", Node: "node1"},
+	}
+
+	m.Reconcile(volumes)
+
+	count := testutil.CollectAndCount(m.volumeDeviceInfo)
+	if count != 2 {
+		t.Errorf("expected 2 metrics, got %d", count)
+	}
+}
+
+func TestReconcile_RemovesStaleSeries(t *testing.T) {
+	m := New()
+
+	volumes1 := map[string]discovery.VolumeDevice{
+		"vol-1": {VolumeHandle: "vol-1", Driver: "driver-a", Device: "sda", Node: "node1"},
+		"vol-2": {VolumeHandle: "vol-2", Driver: "driver-b", Device: "sdb", Node: "node1"},
+	}
+	m.Reconcile(volumes1)
+
+	volumes2 := map[string]discovery.VolumeDevice{
+		"vol-1": {VolumeHandle: "vol-1", Driver: "driver-a", Device: "sda", Node: "node1"},
+	}
+	m.Reconcile(volumes2)
+
+	count := testutil.CollectAndCount(m.volumeDeviceInfo)
+	if count != 1 {
+		t.Errorf("expected 1 metric after stale removal, got %d", count)
+	}
+}
+
+func TestReconcile_HandlesEmptyVolumes(t *testing.T) {
+	m := New()
+
+	volumes := map[string]discovery.VolumeDevice{
+		"vol-1": {VolumeHandle: "vol-1", Driver: "driver-a", Device: "sda", Node: "node1"},
+	}
+	m.Reconcile(volumes)
+
+	m.Reconcile(map[string]discovery.VolumeDevice{})
+
+	count := testutil.CollectAndCount(m.volumeDeviceInfo)
+	if count != 0 {
+		t.Errorf("expected 0 metrics after reconciling empty, got %d", count)
+	}
+}
+
+func TestReconcile_UpdatesVolumesDiscovered(t *testing.T) {
+	m := New()
+
+	volumes := map[string]discovery.VolumeDevice{
+		"vol-1": {VolumeHandle: "vol-1", Driver: "csi.trident.netapp.io", Device: "dm-0", Node: "node1"},
+		"vol-2": {VolumeHandle: "vol-2", Driver: "csi.trident.netapp.io", Device: "dm-1", Node: "node1"},
+		"vol-3": {VolumeHandle: "vol-3", Driver: "csi.hpe.com", Device: "dm-2", Node: "node1"},
+	}
+	m.Reconcile(volumes)
+
+	expected := `
+# HELP csi_volume_device_exporter_volumes_discovered Number of volumes discovered per driver.
+# TYPE csi_volume_device_exporter_volumes_discovered gauge
+csi_volume_device_exporter_volumes_discovered{driver="csi.hpe.com"} 1
+csi_volume_device_exporter_volumes_discovered{driver="csi.trident.netapp.io"} 2
+`
+	if err := testutil.CollectAndCompare(m.volumesDiscovered, strings.NewReader(expected)); err != nil {
+		t.Errorf("unexpected metric output: %v", err)
+	}
+}
+
+func TestMetrics_RegistryNotNil(t *testing.T) {
+	m := New()
+	if m.Registry() == nil {
+		t.Error("registry should not be nil")
+	}
+}
+
+func TestSetLastSuccessfulNow_UpdatesGauge(t *testing.T) {
+	m := New()
+
+	before := time.Now().Unix()
+	m.SetLastSuccessfulNow()
+	after := time.Now().Unix()
+
+	gathered, err := m.registry.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var found bool
+	for _, mf := range gathered {
+		if mf.GetName() == "csi_volume_device_exporter_last_successful_discovery_timestamp_seconds" {
+			found = true
+			v := mf.GetMetric()[0].GetGauge().GetValue()
+			if int64(v) < before || int64(v) > after {
+				t.Errorf("last_successful gauge value %v is outside expected window [%d, %d]", v, before, after)
+			}
+		}
+	}
+	if !found {
+		t.Error("last_successful gauge not found in registry")
+	}
+}
+
+func TestObserveDiscoveryDuration_RecordsHistogram(t *testing.T) {
+	m := New()
+	m.ObserveDiscoveryDuration("kubelet", 0.5)
+	m.ObserveDiscoveryDuration("kubelet", 1.2)
+
+	gathered, err := m.registry.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var found bool
+	for _, mf := range gathered {
+		if mf.GetName() == "csi_volume_device_exporter_discovery_duration_seconds" {
+			found = true
+			if len(mf.GetMetric()) == 0 {
+				t.Error("expected at least one histogram metric")
+			}
+			count := mf.GetMetric()[0].GetHistogram().GetSampleCount()
+			if count != 2 {
+				t.Errorf("expected sample count 2, got %d", count)
+			}
+		}
+	}
+	if !found {
+		t.Error("discovery_duration histogram not found in registry")
+	}
+}
+
+func TestIncDiscoveryErrors_IncrementsCounter(t *testing.T) {
+	m := New()
+	m.IncDiscoveryErrors("trident")
+	m.IncDiscoveryErrors("trident")
+	m.IncDiscoveryErrors("hpe")
+
+	expected := `
+# HELP csi_volume_device_exporter_discovery_errors_total Total number of discovery errors by discoverer.
+# TYPE csi_volume_device_exporter_discovery_errors_total counter
+csi_volume_device_exporter_discovery_errors_total{discoverer="hpe"} 1
+csi_volume_device_exporter_discovery_errors_total{discoverer="trident"} 2
+`
+	if err := testutil.CollectAndCompare(m.discoveryErrors, strings.NewReader(expected)); err != nil {
+		t.Errorf("unexpected metric output: %v", err)
+	}
+}

--- a/internal/exporter/monitoring/rules/alerts/alerts.go
+++ b/internal/exporter/monitoring/rules/alerts/alerts.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package alerts defines Prometheus alert rules for the CSI volume device exporter.
+package alerts
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	runbookAnnotationKey = "runbook_url"
+
+	RunbookURLTemplateEnv = "RUNBOOK_URL_TEMPLATE"
+
+	defaultRunbookURLTemplate = "https://github.com/csi-addons/kubernetes-csi-addons/blob/main/docs/csi-volume-device-exporter/runbooks/%s.md"
+)
+
+func runbookURL(alertName string) string {
+	tpl := os.Getenv(RunbookURLTemplateEnv)
+	if tpl == "" || strings.Count(tpl, "%s") != 1 {
+		tpl = defaultRunbookURLTemplate
+	}
+	return fmt.Sprintf(tpl, alertName)
+}
+
+type Alert struct {
+	Name        string
+	Expr        string
+	For         string
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+func All() []Alert {
+	var all []Alert
+	all = append(all, multipathAlerts()...)
+	all = append(all, nvmeSubsystemAlerts()...)
+	all = append(all, exporterAlerts()...)
+	return all
+}
+
+func exporterAlerts() []Alert {
+	return []Alert{
+		{
+			Name: "CSIVolumeDeviceExporterDown",
+			Expr: `absent(up{job="csi-volume-device-exporter"}) == 1`,
+			For:  "5m",
+			Labels: map[string]string{
+				"severity":              "warning",
+				"operator_health_impact": "warning",
+			},
+			Annotations: map[string]string{
+				"summary":            "CSI volume device exporter is not running",
+				"description":        "No csi-volume-device-exporter targets have been scraped for 5 minutes. Storage path health for CSI volumes cannot be reported.",
+				runbookAnnotationKey: runbookURL("CSIVolumeDeviceExporterDown"),
+			},
+		},
+	}
+}
+
+func multipathAlerts() []Alert {
+	const pvToMultipathExpr = `label_replace(
+  label_replace(
+    kube_persistentvolume_info,
+    "volume_handle", "$1", "csi_volume_handle", "(.+)"
+  )
+  * on(volume_handle) group_left(device, node, driver)
+  csi_volume_node_device_info,
+  "sysfs_name", "$1", "device", "(.*)"
+)
+* on(sysfs_name, node) group_left(device)
+node_dmmultipath_device_info`
+
+	return []Alert{
+		{
+			Name: "CSIVolumeMultipathDegraded",
+			Expr: `(` + pvToMultipathExpr + `)
+* on(device, node) group_left()
+(
+  count by(device, node) (node_dmmultipath_path_state{state!~"running|live"} == 1) > 0
+)`,
+			For: "5m",
+			Labels: map[string]string{
+				"severity": "warning",
+			},
+			Annotations: map[string]string{
+				"summary":            "PV {{ $labels.persistentvolume }} on {{ $labels.node }} has degraded multipath (device {{ $labels.device }})",
+				"description":        "At least one path to the multipath device has failed. Storage is still accessible via remaining paths but redundancy is lost.",
+				runbookAnnotationKey: runbookURL("CSIVolumeMultipathDegraded"),
+			},
+		},
+		{
+			Name: "CSIVolumeMultipathLost",
+			Expr: `(` + pvToMultipathExpr + `)
+* on(device, node) group_left()
+(
+  node_dmmultipath_device_paths_active == 0
+)`,
+			For: "1m",
+			Labels: map[string]string{
+				"severity": "critical",
+			},
+			Annotations: map[string]string{
+				"summary":            "PV {{ $labels.persistentvolume }} on {{ $labels.node }} has lost all multipath paths (device {{ $labels.device }})",
+				"description":        "All paths to the multipath device are down. I/O is likely failing. Immediate investigation of storage connectivity on node {{ $labels.node }} is required.",
+				runbookAnnotationKey: runbookURL("CSIVolumeMultipathLost"),
+			},
+		},
+	}
+}
+
+func nvmeSubsystemAlerts() []Alert {
+	const pvToNVMeExpr = `label_replace(
+  kube_persistentvolume_info,
+  "volume_handle", "$1", "csi_volume_handle", "(.+)"
+)
+* on(volume_handle) group_left(device, node, driver)
+csi_volume_node_device_info{device=~"nvme.*"}
+* on(device, node) group_left(subsystem)
+node_nvmesubsystem_namespace_info`
+
+	return []Alert{
+		{
+			Name: "CSIVolumeNVMeSubsystemDegraded",
+			Expr: `(` + pvToNVMeExpr + `)
+* on(subsystem) group_left()
+(
+  node_nvmesubsystem_paths - node_nvmesubsystem_paths_live > 0
+)`,
+			For: "5m",
+			Labels: map[string]string{
+				"severity": "warning",
+			},
+			Annotations: map[string]string{
+				"summary":            "PV {{ $labels.persistentvolume }} on {{ $labels.node }} has degraded NVMe-oF subsystem ({{ $labels.subsystem }})",
+				"description":        "At least one NVMe-oF controller path is not live. Storage is still accessible via remaining controllers but redundancy is lost.",
+				runbookAnnotationKey: runbookURL("CSIVolumeNVMeSubsystemDegraded"),
+			},
+		},
+		{
+			Name: "CSIVolumeNVMeSubsystemLost",
+			Expr: `(` + pvToNVMeExpr + `)
+* on(subsystem) group_left()
+(
+  node_nvmesubsystem_paths_live == 0
+)`,
+			For: "1m",
+			Labels: map[string]string{
+				"severity": "critical",
+			},
+			Annotations: map[string]string{
+				"summary":            "PV {{ $labels.persistentvolume }} on {{ $labels.node }} has lost all NVMe-oF controller paths ({{ $labels.subsystem }})",
+				"description":        "All NVMe-oF controller paths are dead. I/O is likely failing. Immediate investigation of storage connectivity on node {{ $labels.node }} is required.",
+				runbookAnnotationKey: runbookURL("CSIVolumeNVMeSubsystemLost"),
+			},
+		},
+	}
+}

--- a/internal/exporter/monitoring/rules/rules.go
+++ b/internal/exporter/monitoring/rules/rules.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rules assembles all Prometheus alerting and recording rules for the
+// CSI volume device exporter and can render them as a Kubernetes PrometheusRule
+// manifest or as a plain Prometheus groups file suitable for promtool.
+package rules
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/csi-addons/kubernetes-csi-addons/internal/exporter/monitoring/rules/alerts"
+)
+
+const (
+	ruleGroupName = "csi-volume-path-health"
+)
+
+type prometheusRuleGroup struct {
+	Name  string           `yaml:"name"`
+	Rules []prometheusRule `yaml:"rules"`
+}
+
+type prometheusRule struct {
+	Alert       string            `yaml:"alert,omitempty"`
+	Record      string            `yaml:"record,omitempty"`
+	Expr        string            `yaml:"expr"`
+	For         string            `yaml:"for,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}
+
+type prometheusRuleGroups struct {
+	Groups []prometheusRuleGroup `yaml:"groups"`
+}
+
+type prometheusRuleManifest struct {
+	APIVersion string                 `yaml:"apiVersion"`
+	Kind       string                 `yaml:"kind"`
+	Metadata   map[string]interface{} `yaml:"metadata"`
+	Spec       prometheusRuleGroups   `yaml:"spec"`
+}
+
+func buildGroups() []prometheusRuleGroup {
+	var rules []prometheusRule
+	for _, a := range alerts.All() {
+		rules = append(rules, prometheusRule{
+			Alert:       a.Name,
+			Expr:        a.Expr,
+			For:         a.For,
+			Labels:      a.Labels,
+			Annotations: a.Annotations,
+		})
+	}
+	return []prometheusRuleGroup{{Name: ruleGroupName, Rules: rules}}
+}
+
+func WritePrometheusRulesFile(path string) error {
+	groups := prometheusRuleGroups{Groups: buildGroups()}
+	data, err := marshalYAML(groups)
+	if err != nil {
+		return fmt.Errorf("marshal rules: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write rules file %s: %w", path, err)
+	}
+	return nil
+}
+
+func WritePrometheusRuleManifest(path, namespace string) error {
+	manifest := prometheusRuleManifest{
+		APIVersion: "monitoring.coreos.com/v1",
+		Kind:       "PrometheusRule",
+		Metadata: map[string]interface{}{
+			"name":      "csi-volume-path-health",
+			"namespace": namespace,
+			"labels": map[string]string{
+				"app.kubernetes.io/name": "csi-volume-device-exporter",
+			},
+		},
+		Spec: prometheusRuleGroups{Groups: buildGroups()},
+	}
+	data, err := marshalYAML(manifest)
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write manifest %s: %w", path, err)
+	}
+	return nil
+}
+
+func RulesAsString() (string, error) {
+	groups := prometheusRuleGroups{Groups: buildGroups()}
+	data, err := marshalYAML(groups)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func marshalYAML(v interface{}) ([]byte, error) {
+	return yaml.Marshal(v)
+}

--- a/internal/exporter/monitoring/rules/rules_test.go
+++ b/internal/exporter/monitoring/rules/rules_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rules
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/csi-addons/kubernetes-csi-addons/internal/exporter/monitoring/rules/alerts"
+)
+
+func TestAllAlerts_HaveRequiredFields(t *testing.T) {
+	for _, a := range alerts.All() {
+		t.Run(a.Name, func(t *testing.T) {
+			if a.Name == "" {
+				t.Error("alert name must not be empty")
+			}
+			if a.Expr == "" {
+				t.Errorf("alert %s: expr must not be empty", a.Name)
+			}
+			if a.For == "" {
+				t.Errorf("alert %s: for duration must not be empty", a.Name)
+			}
+			if a.Labels["severity"] == "" {
+				t.Errorf("alert %s: severity label must be set", a.Name)
+			}
+			if a.Annotations["summary"] == "" {
+				t.Errorf("alert %s: summary annotation must be set", a.Name)
+			}
+			if a.Annotations["description"] == "" {
+				t.Errorf("alert %s: description annotation must be set", a.Name)
+			}
+			if a.Annotations["runbook_url"] == "" {
+				t.Errorf("alert %s: runbook_url annotation must be set", a.Name)
+			}
+		})
+	}
+}
+
+func TestRulesAsString_ProducesValidYAML(t *testing.T) {
+	s, err := RulesAsString()
+	if err != nil {
+		t.Fatalf("RulesAsString: %v", err)
+	}
+	if !strings.Contains(s, "groups:") {
+		t.Error("expected 'groups:' key in output")
+	}
+	if !strings.Contains(s, "CSIVolumeMultipathDegraded") {
+		t.Error("expected CSIVolumeMultipathDegraded in output")
+	}
+	if !strings.Contains(s, "CSIVolumeDeviceExporterDown") {
+		t.Error("expected CSIVolumeDeviceExporterDown in output")
+	}
+}
+
+func TestWritePrometheusRulesFile(t *testing.T) {
+	path := t.TempDir() + "/rules.yaml"
+	if err := WritePrometheusRulesFile(path); err != nil {
+		t.Fatalf("WritePrometheusRulesFile: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read rules file: %v", err)
+	}
+	content := string(data)
+	wantCount := len(alerts.All())
+	if wantCount == 0 {
+		t.Fatal("alerts.All() returned no alerts")
+	}
+	got := strings.Count(content, "alert:")
+	if got != wantCount {
+		t.Errorf("expected %d alert entries in rules file, got %d", wantCount, got)
+	}
+	if !strings.Contains(content, "groups:") {
+		t.Error("rules file missing 'groups:' key")
+	}
+}
+
+func TestWritePrometheusRuleManifest(t *testing.T) {
+	path := t.TempDir() + "/manifest.yaml"
+	const ns = "monitoring"
+	if err := WritePrometheusRuleManifest(path, ns); err != nil {
+		t.Fatalf("WritePrometheusRuleManifest: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "kind: PrometheusRule") {
+		t.Error("manifest missing 'kind: PrometheusRule'")
+	}
+	if !strings.Contains(content, "namespace: "+ns) {
+		t.Errorf("manifest missing 'namespace: %s'", ns)
+	}
+	wantCount := len(alerts.All())
+	got := strings.Count(content, "alert:")
+	if got != wantCount {
+		t.Errorf("expected %d alert entries in manifest, got %d", wantCount, got)
+	}
+}

--- a/test/e2e/exporter/e2e_test.go
+++ b/test/e2e/exporter/e2e_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+//go:build e2e
+
+package exporter
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestExporterE2E validates the exporter against a real kubelet filesystem.
+// Run with: go test -tags=e2e -v ./test/e2e/exporter/ -kubelet-root=/var/lib/kubelet
+//
+// Prerequisites:
+// - Run on a node with CSI volumes staged (or mount the host paths into the test environment)
+// - The binary must be built: go build -o bin/csi-volume-device-exporter ./cmd/csi-volume-device-exporter
+func TestExporterE2E(t *testing.T) {
+	binary := os.Getenv("EXPORTER_BINARY")
+	if binary == "" {
+		binary = "../../../bin/csi-volume-device-exporter"
+	}
+
+	if _, err := os.Stat(binary); os.IsNotExist(err) {
+		t.Skipf("exporter binary not found at %s; build with: go build -o bin/csi-volume-device-exporter ./cmd/csi-volume-device-exporter", binary)
+	}
+
+	nodeName := os.Getenv("NODE_NAME")
+	if nodeName == "" {
+		nodeName = "e2e-test-node"
+	}
+
+	listenAddr := ":19091"
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	hostProc := os.Getenv("HOST_PROC")
+	if hostProc == "" {
+		hostProc = "/proc"
+	}
+	hostSys := os.Getenv("HOST_SYS")
+	if hostSys == "" {
+		hostSys = "/sys"
+	}
+	hostKubelet := os.Getenv("HOST_KUBELET")
+	if hostKubelet == "" {
+		hostKubelet = "/var/lib/kubelet"
+	}
+	kubeletRoot := os.Getenv("KUBELET_ROOT")
+	if kubeletRoot == "" {
+		kubeletRoot = "/var/lib/kubelet"
+	}
+	hostTrident := os.Getenv("HOST_TRIDENT_TRACKING")
+	if hostTrident == "" {
+		hostTrident = "/var/lib/trident/tracking"
+	}
+
+	cmd := exec.CommandContext(ctx, binary,
+		"--listen-address="+listenAddr,
+		"--poll-interval=5s",
+		"--log-level=debug",
+		"--host-proc="+hostProc,
+		"--host-sys="+hostSys,
+		"--host-kubelet="+hostKubelet,
+		"--kubelet-root="+kubeletRoot,
+		"--host-trident-tracking="+hostTrident,
+	)
+	cmd.Env = append(os.Environ(),
+		"NODE_NAME="+nodeName,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start exporter: %v", err)
+	}
+	defer func() {
+		cancel()
+		_ = cmd.Wait()
+	}()
+
+	if err := waitForReady(listenAddr, 10*time.Second); err != nil {
+		t.Fatalf("exporter did not become ready: %v", err)
+	}
+
+	t.Run("healthz returns 200", func(t *testing.T) {
+		resp, err := http.Get(fmt.Sprintf("http://localhost%s/healthz", listenAddr))
+		if err != nil {
+			t.Fatalf("healthz request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Errorf("expected 200, got %d: %s", resp.StatusCode, string(body))
+		}
+	})
+
+	t.Run("metrics endpoint serves prometheus format", func(t *testing.T) {
+		resp, err := http.Get(fmt.Sprintf("http://localhost%s/metrics", listenAddr))
+		if err != nil {
+			t.Fatalf("metrics request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200, got %d", resp.StatusCode)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		content := string(body)
+
+		if !strings.Contains(content, "csi_volume_device_exporter_last_successful_discovery_timestamp_seconds") {
+			t.Error("expected csi_volume_device_exporter_last_successful_discovery_timestamp_seconds in output")
+		}
+		if !strings.Contains(content, "csi_volume_device_exporter_discovery_duration_seconds") {
+			t.Error("expected csi_volume_device_exporter_discovery_duration_seconds in output")
+		}
+	})
+
+	t.Run("discovers volumes if present", func(t *testing.T) {
+		resp, err := http.Get(fmt.Sprintf("http://localhost%s/metrics", listenAddr))
+		if err != nil {
+			t.Fatalf("metrics request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("failed to read body: %v", err)
+		}
+		content := string(body)
+
+		if strings.Contains(content, "csi_volume_node_device_info") {
+			t.Logf("SUCCESS: Found csi_volume_node_device_info metrics:")
+			for _, line := range strings.Split(content, "\n") {
+				if strings.HasPrefix(line, "csi_volume_node_device_info{") {
+					t.Logf("  %s", line)
+				}
+			}
+		} else {
+			t.Logf("NOTE: No csi_volume_node_device_info metrics found. " +
+				"This is expected if no CSI volumes are staged on this node. " +
+				"Deploy a CSI PVC and re-run.")
+		}
+
+		for _, line := range strings.Split(content, "\n") {
+			if strings.HasPrefix(line, "csi_volume_device_exporter_volumes_discovered{") {
+				t.Logf("  %s", line)
+			}
+		}
+	})
+}
+
+func waitForReady(addr string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(fmt.Sprintf("http://localhost%s/healthz", addr))
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout waiting for exporter at %s", addr)
+}

--- a/tools/generate-exporter-rules/main.go
+++ b/tools/generate-exporter-rules/main.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// generate-exporter-rules writes the Prometheus rule YAML files derived from
+// the typed alert definitions in internal/exporter/monitoring/rules/alerts.
+//
+// Flags:
+//
+//	-namespace <ns>   Kubernetes namespace embedded in the PrometheusRule manifest.
+//	                  Falls back to the NAMESPACE environment variable, then
+//	                  defaults to "NAMESPACE" as a placeholder when neither is set.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/csi-addons/kubernetes-csi-addons/internal/exporter/monitoring/rules"
+)
+
+func main() {
+	namespace := flag.String("namespace", "", "Kubernetes namespace for the PrometheusRule manifest (overrides NAMESPACE env var)")
+	flag.Parse()
+
+	if *namespace == "" {
+		*namespace = os.Getenv("NAMESPACE")
+	}
+	if *namespace == "" {
+		*namespace = "NAMESPACE"
+		fmt.Fprintln(os.Stderr, "generate-exporter-rules: namespace not set via -namespace flag or NAMESPACE env var; using placeholder \"NAMESPACE\"")
+	}
+
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	rulesDir := filepath.Join(repoRoot, "internal", "exporter", "monitoring", "rules")
+
+	if err := rules.WritePrometheusRulesFile(filepath.Join(rulesDir, "alerts-rules.yaml")); err != nil {
+		fmt.Fprintf(os.Stderr, "generate-exporter-rules: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("wrote internal/exporter/monitoring/rules/alerts-rules.yaml")
+
+	if err := rules.WritePrometheusRuleManifest(filepath.Join(rulesDir, "alerts.yaml"), *namespace); err != nil {
+		fmt.Fprintf(os.Stderr, "generate-exporter-rules: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("wrote internal/exporter/monitoring/rules/alerts.yaml (namespace: %s)\n", *namespace)
+}

--- a/vendor/github.com/kylelemons/godebug/LICENSE
+++ b/vendor/github.com/kylelemons/godebug/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/kylelemons/godebug/diff/diff.go
+++ b/vendor/github.com/kylelemons/godebug/diff/diff.go
@@ -1,0 +1,186 @@
+// Copyright 2013 Google Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package diff implements a linewise diff algorithm.
+package diff
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// Chunk represents a piece of the diff.  A chunk will not have both added and
+// deleted lines.  Equal lines are always after any added or deleted lines.
+// A Chunk may or may not have any lines in it, especially for the first or last
+// chunk in a computation.
+type Chunk struct {
+	Added   []string
+	Deleted []string
+	Equal   []string
+}
+
+func (c *Chunk) empty() bool {
+	return len(c.Added) == 0 && len(c.Deleted) == 0 && len(c.Equal) == 0
+}
+
+// Diff returns a string containing a line-by-line unified diff of the linewise
+// changes required to make A into B.  Each line is prefixed with '+', '-', or
+// ' ' to indicate if it should be added, removed, or is correct respectively.
+func Diff(A, B string) string {
+	aLines := strings.Split(A, "\n")
+	bLines := strings.Split(B, "\n")
+
+	chunks := DiffChunks(aLines, bLines)
+
+	buf := new(bytes.Buffer)
+	for _, c := range chunks {
+		for _, line := range c.Added {
+			fmt.Fprintf(buf, "+%s\n", line)
+		}
+		for _, line := range c.Deleted {
+			fmt.Fprintf(buf, "-%s\n", line)
+		}
+		for _, line := range c.Equal {
+			fmt.Fprintf(buf, " %s\n", line)
+		}
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// DiffChunks uses an O(D(N+M)) shortest-edit-script algorithm
+// to compute the edits required from A to B and returns the
+// edit chunks.
+func DiffChunks(a, b []string) []Chunk {
+	// algorithm: http://www.xmailserver.org/diff2.pdf
+
+	// We'll need these quantities a lot.
+	alen, blen := len(a), len(b) // M, N
+
+	// At most, it will require len(a) deletions and len(b) additions
+	// to transform a into b.
+	maxPath := alen + blen // MAX
+	if maxPath == 0 {
+		// degenerate case: two empty lists are the same
+		return nil
+	}
+
+	// Store the endpoint of the path for diagonals.
+	// We store only the a index, because the b index on any diagonal
+	// (which we know during the loop below) is aidx-diag.
+	// endpoint[maxPath] represents the 0 diagonal.
+	//
+	// Stated differently:
+	// endpoint[d] contains the aidx of a furthest reaching path in diagonal d
+	endpoint := make([]int, 2*maxPath+1) // V
+
+	saved := make([][]int, 0, 8) // Vs
+	save := func() {
+		dup := make([]int, len(endpoint))
+		copy(dup, endpoint)
+		saved = append(saved, dup)
+	}
+
+	var editDistance int // D
+dLoop:
+	for editDistance = 0; editDistance <= maxPath; editDistance++ {
+		// The 0 diag(onal) represents equality of a and b.  Each diagonal to
+		// the left is numbered one lower, to the right is one higher, from
+		// -alen to +blen.  Negative diagonals favor differences from a,
+		// positive diagonals favor differences from b.  The edit distance to a
+		// diagonal d cannot be shorter than d itself.
+		//
+		// The iterations of this loop cover either odds or evens, but not both,
+		// If odd indices are inputs, even indices are outputs and vice versa.
+		for diag := -editDistance; diag <= editDistance; diag += 2 { // k
+			var aidx int // x
+			switch {
+			case diag == -editDistance:
+				// This is a new diagonal; copy from previous iter
+				aidx = endpoint[maxPath-editDistance+1] + 0
+			case diag == editDistance:
+				// This is a new diagonal; copy from previous iter
+				aidx = endpoint[maxPath+editDistance-1] + 1
+			case endpoint[maxPath+diag+1] > endpoint[maxPath+diag-1]:
+				// diagonal d+1 was farther along, so use that
+				aidx = endpoint[maxPath+diag+1] + 0
+			default:
+				// diagonal d-1 was farther (or the same), so use that
+				aidx = endpoint[maxPath+diag-1] + 1
+			}
+			// On diagonal d, we can compute bidx from aidx.
+			bidx := aidx - diag // y
+			// See how far we can go on this diagonal before we find a difference.
+			for aidx < alen && bidx < blen && a[aidx] == b[bidx] {
+				aidx++
+				bidx++
+			}
+			// Store the end of the current edit chain.
+			endpoint[maxPath+diag] = aidx
+			// If we've found the end of both inputs, we're done!
+			if aidx >= alen && bidx >= blen {
+				save() // save the final path
+				break dLoop
+			}
+		}
+		save() // save the current path
+	}
+	if editDistance == 0 {
+		return nil
+	}
+	chunks := make([]Chunk, editDistance+1)
+
+	x, y := alen, blen
+	for d := editDistance; d > 0; d-- {
+		endpoint := saved[d]
+		diag := x - y
+		insert := diag == -d || (diag != d && endpoint[maxPath+diag-1] < endpoint[maxPath+diag+1])
+
+		x1 := endpoint[maxPath+diag]
+		var x0, xM, kk int
+		if insert {
+			kk = diag + 1
+			x0 = endpoint[maxPath+kk]
+			xM = x0
+		} else {
+			kk = diag - 1
+			x0 = endpoint[maxPath+kk]
+			xM = x0 + 1
+		}
+		y0 := x0 - kk
+
+		var c Chunk
+		if insert {
+			c.Added = b[y0:][:1]
+		} else {
+			c.Deleted = a[x0:][:1]
+		}
+		if xM < x1 {
+			c.Equal = a[xM:][:x1-xM]
+		}
+
+		x, y = x0, y0
+		chunks[d] = c
+	}
+	if x > 0 {
+		chunks[0].Equal = a[:x]
+	}
+	if chunks[0].empty() {
+		chunks = chunks[1:]
+	}
+	if len(chunks) == 0 {
+		return nil
+	}
+	return chunks
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+)
+
+// CollectAndLint registers the provided Collector with a newly created pedantic
+// Registry. It then calls GatherAndLint with that Registry and with the
+// provided metricNames.
+func CollectAndLint(c prometheus.Collector, metricNames ...string) ([]promlint.Problem, error) {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return nil, fmt.Errorf("registering collector failed: %w", err)
+	}
+	return GatherAndLint(reg, metricNames...)
+}
+
+// GatherAndLint gathers all metrics from the provided Gatherer and checks them
+// with the linter in the promlint package. If any metricNames are provided,
+// only metrics with those names are checked.
+func GatherAndLint(g prometheus.Gatherer, metricNames ...string) ([]promlint.Problem, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	return promlint.NewWithMetricFamilies(got).Lint()
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/problem.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/problem.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promlint
+
+import dto "github.com/prometheus/client_model/go"
+
+// A Problem is an issue detected by a linter.
+type Problem struct {
+	// The name of the metric indicated by this Problem.
+	Metric string
+
+	// A description of the issue for this Problem.
+	Text string
+}
+
+// newProblem is helper function to create a Problem.
+func newProblem(mf *dto.MetricFamily, text string) Problem {
+	return Problem{
+		Metric: mf.GetName(),
+		Text:   text,
+	}
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
@@ -1,0 +1,123 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promlint provides a linter for Prometheus metrics.
+package promlint
+
+import (
+	"errors"
+	"io"
+	"sort"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// A Linter is a Prometheus metrics linter.  It identifies issues with metric
+// names, types, and metadata, and reports them to the caller.
+type Linter struct {
+	// The linter will read metrics in the Prometheus text format from r and
+	// then lint it, _and_ it will lint the metrics provided directly as
+	// MetricFamily proto messages in mfs. Note, however, that the current
+	// constructor functions New and NewWithMetricFamilies only ever set one
+	// of them.
+	r   io.Reader
+	mfs []*dto.MetricFamily
+
+	customValidations []Validation
+}
+
+// New creates a new Linter that reads an input stream of Prometheus metrics in
+// the Prometheus text exposition format.
+func New(r io.Reader) *Linter {
+	return &Linter{
+		r: r,
+	}
+}
+
+// NewWithMetricFamilies creates a new Linter that reads from a slice of
+// MetricFamily protobuf messages.
+func NewWithMetricFamilies(mfs []*dto.MetricFamily) *Linter {
+	return &Linter{
+		mfs: mfs,
+	}
+}
+
+// AddCustomValidations adds custom validations to the linter.
+func (l *Linter) AddCustomValidations(vs ...Validation) {
+	if l.customValidations == nil {
+		l.customValidations = make([]Validation, 0, len(vs))
+	}
+	l.customValidations = append(l.customValidations, vs...)
+}
+
+// Lint performs a linting pass, returning a slice of Problems indicating any
+// issues found in the metrics stream. The slice is sorted by metric name
+// and issue description.
+func (l *Linter) Lint() ([]Problem, error) {
+	var problems []Problem
+
+	if l.r != nil {
+		d := expfmt.NewDecoder(l.r, expfmt.NewFormat(expfmt.TypeTextPlain))
+
+		mf := &dto.MetricFamily{}
+		for {
+			if err := d.Decode(mf); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, err
+			}
+
+			problems = append(problems, l.lint(mf)...)
+		}
+	}
+	for _, mf := range l.mfs {
+		problems = append(problems, l.lint(mf)...)
+	}
+
+	// Ensure deterministic output.
+	sort.SliceStable(problems, func(i, j int) bool {
+		if problems[i].Metric == problems[j].Metric {
+			return problems[i].Text < problems[j].Text
+		}
+		return problems[i].Metric < problems[j].Metric
+	})
+
+	return problems, nil
+}
+
+// lint is the entry point for linting a single metric.
+func (l *Linter) lint(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	for _, fn := range defaultValidations {
+		errs := fn(mf)
+		for _, err := range errs {
+			problems = append(problems, newProblem(mf, err.Error()))
+		}
+	}
+
+	if l.customValidations != nil {
+		for _, fn := range l.customValidations {
+			errs := fn(mf)
+			for _, err := range errs {
+				problems = append(problems, newProblem(mf, err.Error()))
+			}
+		}
+	}
+
+	// TODO(mdlayher): lint rules for specific metrics types.
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validation.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validation.go
@@ -1,0 +1,34 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promlint
+
+import (
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint/validations"
+)
+
+type Validation = func(mf *dto.MetricFamily) []error
+
+var defaultValidations = []Validation{
+	validations.LintHelp,
+	validations.LintMetricUnits,
+	validations.LintCounter,
+	validations.LintHistogramSummaryReserved,
+	validations.LintMetricTypeInName,
+	validations.LintReservedChars,
+	validations.LintCamelCase,
+	validations.LintUnitAbbreviations,
+	validations.LintDuplicateMetric,
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/counter_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/counter_validations.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// LintCounter detects issues specific to counters, as well as patterns that should
+// only be used with counters.
+func LintCounter(mf *dto.MetricFamily) []error {
+	var problems []error
+
+	isCounter := mf.GetType() == dto.MetricType_COUNTER
+	isUntyped := mf.GetType() == dto.MetricType_UNTYPED
+	hasTotalSuffix := strings.HasSuffix(mf.GetName(), "_total")
+
+	switch {
+	case isCounter && !hasTotalSuffix:
+		problems = append(problems, errors.New(`counter metrics should have "_total" suffix`))
+	case !isUntyped && !isCounter && hasTotalSuffix:
+		problems = append(problems, errors.New(`non-counter metrics should not have "_total" suffix`))
+	}
+
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/duplicate_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/duplicate_validations.go
@@ -1,0 +1,37 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"reflect"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// LintDuplicateMetric detects duplicate metric.
+func LintDuplicateMetric(mf *dto.MetricFamily) []error {
+	var problems []error
+
+	for i, m := range mf.Metric {
+		for _, k := range mf.Metric[i+1:] {
+			if reflect.DeepEqual(m.Label, k.Label) {
+				problems = append(problems, errors.New("metric not unique"))
+				break
+			}
+		}
+	}
+
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/generic_name_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/generic_name_validations.go
@@ -1,0 +1,101 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+var camelCase = regexp.MustCompile(`[a-z][A-Z]`)
+
+// LintMetricUnits detects issues with metric unit names.
+func LintMetricUnits(mf *dto.MetricFamily) []error {
+	var problems []error
+
+	unit, base, ok := metricUnits(*mf.Name)
+	if !ok {
+		// No known units detected.
+		return nil
+	}
+
+	// Unit is already a base unit.
+	if unit == base {
+		return nil
+	}
+
+	problems = append(problems, fmt.Errorf("use base unit %q instead of %q", base, unit))
+
+	return problems
+}
+
+// LintMetricTypeInName detects when the metric type is included in the metric name.
+func LintMetricTypeInName(mf *dto.MetricFamily) []error {
+	if mf.GetType() == dto.MetricType_UNTYPED {
+		return nil
+	}
+
+	var problems []error
+
+	n := strings.ToLower(mf.GetName())
+	typename := strings.ToLower(mf.GetType().String())
+
+	if strings.Contains(n, "_"+typename+"_") || strings.HasSuffix(n, "_"+typename) {
+		problems = append(problems, fmt.Errorf(`metric name should not include type '%s'`, typename))
+	}
+
+	return problems
+}
+
+// LintReservedChars detects colons in metric names.
+func LintReservedChars(mf *dto.MetricFamily) []error {
+	var problems []error
+	if strings.Contains(mf.GetName(), ":") {
+		problems = append(problems, errors.New("metric names should not contain ':'"))
+	}
+	return problems
+}
+
+// LintCamelCase detects metric names and label names written in camelCase.
+func LintCamelCase(mf *dto.MetricFamily) []error {
+	var problems []error
+	if camelCase.FindString(mf.GetName()) != "" {
+		problems = append(problems, errors.New("metric names should be written in 'snake_case' not 'camelCase'"))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if camelCase.FindString(l.GetName()) != "" {
+				problems = append(problems, errors.New("label names should be written in 'snake_case' not 'camelCase'"))
+			}
+		}
+	}
+	return problems
+}
+
+// LintUnitAbbreviations detects abbreviated units in the metric name.
+func LintUnitAbbreviations(mf *dto.MetricFamily) []error {
+	var problems []error
+	n := strings.ToLower(mf.GetName())
+	for _, s := range unitAbbreviations {
+		if strings.Contains(n, "_"+s+"_") || strings.HasSuffix(n, "_"+s) {
+			problems = append(problems, errors.New("metric names should not contain abbreviated units"))
+		}
+	}
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/help_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/help_validations.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// LintHelp detects issues related to the help text for a metric.
+func LintHelp(mf *dto.MetricFamily) []error {
+	var problems []error
+
+	// Expect all metrics to have help text available.
+	if mf.Help == nil {
+		problems = append(problems, errors.New("no help text"))
+	}
+
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/histogram_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/histogram_validations.go
@@ -1,0 +1,63 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// LintHistogramSummaryReserved detects when other types of metrics use names or labels
+// reserved for use by histograms and/or summaries.
+func LintHistogramSummaryReserved(mf *dto.MetricFamily) []error {
+	// These rules do not apply to untyped metrics.
+	t := mf.GetType()
+	if t == dto.MetricType_UNTYPED {
+		return nil
+	}
+
+	var problems []error
+
+	isHistogram := t == dto.MetricType_HISTOGRAM
+	isSummary := t == dto.MetricType_SUMMARY
+
+	n := mf.GetName()
+
+	if !isHistogram && strings.HasSuffix(n, "_bucket") {
+		problems = append(problems, errors.New(`non-histogram metrics should not have "_bucket" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_count") {
+		problems = append(problems, errors.New(`non-histogram and non-summary metrics should not have "_count" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_sum") {
+		problems = append(problems, errors.New(`non-histogram and non-summary metrics should not have "_sum" suffix`))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			ln := l.GetName()
+
+			if !isHistogram && ln == "le" {
+				problems = append(problems, errors.New(`non-histogram metrics should not have "le" label`))
+			}
+			if !isSummary && ln == "quantile" {
+				problems = append(problems, errors.New(`non-summary metrics should not have "quantile" label`))
+			}
+		}
+	}
+
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/units.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/units.go
@@ -1,0 +1,118 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import "strings"
+
+// Units and their possible prefixes recognized by this library.  More can be
+// added over time as needed.
+var (
+	// map a unit to the appropriate base unit.
+	units = map[string]string{
+		// Base units.
+		"amperes": "amperes",
+		"bytes":   "bytes",
+		"celsius": "celsius", // Also allow Celsius because it is common in typical Prometheus use cases.
+		"grams":   "grams",
+		"joules":  "joules",
+		"kelvin":  "kelvin", // SI base unit, used in special cases (e.g. color temperature, scientific measurements).
+		"meters":  "meters", // Both American and international spelling permitted.
+		"metres":  "metres",
+		"seconds": "seconds",
+		"volts":   "volts",
+
+		// Non base units.
+		// Time.
+		"minutes": "seconds",
+		"hours":   "seconds",
+		"days":    "seconds",
+		"weeks":   "seconds",
+		// Temperature.
+		"kelvins":    "kelvin",
+		"fahrenheit": "celsius",
+		"rankine":    "celsius",
+		// Length.
+		"inches": "meters",
+		"yards":  "meters",
+		"miles":  "meters",
+		// Bytes.
+		"bits": "bytes",
+		// Energy.
+		"calories": "joules",
+		// Mass.
+		"pounds": "grams",
+		"ounces": "grams",
+	}
+
+	unitPrefixes = []string{
+		"pico",
+		"nano",
+		"micro",
+		"milli",
+		"centi",
+		"deci",
+		"deca",
+		"hecto",
+		"kilo",
+		"kibi",
+		"mega",
+		"mibi",
+		"giga",
+		"gibi",
+		"tera",
+		"tebi",
+		"peta",
+		"pebi",
+	}
+
+	// Common abbreviations that we'd like to discourage.
+	unitAbbreviations = []string{
+		"s",
+		"ms",
+		"us",
+		"ns",
+		"sec",
+		"b",
+		"kb",
+		"mb",
+		"gb",
+		"tb",
+		"pb",
+		"m",
+		"h",
+		"d",
+	}
+)
+
+// metricUnits attempts to detect known unit types used as part of a metric name,
+// e.g. "foo_bytes_total" or "bar_baz_milligrams".
+func metricUnits(m string) (unit, base string, ok bool) {
+	ss := strings.Split(m, "_")
+
+	for _, s := range ss {
+		if base, found := units[s]; found {
+			return s, base, true
+		}
+
+		for _, p := range unitPrefixes {
+			if strings.HasPrefix(s, p) {
+				if base, found := units[s[len(p):]]; found {
+					return s, base, true
+				}
+			}
+		}
+	}
+
+	return "", "", false
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -1,0 +1,334 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides helpers to test code using the prometheus package
+// of client_golang.
+//
+// While writing unit tests to verify correct instrumentation of your code, it's
+// a common mistake to mostly test the instrumentation library instead of your
+// own code. Rather than verifying that a prometheus.Counter's value has changed
+// as expected or that it shows up in the exposition after registration, it is
+// in general more robust and more faithful to the concept of unit tests to use
+// mock implementations of the prometheus.Counter and prometheus.Registerer
+// interfaces that simply assert that the Add or Register methods have been
+// called with the expected arguments. However, this might be overkill in simple
+// scenarios. The ToFloat64 function is provided for simple inspection of a
+// single-value metric, but it has to be used with caution.
+//
+// End-to-end tests to verify all or larger parts of the metrics exposition can
+// be implemented with the CollectAndCompare or GatherAndCompare functions. The
+// most appropriate use is not so much testing instrumentation of your code, but
+// testing custom prometheus.Collector implementations and in particular whole
+// exporters, i.e. programs that retrieve telemetry data from a 3rd party source
+// and convert it into Prometheus metrics.
+//
+// In a similar pattern, CollectAndLint and GatherAndLint can be used to detect
+// metrics that have issues with their name, type, or metadata without being
+// necessarily invalid, e.g. a counter with a name missing the “_total” suffix.
+package testutil
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/kylelemons/godebug/diff"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/internal"
+)
+
+// ToFloat64 collects all Metrics from the provided Collector. It expects that
+// this results in exactly one Metric being collected, which must be a Gauge,
+// Counter, or Untyped. In all other cases, ToFloat64 panics. ToFloat64 returns
+// the value of the collected Metric.
+//
+// The Collector provided is typically a simple instance of Gauge or Counter, or
+// – less commonly – a GaugeVec or CounterVec with exactly one element. But any
+// Collector fulfilling the prerequisites described above will do.
+//
+// Use this function with caution. It is computationally very expensive and thus
+// not suited at all to read values from Metrics in regular code. This is really
+// only for testing purposes, and even for testing, other approaches are often
+// more appropriate (see this package's documentation).
+//
+// A clear anti-pattern would be to use a metric type from the prometheus
+// package to track values that are also needed for something else than the
+// exposition of Prometheus metrics. For example, you would like to track the
+// number of items in a queue because your code should reject queuing further
+// items if a certain limit is reached. It is tempting to track the number of
+// items in a prometheus.Gauge, as it is then easily available as a metric for
+// exposition, too. However, then you would need to call ToFloat64 in your
+// regular code, potentially quite often. The recommended way is to track the
+// number of items conventionally (in the way you would have done it without
+// considering Prometheus metrics) and then expose the number with a
+// prometheus.GaugeFunc.
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	if err := m.Write(pb); err != nil {
+		panic(fmt.Errorf("error happened while collecting metrics: %w", err))
+	}
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
+}
+
+// CollectAndCount registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCount with that Registry and with
+// the provided metricNames. In the unlikely case that the registration or the
+// gathering fails, this function panics. (This is inconsistent with the other
+// CollectAnd… functions in this package and has historical reasons. Changing
+// the function signature would be a breaking change and will therefore only
+// happen with the next major version bump.)
+func CollectAndCount(c prometheus.Collector, metricNames ...string) int {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		panic(fmt.Errorf("registering collector failed: %w", err))
+	}
+	result, err := GatherAndCount(reg, metricNames...)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// GatherAndCount gathers all metrics from the provided Gatherer and counts
+// them. It returns the number of metric children in all gathered metric
+// families together. If any metricNames are provided, only metrics with those
+// names are counted.
+func GatherAndCount(g prometheus.Gatherer, metricNames ...string) (int, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return 0, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+
+	result := 0
+	for _, mf := range got {
+		result += len(mf.GetMetric())
+	}
+	return result, nil
+}
+
+// ScrapeAndCompare calls a remote exporter's endpoint which is expected to return some metrics in
+// plain text format. Then it compares it with the results that the `expected` would return.
+// If the `metricNames` is not empty it would filter the comparison only to the given metric names.
+//
+// NOTE: Be mindful of accidental discrepancies between expected and metricNames; metricNames filter
+// both expected and scraped metrics. See https://github.com/prometheus/client_golang/issues/1351.
+func ScrapeAndCompare(url string, expected io.Reader, metricNames ...string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("scraping metrics failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("the scraping target returned a status code other than 200: %d",
+			resp.StatusCode)
+	}
+
+	scraped, err := convertReaderToMetricFamily(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	wanted, err := convertReaderToMetricFamily(expected)
+	if err != nil {
+		return err
+	}
+
+	return compareMetricFamilies(scraped, wanted, metricNames...)
+}
+
+// CollectAndCompare collects the metrics identified by `metricNames` and compares them in the Prometheus text
+// exposition format to the data read from expected.
+//
+// NOTE: Be mindful of accidental discrepancies between expected and metricNames; metricNames filter
+// both expected and collected metrics. See https://github.com/prometheus/client_golang/issues/1351.
+func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames ...string) error {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %w", err)
+	}
+	return GatherAndCompare(reg, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+//
+// NOTE: Be mindful of accidental discrepancies between expected and metricNames; metricNames filter
+// both expected and gathered metrics. See https://github.com/prometheus/client_golang/issues/1351.
+func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
+	return TransactionalGatherAndCompare(prometheus.ToTransactionalGatherer(g), expected, metricNames...)
+}
+
+// TransactionalGatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+//
+// NOTE: Be mindful of accidental discrepancies between expected and metricNames; metricNames filter
+// both expected and gathered metrics. See https://github.com/prometheus/client_golang/issues/1351.
+func TransactionalGatherAndCompare(g prometheus.TransactionalGatherer, expected io.Reader, metricNames ...string) error {
+	got, done, err := g.Gather()
+	defer done()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %w", err)
+	}
+
+	wanted, err := convertReaderToMetricFamily(expected)
+	if err != nil {
+		return err
+	}
+
+	return compareMetricFamilies(got, wanted, metricNames...)
+}
+
+// CollectAndFormat collects the metrics identified by `metricNames` and returns them in the given format.
+func CollectAndFormat(c prometheus.Collector, format expfmt.FormatType, metricNames ...string) ([]byte, error) {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return nil, fmt.Errorf("registering collector failed: %w", err)
+	}
+
+	gotFiltered, err := reg.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+
+	gotFiltered = filterMetrics(gotFiltered, metricNames)
+
+	var gotFormatted bytes.Buffer
+	enc := expfmt.NewEncoder(&gotFormatted, expfmt.NewFormat(format))
+	for _, mf := range gotFiltered {
+		if err := enc.Encode(mf); err != nil {
+			return nil, fmt.Errorf("encoding gathered metrics failed: %w", err)
+		}
+	}
+
+	return gotFormatted.Bytes(), nil
+}
+
+// convertReaderToMetricFamily would read from a io.Reader object and convert it to a slice of
+// dto.MetricFamily.
+func convertReaderToMetricFamily(reader io.Reader) ([]*dto.MetricFamily, error) {
+	tp := expfmt.NewTextParser(model.UTF8Validation)
+	notNormalized, err := tp.TextToMetricFamilies(reader)
+	if err != nil {
+		return nil, fmt.Errorf("converting reader to metric families failed: %w", err)
+	}
+
+	// The text protocol handles empty help fields inconsistently. When
+	// encoding, any non-nil value, include the empty string, produces a
+	// "# HELP" line. But when decoding, the help field is only set to a
+	// non-nil value if the "# HELP" line contains a non-empty value.
+	//
+	// Because metrics in a registry always have non-nil help fields, populate
+	// any nil help fields in the parsed metrics with the empty string so that
+	// when we compare text encodings, the results are consistent.
+	for _, metric := range notNormalized {
+		if metric.Help == nil {
+			metric.Help = proto.String("")
+		}
+	}
+
+	return internal.NormalizeMetricFamilies(notNormalized), nil
+}
+
+// compareMetricFamilies would compare 2 slices of metric families, and optionally filters both of
+// them to the `metricNames` provided.
+func compareMetricFamilies(got, expected []*dto.MetricFamily, metricNames ...string) error {
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+		expected = filterMetrics(expected, metricNames)
+	}
+
+	return compare(got, expected)
+}
+
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.NewFormat(expfmt.TypeTextPlain).WithEscapingScheme(model.NoEscaping))
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %w", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.NewFormat(expfmt.TypeTextPlain).WithEscapingScheme(model.NoEscaping))
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %w", err)
+		}
+	}
+	if diffErr := diff.Diff(gotBuf.String(), wantBuf.String()); diffErr != "" {
+		return errors.New(diffErr)
+	}
+	return nil
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -148,6 +148,9 @@ github.com/kubernetes-csi/csi-lib-utils/leaderelection
 github.com/kubernetes-csi/csi-lib-utils/metrics
 github.com/kubernetes-csi/csi-lib-utils/protosanitizer
 github.com/kubernetes-csi/csi-lib-utils/standardflags
+# github.com/kylelemons/godebug v1.1.0
+## explicit; go 1.11
+github.com/kylelemons/godebug/diff
 # github.com/mailru/easyjson v0.9.0
 ## explicit; go 1.20
 github.com/mailru/easyjson/buffer
@@ -214,6 +217,9 @@ github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 github.com/prometheus/client_golang/prometheus/promhttp/internal
+github.com/prometheus/client_golang/prometheus/testutil
+github.com/prometheus/client_golang/prometheus/testutil/promlint
+github.com/prometheus/client_golang/prometheus/testutil/promlint/validations
 # github.com/prometheus/client_model v0.6.2
 ## explicit; go 1.22.0
 github.com/prometheus/client_model/go


### PR DESCRIPTION
## Summary

- Add a new `csi-volume-device-exporter` binary that discovers CSI volume to block device mappings on each node and exposes them as Prometheus metrics (`csi_volume_node_device_info`)
- This enables correlating storage path health metrics (DM-multipath state, NVMe-oF subsystem health) with Kubernetes PersistentVolumes for proactive alerting on storage path degradation
- Ships with 5 Prometheus alert rules (multipath degraded/lost, NVMe-oF degraded/lost, exporter down), complete with runbooks and promtool-based unit tests

### Components added

| Directory | Purpose |
|-----------|---------|
| `cmd/csi-volume-device-exporter/` | Main entry point (standalone binary, DaemonSet) |
| `internal/exporter/discovery/` | Volume discovery engines: kubelet (universal), Trident, HPE |
| `internal/exporter/monitoring/` | Prometheus metrics and typed alert rule definitions |
| `deploy/exporter/` | DaemonSet, PodMonitor, OpenShift SCC manifests |
| `docs/csi-volume-device-exporter/` | Feature docs, 5 alert runbooks |
| `hack/prom-rule-ci/` | promtool lint + unit test scripts |
| `build/Containerfile.exporter` | Container image build |
| `test/e2e/exporter/` | End-to-end tests |
| `tools/generate-exporter-rules/` | Alert YAML codegen |

### Discovery engines

1. **Kubelet** — Parses `vol_data.json` + `/proc/1/mountinfo` + `/sys/dev/block/` to map CSI volumes to block devices; handles filesystem, block, and publish-mount volumes
2. **Trident** — Reads NetApp Trident tracking JSON files
3. **HPE** — Reads HPE CSI `deviceInfo.json` files

All discoverers resolve LUKS-over-multipath stacks, returning the underlying multipath device.

Based on: https://github.com/openshift-virtualization/csi-volume-device-exporter/pull/1

## Test plan

- [x] Unit tests pass: `go test -race ./internal/exporter/...`
- [x] Build succeeds: `go build ./cmd/csi-volume-device-exporter/...`
- [x] `go vet` clean
- [ ] CI passes
- [ ] E2E test on a node with CSI volumes: `go test -tags=e2e ./test/e2e/exporter/`
- [ ] promtool alert rule tests: `hack/prom-rule-ci/verify-rules.sh`
- [ ] Container image builds: `make docker-build-exporter`


Made with [Cursor](https://cursor.com)