### PR TITLE
feat: (sidecar) annotate PVCs with volume health status

### DIFF
--- a/config/rbac/csiaddons_pvc_editor_role.yaml
+++ b/config/rbac/csiaddons_pvc_editor_role.yaml
@@ -1,0 +1,14 @@
+---
+# permissions for csi-addons sidecar to patch PVC annotations.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csiaddons-pvc-editor-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - patch

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - leader_election_role.yaml
   - leader_election_role_binding.yaml
   - csiaddons_event_editor_role.yaml
+  - csiaddons_pvc_editor_role.yaml
   # The following RBAC configurations are used to protect
   # the metrics endpoint with authn/authz. These configurations
   # ensure that only authorized users and service accounts

--- a/deploy/controller/rbac.yaml
+++ b/deploy/controller/rbac.yaml
@@ -119,6 +119,19 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: csi-addons-csiaddons-pvc-editor-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: csi-addons-manager-role
 rules:
 - apiGroups:

--- a/docs/volume-condition.md
+++ b/docs/volume-condition.md
@@ -13,8 +13,29 @@ Condition Reporter.
 
 ## Abnormal Volume Condition reporting
 
-Once enabled, the healthy and abnormal volume condition is reported in the logs
-of the CSI-Addons sidecar, and as an Event for the PersistentVolumeClaim.
+Once enabled, the sidecar reports the healthy and abnormal volume conditions as follows:
+
+- logs in the CSI-Addons sidecar
+- Event for the PersistentVolumeClaim
+- a health annotation on the PersistentVolumeClaim
+
+The health annotation on the PersistentVolumeClaim is written per node:
+
+```yaml
+csiaddons.openshift.io/volumehealth.<node-uid>: '{"state":"healthy|unhealthy","lastChecked":"<RFC3339>","since":"<RFC3339>","node":"<node-name>"}'
+```
+
+The sidecar always writes both states explicitly (`healthy` and `unhealthy`) and
+updates `lastChecked` on every tick.
+
+- `state` is always `healthy` or `unhealthy`
+- `lastChecked` is refreshed on every tick
+- `since` is set when the sidecar first observes the current state, and is
+  kept unchanged while that state does not change
+
+Each sidecar instance only updates its own
+`csiaddons.openshift.io/volumehealth.<node-uid>` key and never modifies keys
+written by sidecars running on other nodes.
 
 Users will see the Event in their Namespace, and also when they describe (with
 `kubectl describe ...`) the PersistentVolumeClaim.
@@ -33,7 +54,6 @@ Additional options for reporting include:
 - annotate one or more of
 
   1. the PersistentVolume
-  1. the PersistentVolumeClaim
   1. the Pod that uses the PersistentVolumeClaim
   1. the Node where the volume condition is abnormal
      > unlikely acceptable, needs permissions to the Node object
@@ -88,10 +108,23 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - persistentvolumes
       - persistentvolumeclaims
     verbs:
       - get
