### PR TITLE
fail early when PVC is part of both VR, VGR

### DIFF
--- a/internal/controller/replication.storage/pvc.go
+++ b/internal/controller/replication.storage/pvc.go
@@ -73,8 +73,8 @@ func annotatePVCWithOwner(client client.Client, ctx context.Context, logger logr
 		pvc.Annotations = map[string]string{}
 	}
 
-	if pvc.Annotations[replicationv1alpha1.VolumeReplicationNameAnnotation] != "" &&
-		pvc.Annotations[replicationv1alpha1.VolumeGroupReplicationNameAnnotation] != "" {
+	if (pvc.Annotations[replicationv1alpha1.VolumeReplicationNameAnnotation] != "" && pvcAnnotation == replicationv1alpha1.VolumeGroupReplicationNameAnnotation) ||
+		(pvc.Annotations[replicationv1alpha1.VolumeGroupReplicationNameAnnotation] != "" && pvcAnnotation == replicationv1alpha1.VolumeReplicationNameAnnotation) {
 		logger.Info("PVC can't be part of both VolumeGroupReplication and VolumeReplication")
 		return fmt.Errorf("PVC (%s/%s) can't be owned by both VolumeReplication and VolumeGroupReplication", pvc.Namespace, pvc.Name)
 	}


### PR DESCRIPTION
Currently, if a PVC is part of VR and we try to create a VGR which includes that PVC, then it will try to group the volumes as the annotation check will pass for the first time and fail in subsequent reconciles. The storage level validation was the only safeguard.
We should fail early if we see a PVC is part of a VR/VGR already through owner annotations.