### PR TITLE
controller: Add exponential backoff on gRPC Aborted

### DIFF
--- a/internal/controller/csiaddons/encryptionkeyrotationjob_controller.go
+++ b/internal/controller/csiaddons/encryptionkeyrotationjob_controller.go
@@ -142,6 +142,11 @@ func (r *EncryptionKeyRotationJobReconciler) Reconcile(ctx context.Context, req 
 		return ctrl.Result{}, nil
 	}
 
+	if result, ok := utils.ResultForAbortedError(err, krJob.Status.Retries); ok {
+		logger.Info("Operation aborted, requeuing with backoff", "err", err, "backoff", result.RequeueAfter)
+		return result, nil
+	}
+
 	return ctrl.Result{}, err
 }
 

--- a/internal/controller/csiaddons/reclaimspacejob_controller.go
+++ b/internal/controller/csiaddons/reclaimspacejob_controller.go
@@ -175,6 +175,11 @@ func (r *ReclaimSpaceJobReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{RequeueAfter: nodeClientRequeueInterval}, nil
 	}
 
+	if result, ok := utils.ResultForAbortedError(err, rsJob.Status.Retries); ok {
+		logger.Info("Operation aborted, requeuing with backoff", "err", err, "backoff", result.RequeueAfter)
+		return result, nil
+	}
+
 	return ctrl.Result{}, err
 }
 

--- a/internal/controller/utils/reclaimspace_keyrotation.go
+++ b/internal/controller/utils/reclaimspace_keyrotation.go
@@ -18,10 +18,14 @@ package utils
 
 import (
 	"errors"
+	"math"
+	"time"
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
+	"github.com/csi-addons/kubernetes-csi-addons/internal/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -33,10 +37,26 @@ const (
 	DefaultRetryDeadlineSeconds = 600
 )
 
+const (
+	abortedRequeueBaseDelay = 5 * time.Second
+)
+
 var (
 	ErrConnNotFoundRequeueNeeded = errors.New("connection not found, requeue needed")
 	ErrScheduleNotFound          = errors.New("schedule not found")
 )
+
+// ResultForAbortedError checks if the error is a gRPC Aborted error and
+// returns a Result with exponential backoff based on the retry count.
+// Returns (result, true) if the error was Aborted, (empty, false) otherwise.
+func ResultForAbortedError(err error, retries int32) (ctrl.Result, bool) {
+	if !util.IsAbortedError(err) {
+		return ctrl.Result{}, false
+	}
+
+	backoff := abortedRequeueBaseDelay * time.Duration(math.Pow(2, float64(retries)))
+	return ctrl.Result{RequeueAfter: backoff}, true
+}
 
 func setKeyrotationSpec(v *csiaddonsv1alpha1.EncryptionKeyRotationCronJob, schedule, pvcName string) {
 	if v == nil {

--- a/internal/util/error.go
+++ b/internal/util/error.go
@@ -41,3 +41,17 @@ func IsUnimplementedError(err error) bool {
 
 	return s.Code() == codes.Unimplemented
 }
+
+// IsAbortedError returns true if the error is a gRPC Aborted error.
+func IsAbortedError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	s, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+
+	return s.Code() == codes.Aborted
+}

--- a/internal/util/error_test.go
+++ b/internal/util/error_test.go
@@ -108,3 +108,48 @@ func TestIsUmplementedError(t *testing.T) {
 		})
 	}
 }
+
+func TestIsAbortedError(t *testing.T) {
+	type input struct {
+		err error
+	}
+	tests := []struct {
+		name string
+		args input
+		want bool
+	}{
+		{
+			name: "nil error",
+			args: input{
+				err: nil,
+			},
+			want: false,
+		},
+		{
+			name: "Aborted error",
+			args: input{
+				err: status.Error(codes.Aborted, "aborted"),
+			},
+			want: true,
+		},
+		{
+			name: "Non aborted error",
+			args: input{
+				err: status.Error(codes.NotFound, "not found"),
+			},
+			want: false,
+		},
+		{
+			name: "Non grpc status error",
+			args: input{
+				err: errors.New("new error"),
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsAbortedError(tt.args.err))
+		})
+	}
+}


### PR DESCRIPTION
When a gRPC request returns `codes.Aborted`, the error was returned directly to controller which requeues with its default ~5ms backoff. This exhausted all retries in under 500ms.

This patch adds exponential backoff when `codes.Aborted` is returned, using `RequeueAfter` instead of the default rate-limited requeue.

Commonly encountered with RelcaimSpace on large PVCs where `fstrim` might take longer to complete. The job was marked failed even when the `fstrim` succeeded (retries exhausted before job completion).