+---
+# permissions for csi-addons sidecar to patch PVC health annotation.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csiaddons-pvc-editor-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - patch
 ```
 
 [nodegetvolumestats]: https://github.com/container-storage-interface/spec/blob/master/spec.md#nodegetvolumestats

--- a/sidecar/internal/volume-condition/event_recorder.go
+++ b/sidecar/internal/volume-condition/event_recorder.go
@@ -18,10 +18,8 @@ package condition
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -47,7 +45,7 @@ func WithEventRecorder() RecorderOption {
 	}
 }
 
-func newEventRecorder(client *kubernetes.Clientset, hostname string) (conditionRecorder, error) {
+func newEventRecorder(client *kubernetes.Clientset, hostname, _ string) (conditionRecorder, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(
 		&typedcorev1.EventSinkImpl{
@@ -71,27 +69,9 @@ func newEventRecorder(client *kubernetes.Clientset, hostname string) (conditionR
 func (er *eventRecorder) record(
 	ctx context.Context,
 	pv *corev1.PersistentVolume,
+	pvc *corev1.PersistentVolumeClaim,
 	vc volume.VolumeCondition,
 ) error {
-	claim := pv.Spec.ClaimRef
-	if claim == nil {
-		return fmt.Errorf("persistent volume %q does not have a claim (unused?)", pv.Name)
-	}
-
-	pvc, err := er.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(
-		ctx,
-		claim.Name,
-		metav1.GetOptions{},
-	)
-	if err != nil {
-		return fmt.Errorf(
-			"failed to get persistent volume claim %q in namespace %q: %w",
-			claim.Name,
-			claim.Namespace,
-			err,
-		)
-	}
-
 	severity := corev1.EventTypeNormal
 	if !vc.IsHealthy() {
 		severity = corev1.EventTypeWarning
@@ -100,4 +80,12 @@ func (er *eventRecorder) record(
 	er.recorder.Event(pvc, severity, vc.GetReason(), vc.GetMessage())
 
 	return nil
+}
+
+func (er *eventRecorder) needsPVC() bool {
+	return true
+}
+
+func (er *eventRecorder) recordUnchangedVolumes() bool {
+	return false
 }

--- a/sidecar/internal/volume-condition/log_recorder.go
+++ b/sidecar/internal/volume-condition/log_recorder.go
@@ -34,7 +34,7 @@ var _ conditionRecorder = &logRecorder{}
 // will report the volume condition in the logs of the CSI-Addons sidecar.
 func WithLogRecorder() RecorderOption {
 	return RecorderOption{
-		newRecorder: func(client *kubernetes.Clientset, hostname string) (conditionRecorder, error) {
+		newRecorder: func(client *kubernetes.Clientset, hostname, nodeUID string) (conditionRecorder, error) {
 			return &logRecorder{}, nil
 		},
 	}
@@ -43,6 +43,7 @@ func WithLogRecorder() RecorderOption {
 func (lr *logRecorder) record(
 	ctx context.Context,
 	pv *corev1.PersistentVolume,
+	pvc *corev1.PersistentVolumeClaim,
 	vc volume.VolumeCondition,
 ) error {
 	if vc.IsHealthy() {
@@ -52,4 +53,12 @@ func (lr *logRecorder) record(
 	}
 
 	return nil
+}
+
+func (lr *logRecorder) needsPVC() bool {
+	return false
+}
+
+func (lr *logRecorder) recordUnchangedVolumes() bool {
+	return false
 }

--- a/sidecar/internal/volume-condition/node/node.go
+++ b/sidecar/internal/volume-condition/node/node.go
@@ -36,6 +36,8 @@ type Node interface {
 	// ListCSIVolumes returns a slice of CSI-volumes that are attached to the
 	// local worker node.
 	ListCSIVolumes(ctx context.Context) ([]volume.CSIVolume, error)
+	// UID returns the immutable Kubernetes UID of the local node object.
+	UID() string
 }
 
 type node struct {
@@ -43,6 +45,8 @@ type node struct {
 
 	// nodename is used to filter the attachments by node
 	nodename string
+	// nodeUID is used to annotate the PVC with the volume condition
+	nodeUID string
 }
 
 // assert that node implements the Node interface.
@@ -51,15 +55,23 @@ var _ Node = &node{}
 // NewNode creates a new Node that represents the local worker node.
 func NewNode(ctx context.Context, clientset *kubernetes.Clientset, nodename string) (Node, error) {
 	// verify that my local Node exists, will be fetched again in .ListCSIVolumes()
-	_, err := clientset.CoreV1().Nodes().Get(ctx, nodename, metav1.GetOptions{})
+	localNode, err := clientset.CoreV1().Nodes().Get(ctx, nodename, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not get my local Node %q: %v", nodename, err)
+	}
+	if localNode.UID == "" {
+		return nil, fmt.Errorf("could not determine UID of local Node %q", nodename)
 	}
 
 	return &node{
 		clientset: clientset,
 		nodename:  nodename,
+		nodeUID:   string(localNode.UID),
 	}, nil
+}
+
+func (n *node) UID() string {
+	return n.nodeUID
 }
 
 func (n *node) ListCSIVolumes(ctx context.Context) ([]volume.CSIVolume, error) {

--- a/sidecar/internal/volume-condition/pvc_annotation_recorder.go
+++ b/sidecar/internal/volume-condition/pvc_annotation_recorder.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package condition
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition/volume"
+)
+
+const (
+	pvcVolumeHealthAnnotationKeyPrefix = "csiaddons.openshift.io/volumehealth."
+
+	pvcVolumeHealthAnnotationStateHealthy   = "healthy"
+	pvcVolumeHealthAnnotationStateUnhealthy = "unhealthy"
+)
+
+type pvcAnnotationRecorder struct {
+	client   *kubernetes.Clientset
+	hostName string
+	nodeUID  string
+}
+
+type pvcVolumeHealthAnnotation struct {
+	State       string `json:"state"`
+	LastChecked string `json:"lastChecked"`
+	Since       string `json:"since"`
+	Node        string `json:"node"`
+}
+
+// assert on conditionRecorder interface
+var _ conditionRecorder = &pvcAnnotationRecorder{}
+
+// WithPVCAnnotationRecorder can be passed to the VolumeConditionReporter so
+// that it annotates a PersistentVolumeClaim with the local node volume-health
+// state and timestamps.
+func WithPVCAnnotationRecorder() RecorderOption {
+	return RecorderOption{
+		newRecorder: func(client *kubernetes.Clientset, hostname, nodeUID string) (conditionRecorder, error) {
+			return &pvcAnnotationRecorder{
+				client:   client,
+				hostName: hostname,
+				nodeUID:  nodeUID,
+			}, nil
+		},
+	}
+}
+
+func (par *pvcAnnotationRecorder) record(
+	ctx context.Context,
+	pv *corev1.PersistentVolume,
+	pvc *corev1.PersistentVolumeClaim,
+	vc volume.VolumeCondition,
+) error {
+	if pvc.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
+	patch, err := buildPVCVolumeHealthAnnotationPatch(
+		pvc.GetAnnotations(),
+		par.nodeUID,
+		par.hostName,
+		vc.IsHealthy(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to build volume health annotation patch for persistent volume claim %q in namespace %q: %w",
+			pvc.Name, pvc.Namespace, err)
+	}
+
+	_, err = par.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Patch(
+		ctx,
+		pvc.Name,
+		types.MergePatchType,
+		patch,
+		metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to patch volume health annotation for persistent volume claim %q in namespace %q: %w",
+			pvc.Name,
+			pvc.Namespace,
+			err,
+		)
+	}
+
+	return nil
+}
+
+func (par *pvcAnnotationRecorder) needsPVC() bool {
+	return true
+}
+
+func (par *pvcAnnotationRecorder) recordUnchangedVolumes() bool {
+	// "true" so the sidecar keeps refreshing the PVC health annotation
+	// every reporting tick, even when health stays the same.
+	// Otherwise, "lastChecked" timestamp would become stale.
+	return true
+}
+
+func buildPVCVolumeHealthAnnotationPatch(
+	annotations map[string]string,
+	nodeUID string,
+	nodeName string,
+	healthy bool,
+) ([]byte, error) {
+	if nodeUID == "" {
+		return nil, fmt.Errorf("node UID cannot be empty")
+	}
+
+	state := pvcVolumeHealthAnnotationStateHealthy
+	if !healthy {
+		state = pvcVolumeHealthAnnotationStateUnhealthy
+	}
+
+	annotationKey := getPVCVolumeHealthAnnotationKey(nodeUID)
+	lastCheckedTimestamp := time.Now().Format(time.RFC3339)
+	since := getSinceTimestamp(annotations[annotationKey], state)
+	if since == "" {
+		since = lastCheckedTimestamp
+	}
+
+	annotationValue, err := json.Marshal(pvcVolumeHealthAnnotation{
+		State:       state,
+		LastChecked: lastCheckedTimestamp,
+		Since:       since,
+		Node:        nodeName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				annotationKey: string(annotationValue),
+			},
+		},
+	}
+
+	data, err := json.Marshal(patch)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func getPVCVolumeHealthAnnotationKey(nodeUID string) string {
+	return pvcVolumeHealthAnnotationKeyPrefix + nodeUID
+}
+
+func getSinceTimestamp(encodedAnnotation string, state string) string {
+	if encodedAnnotation == "" {
+		return ""
+	}
+
+	annotation := pvcVolumeHealthAnnotation{}
+	if err := json.Unmarshal([]byte(encodedAnnotation), &annotation); err != nil {
+		return ""
+	}
+
+	if annotation.State != state {
+		return ""
+	}
+
+	return annotation.Since
+}

--- a/sidecar/internal/volume-condition/pvc_annotation_recorder_test.go
+++ b/sidecar/internal/volume-condition/pvc_annotation_recorder_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package condition
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPVCVolumeHealthAnnotationKey(t *testing.T) {
+	assert.Equal(
+		t,
+		"csiaddons.openshift.io/volumehealth.35d4f4a8-0000-1111-2222-2e9fdf21e086",
+		getPVCVolumeHealthAnnotationKey("35d4f4a8-0000-1111-2222-2e9fdf21e086"),
+	)
+}
+
+func TestGetSinceTimestamp(t *testing.T) {
+	empty := getSinceTimestamp("", pvcVolumeHealthAnnotationStateUnhealthy)
+	assert.Equal(t, "", empty)
+
+	invalidJSON := getSinceTimestamp("unhealthy", pvcVolumeHealthAnnotationStateUnhealthy)
+	assert.Equal(t, "", invalidJSON)
+
+	stateMismatch := getSinceTimestamp(
+		`{"state":"healthy","lastChecked":"2026-06-23T05:16:00Z","since":"2026-06-23T04:30:00Z"}`,
+		pvcVolumeHealthAnnotationStateUnhealthy,
+	)
+	assert.Equal(t, "", stateMismatch)
+
+	stateMatch := getSinceTimestamp(
+		`{"state":"unhealthy","lastChecked":"2026-06-23T05:16:00Z","since":"2026-06-23T04:30:00Z"}`,
+		pvcVolumeHealthAnnotationStateUnhealthy,
+	)
+	assert.Equal(t, "2026-06-23T04:30:00Z", stateMatch)
+}
+
+func TestBuildPVCVolumeHealthAnnotationPatchOnlyTouchesLocalKey(t *testing.T) {
+	localNodeUID := "35d4f4a8-0000-1111-2222-2e9fdf21e086"
+	remoteNodeUID := "028ab0a3-1111-2222-3333-f2ad83f31389"
+
+	patch, err := buildPVCVolumeHealthAnnotationPatch(map[string]string{
+		"other": "value",
+		getPVCVolumeHealthAnnotationKey(remoteNodeUID): `{"state":"healthy","lastChecked":"2026-06-23T05:16:00Z","since":"2026-06-23T04:30:00Z","node":"node-b"}`,
+	}, localNodeUID, "node-a", false)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	patchObj := map[string]interface{}{}
+	err = json.Unmarshal(patch, &patchObj)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	patchMetadata, ok := patchObj["metadata"].(map[string]interface{})
+	if !assert.True(t, ok) {
+		return
+	}
+
+	patchAnnotation, ok := patchMetadata["annotations"].(map[string]interface{})
+	if !assert.True(t, ok) {
+		return
+	}
+
+	// The merge-patch should include only the local node annotation key update.
+	assert.Len(t, patchAnnotation, 1)
+	_, found := patchAnnotation[getPVCVolumeHealthAnnotationKey(remoteNodeUID)]
+	assert.False(t, found)
+
+	volumeConditionAnnotationJSON, ok := patchAnnotation[getPVCVolumeHealthAnnotationKey(localNodeUID)].(string)
+	if !assert.True(t, ok) {
+		return
+	}
+
+	volumeConditionAnnotation := pvcVolumeHealthAnnotation{}
+	err = json.Unmarshal([]byte(volumeConditionAnnotationJSON), &volumeConditionAnnotation)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, pvcVolumeHealthAnnotationStateUnhealthy, volumeConditionAnnotation.State)
+	assert.Equal(t, "node-a", volumeConditionAnnotation.Node)
+	// Since the state is changed, the "since" timestamp should be updated.
+	assert.Equal(t, volumeConditionAnnotation.LastChecked, volumeConditionAnnotation.Since)
+	_, err = time.Parse(time.RFC3339, volumeConditionAnnotation.LastChecked)
+	assert.NoError(t, err)
+}
+
+func TestBuildPVCVolumeHealthAnnotationPatchPreservesSinceWhenStateUnchanged(t *testing.T) {
+	nodeUID := "35d4f4a8-0000-1111-2222-2e9fdf21e086"
+
+	patch, err := buildPVCVolumeHealthAnnotationPatch(map[string]string{
+		getPVCVolumeHealthAnnotationKey(nodeUID): `{"state":"unhealthy","lastChecked":"2026-06-23T05:17:00Z","since":"2026-06-23T04:52:00Z","node":"node-a"}`,
+	}, nodeUID, "node-a", false)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	patchObj := map[string]interface{}{}
+	err = json.Unmarshal(patch, &patchObj)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	patchMetadata, ok := patchObj["metadata"].(map[string]interface{})
+	if !assert.True(t, ok) {
+		return
+	}
+
+	patchAnnotation, ok := patchMetadata["annotations"].(map[string]interface{})
+	if !assert.True(t, ok) {
+		return
+	}
+
+	volumeConditionAnnotationJSON, ok := patchAnnotation[getPVCVolumeHealthAnnotationKey(nodeUID)].(string)
+	if !assert.True(t, ok) {
+		return
+	}
+
+	volumeConditionAnnotation := pvcVolumeHealthAnnotation{}
+	err = json.Unmarshal([]byte(volumeConditionAnnotationJSON), &volumeConditionAnnotation)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, pvcVolumeHealthAnnotationStateUnhealthy, volumeConditionAnnotation.State)
+	assert.Equal(t, "node-a", volumeConditionAnnotation.Node)
+	// Since state is unchanged, the original "since" must be preserved.
+	assert.Equal(t, "2026-06-23T04:52:00Z", volumeConditionAnnotation.Since)
+}
+
+func TestBuildPVCVolumeHealthAnnotationPatchRejectsEmptyNodeUID(t *testing.T) {
+	_, err := buildPVCVolumeHealthAnnotationPatch(map[string]string{}, "", "node-a", true)
+	assert.Error(t, err)
+}

--- a/sidecar/internal/volume-condition/recorder.go
+++ b/sidecar/internal/volume-condition/recorder.go
@@ -28,12 +28,19 @@ import (
 // conditionRecorder provides the interface for recorders that will record the
 // volume condition.
 type conditionRecorder interface {
-	record(ctx context.Context, pv *corev1.PersistentVolume, vc volume.VolumeCondition) error
+	record(ctx context.Context, pv *corev1.PersistentVolume, pvc *corev1.PersistentVolumeClaim, vc volume.VolumeCondition) error
+	// needsPVC indicates whether this recorder requires a PVC object.
+	// The reporter fetches PVC details only once, when at least one active recorder
+	// for the current volume condition needs it.
+	needsPVC() bool
+	// recordUnchangedVolumes indicates whether this recorder should be called
+	// when the volume condition does not change between ticks.
+	recordUnchangedVolumes() bool
 }
 
 // RecorderOption is the interface for creating new recorders. The
 // VolumeConditionReporter will use this interface to configure a recorder
 // and uses it to report the volume condition.
 type RecorderOption struct {
-	newRecorder func(client *kubernetes.Clientset, hostname string) (conditionRecorder, error)
+	newRecorder func(client *kubernetes.Clientset, hostname, nodeUID string) (conditionRecorder, error)
 }

--- a/sidecar/internal/volume-condition/reporter.go
+++ b/sidecar/internal/volume-condition/reporter.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -75,12 +76,13 @@ func NewVolumeConditionReporter(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get node %q: %w", hostname, err)
 	}
+	nodeUID := n.UID()
 
 	// TODO: use options for the recorders
 	recorders := make([]conditionRecorder, len(recorderOptions))
 	for i, opt := range recorderOptions {
 		var rec conditionRecorder
-		rec, err = opt.newRecorder(client, hostname)
+		rec, err = opt.newRecorder(client, hostname, nodeUID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create recorder: %w", err)
 		}
@@ -100,7 +102,8 @@ func NewVolumeConditionReporter(
 // Run starts the volume condition reporter. This function never returns, only
 // if a critical error occurs.
 // Only new/updated volume conditions are reported, this prevents noise of
-// recurring conditions.
+// recurring conditions. But, this can be overridden
+// by the "recordUnchangedVolumes" flag on a recorder.
 func (cvr *volumeConditionReporter) Run(ctx context.Context, interval time.Duration) error {
 	running := time.Tick(interval)
 	if running == nil {
@@ -128,12 +131,12 @@ func (cvr *volumeConditionReporter) Run(ctx context.Context, interval time.Durat
 				continue
 			}
 
-			if !cvr.isUpdatedVolumeCondition(v.GetVolumeID(), vc) {
-				// skip recording if there is no update
+			updated := cvr.isUpdatedVolumeCondition(v.GetVolumeID(), vc)
+			if !updated && !cvr.hasAnyRecorderForUnchangedVolume() {
 				continue
 			}
 
-			cvr.recordVolumeCondition(ctx, v.GetVolumeID(), vc)
+			cvr.recordVolumeCondition(ctx, v.GetVolumeID(), vc, updated)
 		}
 
 		cvr.pruneConditionCache(volumes)
@@ -171,7 +174,12 @@ func (cvr *volumeConditionReporter) pruneConditionCache(volumes []volume.CSIVolu
 
 // recordVolumeCondition resolves the PersistentVolume from the given volumeID
 // and loops through all recorders to report the volume condition.
-func (cvr *volumeConditionReporter) recordVolumeCondition(ctx context.Context, volumeID string, vc volume.VolumeCondition) {
+func (cvr *volumeConditionReporter) recordVolumeCondition(
+	ctx context.Context,
+	volumeID string,
+	vc volume.VolumeCondition,
+	updated bool,
+) {
 	pvName, err := platform.GetPlatform().ResolvePersistentVolumeName(cvr.driver.GetDrivername(), volumeID)
 	if err != nil {
 		logger.Error(err, "Failed to resolve persistent volume name")
@@ -184,11 +192,61 @@ func (cvr *volumeConditionReporter) recordVolumeCondition(ctx context.Context, v
 		return
 	}
 
+	claim := pv.Spec.ClaimRef
+	var (
+		pvc    *corev1.PersistentVolumeClaim
+		pvcErr error
+	)
+	// fetch PVC details only once, when at least one active recorder needs it,
+	// instead of fetching it for every recorder, preventing unnecessary API calls.
+	if cvr.hasAnyRecorderNeedingPVC(updated) {
+		if claim == nil {
+			pvcErr = fmt.Errorf("persistent volume %q does not have a claim (unused?)", pv.Name)
+			logger.Error(pvcErr, "Failed to get claim from persistent volume", "pvName", pvName)
+		} else {
+			pvc, pvcErr = cvr.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(ctx, claim.Name, metav1.GetOptions{})
+			if pvcErr != nil {
+				logger.Error(pvcErr, "Failed to get persistent volume claim", "pvcName", claim.Name, "namespace", claim.Namespace)
+			}
+		}
+	}
+
 	for _, recorder := range cvr.recorders {
-		err = recorder.record(ctx, pv, vc)
+		if !updated && !recorder.recordUnchangedVolumes() {
+			continue
+		}
+
+		if recorder.needsPVC() && pvcErr != nil {
+			continue
+		}
+
+		err = recorder.record(ctx, pv, pvc, vc)
 		if err != nil {
 			logger.Error(err, "Failed to record volume condition for persistent volume",
 				"recorder", fmt.Sprintf("%T", recorder), "pvName", pv.Name)
 		}
 	}
+}
+
+func (cvr *volumeConditionReporter) hasAnyRecorderForUnchangedVolume() bool {
+	for _, recorder := range cvr.recorders {
+		if recorder.recordUnchangedVolumes() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (cvr *volumeConditionReporter) hasAnyRecorderNeedingPVC(updated bool) bool {
+	for _, recorder := range cvr.recorders {
+		if !updated && !recorder.recordUnchangedVolumes() {
+			continue
+		}
+		if recorder.needsPVC() {
+			return true
+		}
+	}
+
+	return false
 }

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -51,10 +51,12 @@ var (
 	// available recorders for the --volume-condition-recorders flag
 	volumeConditionLogRecorder      = "log"
 	volumeConditionPVCEventRecorder = "pvcEvent"
+	volumeConditionPVCAnnotation    = "pvcAnnotation"
 
 	defaultVolumeConditionRecorders = strings.Join([]string{
 		volumeConditionLogRecorder,
 		volumeConditionPVCEventRecorder,
+		volumeConditionPVCAnnotation,
 	}, ",")
 )
 
@@ -206,6 +208,8 @@ func main() {
 					recorderOptions = append(recorderOptions, condition.WithLogRecorder())
 				case volumeConditionPVCEventRecorder:
 					recorderOptions = append(recorderOptions, condition.WithEventRecorder())
+				case volumeConditionPVCAnnotation:
+					recorderOptions = append(recorderOptions, condition.WithPVCAnnotationRecorder())
 				default:
 					setupLog.Error(fmt.Errorf("condition recorder %q is unknown", vcr), "Unknown condition recorder")
 					os.Exit(1)


### PR DESCRIPTION
Add a PVC annotation recorder that writes per-node keys (`csiaddons.openshift.io/volumehealth.<hostUID>`).
Records both `healthy` and `unhealthy` states, updates `lastChecked` on each tick/run, adds `since` while state is unchanged and adds `node` which is the node of which PV is attached.

Ref: https://github.com/csi-addons/kubernetes-csi-addons/pull/1048#discussion_r3443180800 for more details.

Other related changes:
`flags: (sidecar) enable volume condition reporting by default (GA)` https://github.com/csi-addons/kubernetes-csi-addons/pull/1050
`feat: (controller) add periodic PVC stale volume health cleanup` https://github.com/csi-addons/kubernetes-csi-addons/pull/1055

## 1. Normal Testing

> CephFS PVCs: 3
> CephRBD PVCs: 62
> CephRBD Virt PVCs: 3

##### Annotated RWX PVC:
```
metadata:
  name: cephfs-rwx-health
  namespace: volume-health-test
  uid: 73a964ac-e133-4c8b-bc43-b999ee930f4c
  resourceVersion: '579908'
  creationTimestamp: '2026-07-13T10:19:26Z'
  annotations:
    csiaddons.openshift.io/volumehealth.6aed389b-2965-463d-ba31-960fa627bba8: '{"state":"healthy","lastChecked":"2026-07-13T10:20:47Z","since":"2026-07-13T10:19:48Z","node":"ip-10-0-42-8.ec2.internal"}'
    csiaddons.openshift.io/volumehealth.7c4f36ac-b7f2-4eda-9fb4-a5ddb4126a86: '{"state":"healthy","lastChecked":"2026-07-13T10:21:15Z","since":"2026-07-13T10:20:15Z","node":"ip-10-0-89-115.ec2.internal"}'
