### PR TITLE
flags: (sidecar) enable volume condition reporting by default (GA)

### DIFF
--- a/docs/volume-condition.md
+++ b/docs/volume-condition.md
@@ -7,9 +7,8 @@ condition of a volume in the `NodeVolumeStatsResponse` message.
 
 ## Usage
 
-The Volume Condition Reporter is disabled by default. Enabling the
-`--enable-volume-condition` for the CSI-Addons sidecar starts the Volume
-Condition Reporter.
+The Volume Condition Reporter is enabled by default in the CSI-Addons sidecar.
+Use `--enable-volume-condition=false` to disable it.
 
 ## Abnormal Volume Condition reporting
 

--- a/sidecar/internal/volume-condition/reporter.go
+++ b/sidecar/internal/volume-condition/reporter.go
@@ -68,7 +68,12 @@ func NewVolumeConditionReporter(
 	}
 
 	if !drv.SupportsVolumeCondition() {
-		return nil, fmt.Errorf("driver %q does not support volume-condition", drivername)
+		// volume condition is enabled by default, but drivers can still
+		// choose not to support it. Logging instead of calling os.Exit(1) (in main.go) so
+		// that only this feature is skipped and the rest of the sidecar
+		// process continues running normally.
+		logger.Info(fmt.Sprintf("driver %q does not support volume-condition", drivername))
+		return nil, nil
 	}
 
 	n, err := node.NewNode(ctx, client, hostname)

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -82,7 +82,7 @@ func main() {
 		enableAuthChecks            = flag.Bool("enable-auth", true, "Enable Authorization checks and TLS communication (enabled by default)")
 
 		// volume condition reporting
-		enableVolumeCondition    = flag.Bool("enable-volume-condition", false, "Enable reporting of the volume condition")
+		enableVolumeCondition    = flag.Bool("enable-volume-condition", true, "Enable reporting of the volume condition (enabled by default)")
 		volumeConditionInterval  = flag.Duration("volume-condition-interval", 1*time.Minute, "Interval between volume condition checks")
 		volumeConditionRecorders = flag.String("volume-condition-recorders", defaultVolumeConditionRecorders, "location(s) to report volume condition to")
 	)
@@ -217,6 +217,14 @@ func main() {
 			if err != nil {
 				setupLog.Error(err, "Failed to create volume condition reporter")
 				os.Exit(1)
+			}
+			if reporter == nil {
+				// volume condition is enabled by default, but drivers can still
+				// choose not to support it. Logging instead of calling os.Exit(1) so
+				// that only this feature is skipped and the rest of the sidecar
+				// process continues running normally.
+				setupLog.Info("Volume condition reporting is not supported by the driver, skipping", "driver", driver)
+				return
 			}
 
 			setupLog.Info("Starting volume condition reporter", "driver", driver)


### PR DESCRIPTION
Enable '--enable-volume-condition' by default (GA).

Other related changes:
`feat: (sidecar) annotate PVCs with volume health status` https://github.com/csi-addons/kubernetes-csi-addons/pull/1048
`feat: (controller) add periodic PVC stale volume health cleanup` https://github.com/csi-addons/kubernetes-csi-addons/pull/1055