```

##### Annotated RWO PVC:
```
metadata:
  name: cephfs-rwo-health
  namespace: volume-health-test
  uid: 4e836f1a-5bca-491b-800a-6024f0dd698c
  resourceVersion: '581661'
  creationTimestamp: '2026-07-13T10:19:24Z'
  annotations:
    csiaddons.openshift.io/volumehealth.6aed389b-2965-463d-ba31-960fa627bba8: '{"state":"healthy","lastChecked":"2026-07-13T10:22:47Z","since":"2026-07-13T10:19:47Z","node":"ip-10-0-42-8.ec2.internal"}'
```

##### openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addonztvzj Logs:
```
2026-07-13T08:49:47.624Z INFO client Probing CSI driver for readiness
2026-07-13T08:49:47.630Z INFO setup The CSI-plugin does not have the CSI-Addons CONTROLLER_SERVICE capability, not running leader election
2026-07-13T08:49:47.816Z INFO setup Starting volume condition reporter {"driver": "openshift-storage.cephfs.csi.ceph.com"}
2026-07-13T08:49:47.936Z INFO csiaddonsnode Starting watcher for CSIAddonsNode {"name": "ip-10-0-42-8.ec2.internal-openshift-storage-daemonset-openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addons"}
2026-07-13T08:49:48.619Z INFO server Listening for CSI-Addons requests {"address": "[::]:9071"}
2026-07-13T10:19:47.844Z INFO volume-condition Persistent volume is healthy {"pvName": "pvc-4e836f1a-5bca-491b-800a-6024f0dd698c", "message": "volume is in a healthy condition"}
2026-07-13T10:19:47.874Z INFO volume-condition Persistent volume is healthy {"pvName": "pvc-2af09987-c33a-44aa-8673-a34b35c94add", "message": "volume is in a healthy condition"}
2026-07-13T10:19:48.022Z INFO volume-condition Persistent volume is healthy {"pvName": "pvc-73a964ac-e133-4c8b-bc43-b999ee930f4c", "message": "volume is in a healthy condition"}
2026-07-13T10:22:02.525Z INFO csiaddonsnode Watcher exited gracefully, will be restarted soon {"name": "ip-10-0-42-8.ec2.internal-openshift-storage-daemonset-openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addons"}
2026-07-13T10:22:02.552Z INFO csiaddonsnode Starting watcher for CSIAddonsNode {"name": "ip-10-0-42-8.ec2.internal-openshift-storage-daemonset-openshift-storage.cephfs.csi.ceph.com-nodeplugin-csi-addons"}
```

##### csi-addons-controller-manager-bc56675d-f8w4f Logs:
```
2026-07-13T10:48:18.842Z INFO Starting EventSource {"controller": "encryptionkeyrotationcronjob", "controllerGroup": "csiaddons.openshift.io", "controllerKind": "EncryptionKeyRotationCronJob", "source": "kind source: *v1alpha1.EncryptionKeyRotationCronJob"}
2026-07-13T10:48:18.843Z INFO volume-health-cleanup-worker Completed volume health cleanup {"pvcWithVolumeHealth": 65, "pvcCleaned": 0, "malformedSkipped": 0, "errors": 0}
2026-07-13T10:48:18.930Z INFO Starting Controller {"controller": "csiaddonsnode", "controllerGroup": "csiaddons.openshift.io", "controllerKind": "CSIAddonsNode"}
```

##### Events:
<img width="1424" height="808" alt="Screenshot 2026-07-13 at 3 54 23 PM" src="https://github.com/user-attachments/assets/51368970-ab5d-407b-95c1-638e4e631908" />
<img width="1405" height="736" alt="Screenshot 2026-07-13 at 3 54 47 PM" src="https://github.com/user-attachments/assets/272130de-9a83-4ead-a0d6-5fd0ac393960" />

## 2. Load Testing

> Total PVCs (with corresponding Pods) ~ 1000-1100
> Bound PVCs (attached to running Pods) ~ 700-800
> Bound PVCs (attached to pending Pods) ~ 200-300
> CephFS PVCs ~ 50%
> CephRBD PVCs ~ 50%
> Sidecar PVCs condition interval - default 1m

##### Cluster Dashboards:
<img width="899" height="458" alt="Screenshot 2026-07-13 at 5 13 26 PM" src="https://github.com/user-attachments/assets/25dfbf57-db23-436a-b41c-fc59f7d6df19" />
<img width="716" height="490" alt="Screenshot 2026-07-13 at 5 13 33 PM" src="https://github.com/user-attachments/assets/8b17efa5-4a2a-4110-a395-410940645ac7" />
<img width="1197" height="583" alt="Screenshot 2026-07-13 at 5 14 19 PM" src="https://github.com/user-attachments/assets/abd0810a-96e8-445e-84cb-f41542ac7794" />

##### Generated Report:
```
================================================================
  Volume Health Feature — Load Test Report
  Generated: 2026-07-13T12:14:15Z
================================================================

CLUSTER OVERVIEW
────────────────────────────────────────────────────────────────

  Nodes:
    ip-10-0-11-132.ec2.internal              master/infra   Ready    v1.35.5 (max 250 pods)
    ip-10-0-152-236.ec2.internal             worker         v1.35.5  250 (max  pods)
    ip-10-0-169-134.ec2.internal             worker         v1.35.5  250 (max  pods)
    ip-10-0-24-142.ec2.internal              worker         v1.35.5  250 (max  pods)
    ip-10-0-42-8.ec2.internal                worker         v1.35.5  250 (max  pods)
    ip-10-0-47-81.ec2.internal               master/infra   Ready    v1.35.5 (max 250 pods)
    ip-10-0-89-115.ec2.internal              worker         v1.35.5  250 (max  pods)
    ip-10-0-90-58.ec2.internal               master/infra   Ready    v1.35.5 (max 250 pods)

  Pod count per node:
    ip-10-0-90-58.ec2.internal               70 pods
    ip-10-0-89-115.ec2.internal              262 pods
    ip-10-0-47-81.ec2.internal               71 pods
    ip-10-0-42-8.ec2.internal                248 pods
    ip-10-0-24-142.ec2.internal              250 pods
    ip-10-0-169-134.ec2.internal             15 pods
    ip-10-0-152-236.ec2.internal             249 pods
    ip-10-0-11-132.ec2.internal              58 pods
    9h                                       4 pods
    10h                                      27 pods
    (unscheduled/pending)                        279 pods


API SERVER & ETCD METRICS (from Prometheus)
NOTE: VolumeCondition interval used by the Sidecar - (default) 1m
────────────────────────────────────────────────────────────────
[0;36m[INFO][0m Capturing API server metrics...

=== API Server Metrics ===
[0;36m[INFO][0m Found route: thanos-querier -> thanos-querier-openshift-monitoring.apps.dr1-jul-13-26.odf-devcluster.com
[0;36m[INFO][0m Querying Prometheus at thanos-querier-openshift-monitoring.apps.dr1-jul-13-26.odf-devcluster.com...

╔══════════════════════════════════════════════════════════════╗
║  SECTION A: Sidecar → API Server Write Load                ║
║  The sidecar PATCHes PVC annotations with health status.   ║
║  These metrics show how many writes/sec and how fast       ║
║  the API server processes them.                            ║
╚══════════════════════════════════════════════════════════════╝

  [A1] PVC PATCH rate — annotation writes from sidecar (req/s, 5m avg)
  PromQL: sum(rate(apiserver_request_total{verb="PATCH",resource="persistentvolumeclaims"}[5m])) by (instance)
    10.0.11.132:6443: 3.2370 req/s
    10.0.47.81:6443: 0.8667 req/s
    10.0.90.58:6443: 4.3613 req/s
    ── total: 8.4650 req/s

  [A2] PVC PATCH p99 latency — worst-case annotation write time
  PromQL: histogram_quantile(0.99,sum(rate(apiserver_request_duration_seconds_bucket{verb="PATCH",resource="persistentvolumeclaims"}[5m])) by (instance,le))
    10.0.11.132:6443: 24.8 ms
    10.0.47.81:6443: 24.8 ms
    10.0.90.58:6443: 24.8 ms

╔══════════════════════════════════════════════════════════════╗
║  SECTION B: Sidecar → API Server Read Load                 ║
║  Before patching, the sidecar GETs the PVC to read its     ║
║  current annotations. This shows read amplification.       ║
╚══════════════════════════════════════════════════════════════╝

  [B1] PVC GET rate — sidecar reads PVC before patching (req/s, 5m avg)
  PromQL: sum(rate(apiserver_request_total{verb="GET",resource="persistentvolumeclaims"}[5m])) by (instance)
    10.0.11.132:6443: 5.4741 req/s
    10.0.47.81:6443: 3.2667 req/s
    10.0.90.58:6443: 10.4089 req/s
    ── total: 19.1497 req/s

╔══════════════════════════════════════════════════════════════╗
║  SECTION C: PVC Impact — Share of Total API Server Load    ║
║  Compares PVC request rates against the total API server   ║
║  request rate to show what fraction of cluster load comes  ║
║  from the volume health feature.                           ║
╚══════════════════════════════════════════════════════════════╝

  [C1] All PVC operations vs total API server requests (req/s, 5m avg)
  PromQL: sum(rate(apiserver_request_total{resource="persistentvolumeclaims"}[5m])) by (verb)
    PVC GET           18.9678 req/s
    PVC PATCH          8.5485 req/s
    PVC LIST           0.0586 req/s
    PVC WATCH          0.0472 req/s
    PVC DELETE         0.0000 req/s
    PVC PUT            0.0000 req/s
    PVC POST           0.0000 req/s
                   ----------
    PVC total         27.6221 req/s

  [C2] Total API server request rate (all resources, all verbs)
  PromQL: sum(rate(apiserver_request_total[5m]))
    All resources:     188.7716 req/s

  [C3] PVC requests as % of total API server load
  PromQL: sum(rate(apiserver_request_total{resource="persistentvolumeclaims"}[5m])) / sum(rate(apiserver_request_total[5m])) * 100
    PVC share:       14.63%
    Verdict:         MODERATE — PVC operations are a noticeable portion

╔══════════════════════════════════════════════════════════════╗
║  SECTION D: API Server Saturation                          ║
║  How many requests are in-flight right now? High numbers   ║
║  (close to max) indicate the API server is under stress.   ║
╚══════════════════════════════════════════════════════════════╝

  [D1] Inflight requests — summed across all API server instances
  PromQL: sum(apiserver_current_inflight_requests) by (request_kind)
    mutating: 9 inflight
    readOnly: 13 inflight

╔══════════════════════════════════════════════════════════════╗
║  SECTION E: WATCH Fan-out                                  ║
║  Every PVC annotation change triggers WATCH events to all  ║
║  controllers watching PVCs. High rates indicate fan-out    ║
║  amplification from volume health writes.                  ║
╚══════════════════════════════════════════════════════════════╝

  [E1] PVC WATCH rate — watch events triggered by annotation changes (req/s, 5m avg)
  PromQL: sum(rate(apiserver_request_total{verb="WATCH",resource="persistentvolumeclaims"}[5m])) by (instance)
    10.0.11.132:6443: 0.0333 req/s
    10.0.47.81:6443: 0.0111 req/s
    10.0.90.58:6443: 0.0283 req/s
    ── total: 0.0728 req/s
```