### PR TITLE
feat: (controller) add periodic PVC stale volume health cleanup

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -76,6 +76,7 @@ func main() {
 		metricsAddr                 string
 		probeAddr                   string
 		enableLeaderElection        bool
+		enableVolumeHealthCleanup   bool
 		enableHTTP2                 bool
 		leaderElectionLeaseDuration time.Duration
 		leaderElectionRenewDeadline time.Duration
@@ -108,6 +109,9 @@ func main() {
 	flag.IntVar(&cfg.MaxGroupPVC, "max-group-pvc", cfg.MaxGroupPVC, "Maximum number of PVCs allowed in a volume group")
 	flag.IntVar(&cfg.CSIAddonsNodeRetryDelay, util.CsiaddonsNodeRetryDelayKey, cfg.CSIAddonsNodeRetryDelay, "Duration, in seconds, the CSIAddonsNode reconciler must wait before retrying the connection to csi-addons sidecar")
 	flag.IntVar(&cfg.CronJobStaggerWindow, util.CronJobStaggerWindowKey, cfg.CronJobStaggerWindow, "Duration, in hours, that the CronJobs for KeyRotation and ReclaimSpace are staggered within. Defaults to 2 hours, set as 0 to disable.")
+	flag.BoolVar(&enableVolumeHealthCleanup, "enable-volume-health-cleanup", true, "Enable stale PVC volume health annotation cleanup worker")
+	flag.DurationVar(&cfg.VolumeHealthCleanupInterval, util.VolumeHealthCleanupIntervalKey, cfg.VolumeHealthCleanupInterval, "Interval at which stale PVC volume health annotations are scanned and cleaned up")
+	flag.DurationVar(&cfg.VolumeHealthStaleThreshold, util.VolumeHealthStaleThresholdKey, cfg.VolumeHealthStaleThreshold, "Age after which a PVC volume health annotation is considered stale and eligible for cleanup")
 	opts := zap.Options{
 		Development: true,
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
@@ -327,6 +331,19 @@ func main() {
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder
+
+	if enableVolumeHealthCleanup {
+		if err = mgr.Add(&controllers.VolumeHealthCleanupWorker{
+			Client:          mgr.GetClient(),
+			CleanupInterval: cfg.VolumeHealthCleanupInterval,
+			StaleThreshold:  cfg.VolumeHealthStaleThreshold,
+		}); err != nil {
+			setupLog.Error(err, "unable to add runnable", "runnable", "VolumeHealthCleanupWorker")
+			os.Exit(1)
+		}
+	} else {
+		setupLog.Info("Volume health cleanup worker is disabled by flag")
+	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")

--- a/deploy/controller/csi-addons-config.yaml
+++ b/deploy/controller/csi-addons-config.yaml
@@ -11,3 +11,5 @@ data:
   "max-group-pvcs": "100"
   "csi-addons-node-retry-delay": "5"
   "cronjob-stagger-window": "2"
+  "volume-health-cleanup-interval": "30m"
+  "volume-health-stale-threshold": "2h"

--- a/docs/csi-addons-config.md
+++ b/docs/csi-addons-config.md
@@ -4,13 +4,15 @@ CSI-Addons Operator can consume configuration from a ConfigMap named `csi-addons
 in the same namespace as the operator. This enables configuration of the operator to persist across
 upgrades. The ConfigMap can support the following configuration options:
 
-| Option                        | Default value | Description                                                                                                              |
-| ----------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `max-concurrent-reconciles`   | `"100"`       | Maximum number of concurrent reconciles                                                                                  |
-| `max-group-pvcs`              | `"100"`       | Maximum number of PVCs allowed in a volume group                                                                         |
-| `csi-addons-node-retry-delay` | `"5"`         | Duration, in seconds, that csi-addons reconcile must wait before retrying connection to the sidecar                      |
-| `schedule-precedence`         | `"pvc"`       | The order in which the schedule annotation should be read                                                                |
-| `cronjob-stagger-window`      | `"2"`         | Maximum stagger window, in hours, for key rotation and reclaim space CronJob schedules. Set to `0` to disable staggering |
+| Option                           | Default value | Description                                                                                                              |
+| -------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `max-concurrent-reconciles`      | `"100"`       | Maximum number of concurrent reconciles                                                                                  |
+| `max-group-pvcs`                 | `"100"`       | Maximum number of PVCs allowed in a volume group                                                                         |
+| `csi-addons-node-retry-delay`    | `"5"`         | Duration, in seconds, that csi-addons reconcile must wait before retrying connection to the sidecar                      |
+| `schedule-precedence`            | `"pvc"`       | The order in which the schedule annotation should be read                                                                |
+| `cronjob-stagger-window`         | `"2"`         | Maximum stagger window, in hours, for key rotation and reclaim space CronJob schedules. Set to `0` to disable staggering |
+| `volume-health-cleanup-interval` | `"30m"`       | Interval for addons-controller stale volume health annotation cleanup runs                                               |
+| `volume-health-stale-threshold`  | `"2h"`        | Threshold age after which a per-node volume health annotation is considered stale and removed                            |
 
 [`csi-addons-config` ConfigMap](../deploy/controller/csi-addons-config.yaml) is provided as an example.
 

--- a/docs/deploy-controller.md
+++ b/docs/deploy-controller.md
@@ -6,16 +6,20 @@ The CSI-Addons Controller can be deployed by different ways:
 
 **Available command-line arguments:**
 
-| Option                        | Default value | Description                                    |
-| ----------------------------- | ------------- | ---------------------------------------------- |
-| `--metrics-bind-address`      | `:8080`       | The address the metric endpoint binds to.      |
-| `--health-probe-bind-address` | `:8081`       | The address the probe endpoint binds to.       |
-| `--leader-elect`              | `false`       | Enable leader election for controller manager. |
-| `--reclaim-space-timeout`     | `3m`          | Timeout for reclaimspace operation             |
-| `--max-concurrent-reconciles` | 100           | Maximum number of concurrent reconciles        |
-| `--enable-auth`               | true          | Enable adding SA tokens to headers and TLS     |
+| Option                             | Default value | Description                                                        |
+| ---------------------------------- | ------------- | ------------------------------------------------------------------ |
+| `--metrics-bind-address`           | `:8080`       | The address the metric endpoint binds to.                          |
+| `--health-probe-bind-address`      | `:8081`       | The address the probe endpoint binds to.                           |
+| `--leader-elect`                   | `false`       | Enable leader election for controller manager.                     |
+| `--reclaim-space-timeout`          | `3m`          | Timeout for reclaimspace operation                                 |
+| `--max-concurrent-reconciles`      | 100           | Maximum number of concurrent reconciles                            |
+| `--enable-auth`                    | true          | Enable adding SA tokens to headers and TLS                         |
+| `--volume-health-cleanup-interval` | `30m`         | Interval for stale PVC volume health annotation cleanup runs       |
+| `--volume-health-stale-threshold`  | `2h`          | Staleness threshold for removing per-node volume health annotation |
 
 > Note: Some of the above configuration options can also be configured using [`"csi-addons-config"` configmap](./csi-addons-config.md).
+>
+> Note: When `--enable-volume-health-cleanup=false`, the volume health cleanup worker is disabled.
 
 ## Installation for latest deployments
 

--- a/docs/volume-condition.md
+++ b/docs/volume-condition.md
@@ -40,6 +40,21 @@ written by sidecars running on other nodes.
 Users will see the Event in their Namespace, and also when they describe (with
 `kubectl describe ...`) the PersistentVolumeClaim.
 
+### Stale Annotation Cleanup
+
+Stale health annotations are cleaned up by the addons-controller with periodic
+cleanup. The cleanup removes complete per-node keys when their
+`lastChecked` value is older than a configured stale threshold.
+
+Cleanup behavior:
+
+- cleanup is eventual, not immediate
+- cleanup interval and stale threshold are configurable
+- cleanup can be disabled with `--enable-volume-health-cleanup=false`
+  (default is enabled)
+- only stale `csiaddons.openshift.io/volumehealth.<node-uid>` keys are removed
+- other annotation keys on the PVC are preserved
+
 ### Future Enhancements
 
 Additional options for reporting include:

--- a/internal/controller/csiaddons/volumehealth_cleanup_controller.go
+++ b/internal/controller/csiaddons/volumehealth_cleanup_controller.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	volumeHealthAnnotationKeyPrefix = "csiaddons.openshift.io/volumehealth."
+)
+
+type volumeHealthAnnotation struct {
+	State       string `json:"state"`
+	LastChecked string `json:"lastChecked"`
+	Since       string `json:"since"`
+}
+
+type VolumeHealthCleanupWorker struct {
+	client.Client
+	CleanupInterval time.Duration
+	StaleThreshold  time.Duration
+}
+
+func (w *VolumeHealthCleanupWorker) Start(ctx context.Context) error {
+	if w.CleanupInterval <= 0 {
+		return fmt.Errorf("volume health cleanup interval must be > 0")
+	}
+
+	if w.StaleThreshold <= 0 {
+		return fmt.Errorf("volume health stale threshold must be > 0")
+	}
+
+	logger := ctrllog.FromContext(ctx).WithName("volume-health-cleanup-worker")
+	// Run an initial cleanup, until the first ticker interval runs.
+	if err := w.runCleanup(ctx, logger); err != nil {
+		logger.Error(err, "Initial cleanup failed")
+	}
+
+	ticker := time.NewTicker(w.CleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("Stopping volume health cleanup worker")
+
+			return nil
+		case <-ticker.C:
+			if err := w.runCleanup(ctx, logger); err != nil {
+				logger.Error(err, "Cleanup failed")
+			}
+		}
+	}
+}
+
+func (w *VolumeHealthCleanupWorker) runCleanup(ctx context.Context, logger logr.Logger) error {
+	var pvcList corev1.PersistentVolumeClaimList
+	if err := w.List(ctx, &pvcList); err != nil {
+		return fmt.Errorf("failed to list PVCs for stale volume health cleanup: %w", err)
+	}
+
+	now := time.Now()
+	pvcWithVolumeHealth := 0
+	cleanedPVCs := 0
+	skippedMalformed := 0
+	cleanupErrors := 0
+
+	for i := range pvcList.Items {
+		pvc := &pvcList.Items[i]
+		if pvc.DeletionTimestamp != nil || len(pvc.Annotations) == 0 {
+			continue
+		}
+
+		staleKeys, malformedCount, hasVolumeHealth := staleVolumeHealthAnnotationKeys(logger, pvc.Namespace, pvc.Name, pvc.Annotations, now, w.StaleThreshold)
+		if hasVolumeHealth {
+			pvcWithVolumeHealth++
+		}
+		skippedMalformed += malformedCount
+		if len(staleKeys) == 0 {
+			continue
+		}
+
+		patch, err := staleAnnotationDeletePatch(staleKeys)
+		if err != nil {
+			cleanupErrors++
+			logger.Error(err, "Failed to build stale annotation cleanup patch", "pvc", pvc.Name, "namespace", pvc.Namespace)
+
+			continue
+		}
+
+		if err := w.Patch(ctx, pvc, client.RawPatch(types.StrategicMergePatchType, patch)); err != nil {
+			cleanupErrors++
+			logger.Error(err, "Failed to patch stale volume health annotations", "pvc", pvc.Name, "namespace", pvc.Namespace)
+
+			continue
+		}
+
+		cleanedPVCs++
+	}
+
+	logger.Info("Completed volume health cleanup",
+		"pvcWithVolumeHealth", pvcWithVolumeHealth,
+		"pvcCleaned", cleanedPVCs,
+		"malformedSkipped", skippedMalformed,
+		"errors", cleanupErrors)
+
+	return nil
+}
+
+func staleVolumeHealthAnnotationKeys(
+	logger logr.Logger,
+	namespace string,
+	pvcName string,
+	annotations map[string]string,
+	now time.Time,
+	staleThreshold time.Duration,
+) ([]string, int, bool) {
+	staleKeys := make([]string, 0)
+	malformedCount := 0
+	hasVolumeHealth := false
+
+	for key, val := range annotations {
+		if !strings.HasPrefix(key, volumeHealthAnnotationKeyPrefix) {
+			continue
+		}
+		hasVolumeHealth = true
+
+		lastChecked, err := annotationLastChecked(val)
+		if err != nil {
+			malformedCount++
+			logger.Error(err, "Skipping malformed volume health annotation",
+				"namespace", namespace,
+				"pvc", pvcName,
+				"annotationKey", key)
+			continue
+		}
+
+		if now.Sub(lastChecked) > staleThreshold {
+			staleKeys = append(staleKeys, key)
+		}
+	}
+
+	return staleKeys, malformedCount, hasVolumeHealth
+}
+
+func staleAnnotationDeletePatch(keys []string) ([]byte, error) {
+	annotationPatch := make(map[string]interface{}, len(keys))
+	for _, key := range keys {
+		annotationPatch[key] = nil
+	}
+
+	patch := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": annotationPatch,
+		},
+	}
+
+	return json.Marshal(patch)
+}
+
+func annotationLastChecked(payload string) (time.Time, error) {
+	var state volumeHealthAnnotation
+	if err := json.Unmarshal([]byte(payload), &state); err != nil {
+		return time.Time{}, err
+	}
+
+	if state.LastChecked == "" {
+		return time.Time{}, fmt.Errorf("missing lastChecked")
+	}
+
+	parsed, err := time.Parse(time.RFC3339, state.LastChecked)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return parsed, nil
+}

--- a/internal/controller/csiaddons/volumehealth_cleanup_controller_test.go
+++ b/internal/controller/csiaddons/volumehealth_cleanup_controller_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestStaleVolumeHealthAnnotationKeys(t *testing.T) {
+	now := time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+	annotations := map[string]string{
+		"csiaddons.openshift.io/volumehealth.node-a": `{"state":"unhealthy","lastChecked":"2026-06-24T07:30:00Z","since":"2026-06-24T07:00:00Z"}`,
+		"csiaddons.openshift.io/volumehealth.node-b": `{"state":"healthy","lastChecked":"2026-06-24T09:50:00Z"}`,
+		"csiaddons.openshift.io/volumehealth.node-c": `{"state":"unhealthy","lastchecked":"2026-06-24T07:45:00Z"}`,
+		"csiaddons.openshift.io/volumehealth.node-d": `{"state":"healthy"}`,
+		"example.com/other":                          "value",
+	}
+
+	keys, malformed, hasVolumeHealth := staleVolumeHealthAnnotationKeys(logr.Discard(), "default", "test-pvc", annotations, now, time.Hour)
+
+	assert.ElementsMatch(t, []string{
+		"csiaddons.openshift.io/volumehealth.node-a",
+		"csiaddons.openshift.io/volumehealth.node-c",
+	}, keys)
+	assert.Equal(t, 1, malformed)
+	assert.True(t, hasVolumeHealth)
+}
+
+func TestCleanupOnceRemovesOnlyStaleVolumeHealthAnnotations(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+
+	now := time.Now().UTC()
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"csiaddons.openshift.io/volumehealth.node-a": `{"state":"unhealthy","lastChecked":"` + now.Add(-3*time.Hour).Format(time.RFC3339) + `"}`,
+				"csiaddons.openshift.io/volumehealth.node-b": `{"state":"healthy","lastChecked":"` + now.Add(-5*time.Minute).Format(time.RFC3339) + `"}`,
+				"example.com/keep":                           "true",
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc).
+		Build()
+
+	worker := &VolumeHealthCleanupWorker{
+		Client:          cl,
+		CleanupInterval: 30 * time.Minute,
+		StaleThreshold:  time.Hour,
+	}
+
+	assert.NoError(t, worker.runCleanup(context.Background(), logr.Discard()))
+
+	got := &corev1.PersistentVolumeClaim{}
+	assert.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, got))
+	assert.NotContains(t, got.Annotations, "csiaddons.openshift.io/volumehealth.node-a")
+	assert.Contains(t, got.Annotations, "csiaddons.openshift.io/volumehealth.node-b")
+	assert.Equal(t, "true", got.Annotations["example.com/keep"])
+}
+
+func TestCleanupOnceSkipsMalformedPayload(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+
+	now := time.Now().UTC()
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pvc-malformed",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"csiaddons.openshift.io/volumehealth.node-a": `{"state":"unhealthy","lastChecked":"not-a-time"}`,
+				"csiaddons.openshift.io/volumehealth.node-b": `{"state":"healthy","lastChecked":"` + now.Add(-2*time.Minute).Format(time.RFC3339) + `"}`,
+			},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pvc).
+		Build()
+
+	worker := &VolumeHealthCleanupWorker{
+		Client:          cl,
+		CleanupInterval: 30 * time.Minute,
+		StaleThreshold:  time.Hour,
+	}
+
+	assert.NoError(t, worker.runCleanup(context.Background(), logr.Discard()))
+
+	got := &corev1.PersistentVolumeClaim{}
+	assert.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}, got))
+	assert.Contains(t, got.Annotations, "csiaddons.openshift.io/volumehealth.node-a")
+	assert.Contains(t, got.Annotations, "csiaddons.openshift.io/volumehealth.node-b")
+}

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -31,43 +31,51 @@ import (
 // Config holds the configuration options that
 // can be overrrided via a config file.
 type Config struct {
-	Namespace               string
-	ReclaimSpaceTimeout     time.Duration
-	MaxConcurrentReconciles int
-	SchedulePrecedence      string
-	MaxGroupPVC             int
-	CSIAddonsNodeRetryDelay int
-	CronJobStaggerWindow    int
+	Namespace                   string
+	ReclaimSpaceTimeout         time.Duration
+	MaxConcurrentReconciles     int
+	SchedulePrecedence          string
+	MaxGroupPVC                 int
+	CSIAddonsNodeRetryDelay     int
+	CronJobStaggerWindow        int
+	VolumeHealthCleanupInterval time.Duration
+	VolumeHealthStaleThreshold  time.Duration
 }
 
 const (
-	csiAddonsConfigMapName         = "csi-addons-config"
-	ReclaimSpaceTimeoutKey         = "reclaim-space-timeout"
-	MaxConcurrentReconcilesKey     = "max-concurrent-reconciles"
-	defaultNamespace               = "csi-addons-system"
-	defaultMaxConcurrentReconciles = 100
-	defaultReclaimSpaceTimeout     = time.Minute * 3
-	SchedulePrecedenceKey          = "schedule-precedence"
-	ScheduleSC                     = "storageclass"
-	SchedulePVC                    = "pvc"
-	MaxGroupPVCKey                 = "max-group-pvcs"
-	defaultMaxGroupPVC             = 100 // based on ceph's support/testing
-	defaultCSIAddonsNodeRetryDelay = 5   // seconds
-	CsiaddonsNodeRetryDelayKey     = "csi-addons-node-retry-delay"
-	defaultCronJobStaggerWindow    = 2
-	CronJobStaggerWindowKey        = "cronjob-stagger-window"
+	csiAddonsConfigMapName             = "csi-addons-config"
+	ReclaimSpaceTimeoutKey             = "reclaim-space-timeout"
+	MaxConcurrentReconcilesKey         = "max-concurrent-reconciles"
+	defaultNamespace                   = "csi-addons-system"
+	defaultMaxConcurrentReconciles     = 100
+	defaultReclaimSpaceTimeout         = time.Minute * 3
+	SchedulePrecedenceKey              = "schedule-precedence"
+	ScheduleSC                         = "storageclass"
+	SchedulePVC                        = "pvc"
+	MaxGroupPVCKey                     = "max-group-pvcs"
+	defaultMaxGroupPVC                 = 100 // based on ceph's support/testing
+	defaultCSIAddonsNodeRetryDelay     = 5   // seconds
+	CsiaddonsNodeRetryDelayKey         = "csi-addons-node-retry-delay"
+	defaultCronJobStaggerWindow        = 2
+	CronJobStaggerWindowKey            = "cronjob-stagger-window"
+	defaultVolumeHealthCleanupInterval = 30 * time.Minute
+	defaultVolumeHealthStaleThreshold  = 2 * time.Hour
+	VolumeHealthCleanupIntervalKey     = "volume-health-cleanup-interval"
+	VolumeHealthStaleThresholdKey      = "volume-health-stale-threshold"
 )
 
 // NewConfig returns a new Config object with default values.
 func NewConfig() Config {
 	return Config{
-		Namespace:               defaultNamespace,
-		ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-		MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-		SchedulePrecedence:      SchedulePVC,
-		MaxGroupPVC:             defaultMaxGroupPVC,
-		CSIAddonsNodeRetryDelay: defaultCSIAddonsNodeRetryDelay,
-		CronJobStaggerWindow:    defaultCronJobStaggerWindow,
+		Namespace:                   defaultNamespace,
+		ReclaimSpaceTimeout:         defaultReclaimSpaceTimeout,
+		MaxConcurrentReconciles:     defaultMaxConcurrentReconciles,
+		SchedulePrecedence:          SchedulePVC,
+		MaxGroupPVC:                 defaultMaxGroupPVC,
+		CSIAddonsNodeRetryDelay:     defaultCSIAddonsNodeRetryDelay,
+		CronJobStaggerWindow:        defaultCronJobStaggerWindow,
+		VolumeHealthCleanupInterval: defaultVolumeHealthCleanupInterval,
+		VolumeHealthStaleThreshold:  defaultVolumeHealthStaleThreshold,
 	}
 }
 
@@ -133,6 +141,11 @@ func (cfg *Config) readConfig(dataMap map[string]string) error {
 				return err
 			}
 
+		case VolumeHealthCleanupIntervalKey, VolumeHealthStaleThresholdKey:
+			if err := cfg.validateAndSetVolumeHealthConfig(key, val); err != nil {
+				return err
+			}
+
 		default:
 			return fmt.Errorf("unknown config key %q", key)
 		}
@@ -190,6 +203,28 @@ func (cfg *Config) validateAndSetStaggerWindow(val string) error {
 	}
 
 	cfg.CronJobStaggerWindow = win
+
+	return nil
+}
+
+func (cfg *Config) validateAndSetVolumeHealthConfig(key, val string) error {
+	duration, err := time.ParseDuration(val)
+	if err != nil {
+		return fmt.Errorf("failed to parse key %q value %q as duration: %w", key, val, err)
+	}
+
+	if duration <= 0 {
+		return fmt.Errorf("invalid value %q for key %q", val, key)
+	}
+
+	switch key {
+	case VolumeHealthCleanupIntervalKey:
+		cfg.VolumeHealthCleanupInterval = duration
+	case VolumeHealthStaleThresholdKey:
+		cfg.VolumeHealthStaleThreshold = duration
+	default:
+		return fmt.Errorf("invalid volume health config key %q", key)
+	}
 
 	return nil
 }

--- a/internal/util/config_test.go
+++ b/internal/util/config_test.go
@@ -31,47 +31,69 @@ func TestConfigReadConfigFile(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name:    "config file does not exist",
-			dataMap: nil,
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
+			name:      "config file does not exist",
+			dataMap:   nil,
+			newConfig: expectedConfig(nil),
+			wantErr:   false,
+		},
+		{
+			name:      "config file does exist but empty configuration",
+			dataMap:   make(map[string]string),
+			newConfig: expectedConfig(nil),
+			wantErr:   false,
+		},
+		{
+			name: "config file modifies volume-health-cleanup-interval",
+			dataMap: map[string]string{
+				"volume-health-cleanup-interval": "45m",
 			},
+			newConfig: expectedConfig(func(cfg *Config) {
+				cfg.VolumeHealthCleanupInterval = 45 * time.Minute
+			}),
 			wantErr: false,
 		},
 		{
-			name:    "config file does exist but empty configuration",
-			dataMap: make(map[string]string),
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
+			name: "config file has invalid volume-health-cleanup-interval",
+			dataMap: map[string]string{
+				"volume-health-cleanup-interval": "invalid",
 			},
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
+		},
+		{
+			name: "config file has non positive volume-health-cleanup-interval",
+			dataMap: map[string]string{
+				"volume-health-cleanup-interval": "0s",
+			},
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
+		},
+		{
+			name: "config file modifies volume-health-stale-threshold",
+			dataMap: map[string]string{
+				"volume-health-stale-threshold": "3h",
+			},
+			newConfig: expectedConfig(func(cfg *Config) {
+				cfg.VolumeHealthStaleThreshold = 3 * time.Hour
+			}),
 			wantErr: false,
+		},
+		{
+			name: "config file has invalid volume-health-stale-threshold",
+			dataMap: map[string]string{
+				"volume-health-stale-threshold": "hours",
+			},
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
 		},
 		{
 			name: "config file modifies reclaim-space-timeout",
 			dataMap: map[string]string{
 				"reclaim-space-timeout": "10m",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     time.Minute * 10,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
+			newConfig: expectedConfig(func(cfg *Config) {
+				cfg.ReclaimSpaceTimeout = 10 * time.Minute
+			}),
 			wantErr: false,
 		},
 		{
@@ -79,31 +101,17 @@ func TestConfigReadConfigFile(t *testing.T) {
 			dataMap: map[string]string{
 				"reclaim-space-timeout": "hours",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
-			wantErr: true,
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
 		},
 		{
 			name: "config file modifies max-concurrent-reconciles",
 			dataMap: map[string]string{
 				"max-concurrent-reconciles": "1",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: 1,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
+			newConfig: expectedConfig(func(cfg *Config) {
+				cfg.MaxConcurrentReconciles = 1
+			}),
 			wantErr: false,
 		},
 		{
@@ -111,16 +119,8 @@ func TestConfigReadConfigFile(t *testing.T) {
 			dataMap: map[string]string{
 				"max-concurrent-reconciles": "invalid",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
-			wantErr: true,
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
 		},
 		{
 			name: "config file modifies both reclaim-space-timeout and max-concurrent-reconciles",
@@ -128,15 +128,10 @@ func TestConfigReadConfigFile(t *testing.T) {
 				"reclaim-space-timeout":     "10m",
 				"max-concurrent-reconciles": "5",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     time.Minute * 10,
-				MaxConcurrentReconciles: 5,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
+			newConfig: expectedConfig(func(cfg *Config) {
+				cfg.ReclaimSpaceTimeout = 10 * time.Minute
+				cfg.MaxConcurrentReconciles = 5
+			}),
 			wantErr: false,
 		},
 		{
@@ -144,47 +139,25 @@ func TestConfigReadConfigFile(t *testing.T) {
 			dataMap: map[string]string{
 				"network-fence-duration": "3m",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
-			wantErr: true,
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
 		},
 		{
 			name: "config file modifies schedule-precedence to pvc",
 			dataMap: map[string]string{
 				"schedule-precedence": "pvc",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
-			wantErr: false,
+			newConfig: expectedConfig(nil),
+			wantErr:   false,
 		},
 		{
 			name: "config file modifies schedule-precedence to storageclass",
 			dataMap: map[string]string{
 				"schedule-precedence": "storageclass",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      ScheduleSC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
+			newConfig: expectedConfig(func(cfg *Config) {
+				cfg.SchedulePrecedence = ScheduleSC
+			}),
 			wantErr: false,
 		},
 		{
@@ -192,15 +165,9 @@ func TestConfigReadConfigFile(t *testing.T) {
 			dataMap: map[string]string{
 				"schedule-precedence": "sc-only",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      ScheduleSC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
+			newConfig: expectedConfig(func(cfg *Config) {
+				cfg.SchedulePrecedence = ScheduleSC
+			}),
 			wantErr: false,
 		},
 		{
@@ -208,63 +175,33 @@ func TestConfigReadConfigFile(t *testing.T) {
 			dataMap: map[string]string{
 				"schedule-precedence": "invalid-precedence",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
-			wantErr: true,
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
 		},
 		{
 			name: "config file has empty schedule-precedence which was once valid and inferred as pvc",
 			dataMap: map[string]string{
 				"schedule-precedence": "",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
-			wantErr: false,
+			newConfig: expectedConfig(nil),
+			wantErr:   false,
 		},
 		{
 			name: "config file has empty max-group-pvcs",
 			dataMap: map[string]string{
 				"max-group-pvcs": "",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
-			wantErr: true,
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
 		},
 		{
 			name: "config file modifies max-group-pvcs",
 			dataMap: map[string]string{
 				"max-group-pvcs": "25",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             25,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
+			newConfig: expectedConfig(func(cfg *Config) {
+				cfg.MaxGroupPVC = 25
+			}),
 			wantErr: false,
 		},
 		{
@@ -272,47 +209,25 @@ func TestConfigReadConfigFile(t *testing.T) {
 			dataMap: map[string]string{
 				"max-group-pvcs": "200",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
-			wantErr: true,
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
 		},
 		{
 			name: "config file has empty csi-addons-node-retry-delay",
 			dataMap: map[string]string{
 				"csi-addons-node-retry-delay": "",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
-			wantErr: true,
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
 		},
 		{
 			name: "config file modifies csi-addons-node-retry-delay",
 			dataMap: map[string]string{
 				"csi-addons-node-retry-delay": "30",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 30,
-				CronJobStaggerWindow:    2,
-			},
+			newConfig: expectedConfig(func(cfg *Config) {
+				cfg.CSIAddonsNodeRetryDelay = 30
+			}),
 			wantErr: false,
 		},
 		{
@@ -320,31 +235,17 @@ func TestConfigReadConfigFile(t *testing.T) {
 			dataMap: map[string]string{
 				"csi-addons-node-retry-delay": "0",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
-			wantErr: true,
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
 		},
 		{
 			name: "config file modifies cronjob-stagger-window",
 			dataMap: map[string]string{
 				"cronjob-stagger-window": "5",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    5,
-			},
+			newConfig: expectedConfig(func(cfg *Config) {
+				cfg.CronJobStaggerWindow = 5
+			}),
 			wantErr: false,
 		},
 		{
@@ -352,31 +253,17 @@ func TestConfigReadConfigFile(t *testing.T) {
 			dataMap: map[string]string{
 				"cronjob-stagger-window": "",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    2,
-			},
-			wantErr: true,
+			newConfig: expectedConfig(nil),
+			wantErr:   true,
 		},
 		{
 			name: "config file sets cronjob-stagger-window to zero to disable",
 			dataMap: map[string]string{
 				"cronjob-stagger-window": "0",
 			},
-			newConfig: Config{
-				Namespace:               defaultNamespace,
-				ReclaimSpaceTimeout:     defaultReclaimSpaceTimeout,
-				MaxConcurrentReconciles: defaultMaxConcurrentReconciles,
-				SchedulePrecedence:      SchedulePVC,
-				MaxGroupPVC:             100,
-				CSIAddonsNodeRetryDelay: 5,
-				CronJobStaggerWindow:    0,
-			},
+			newConfig: expectedConfig(func(cfg *Config) {
+				cfg.CronJobStaggerWindow = 0
+			}),
 			wantErr: false,
 		},
 	}
@@ -390,4 +277,14 @@ func TestConfigReadConfigFile(t *testing.T) {
 			assert.Equal(t, tt.newConfig, cfg)
 		})
 	}
+}
+
+func expectedConfig(override func(*Config)) Config {
+	cfg := NewConfig()
+
+	if override != nil {
+		override(&cfg)
+	}
+
+	return cfg
 }


### PR DESCRIPTION
Add an addons-controller background cleanup worker that periodically removes stale volume health PVC annotations based on lastChecked and configurable interval/threshold settings.

Ref: https://github.com/csi-addons/kubernetes-csi-addons/pull/1048#discussion_r3443180800 for more details.

Other related changes:
`feat: (sidecar) annotate PVCs with volume health status` https://github.com/csi-addons/kubernetes-csi-addons/pull/1048
`flags: (sidecar) enable volume condition reporting by default (GA)` https://github.com/csi-addons/kubernetes-csi-addons/pull/1050

## 1. Normal Testing

##### csi-addons-controller-manager-bc56675d-w2qx4 Logs:
```
2026-07-13T12:45:46.541Z	INFO	volume-health-cleanup-worker	Completed volume health cleanup	{"pvcWithVolumeHealth": 794, "pvcCleaned": 710, "malformedSkipped": 0, "errors": 0}
2026-07-13T12:45:46.565Z	INFO	Reconciling PVC	{"controller": "persistentvolumeclaim", "controllerGroup": "", "controllerKind": "PersistentVolumeClaim", "PersistentVolumeClaim": {"name":"loadtest-fs-pvc-0398","namespace":"volume-health-loadtest"}, "namespace": "volume-health-loadtest", "name": "loadtest-fs-pvc-0398", "reconcileID": "d5637547-9a1a-435c-bdf9-729126b45065", "PVCInfo": {"name":"loadtest-fs-pvc-0398","namespace":"volume-health-loadtest"}}
```

##### PVC Annotations (when bound to a running pod):
```
// RWX (2 replicas using the PV on diff nodes)
metadata:
  name: cephfs-rwx-health
  namespace: volume-health-test
  uid: 73a964ac-e133-4c8b-bc43-b999ee930f4c
  resourceVersion: '808945'
  creationTimestamp: '2026-07-13T10:19:26Z'
  annotations:
    csiaddons.openshift.io/volumehealth.6aed389b-2965-463d-ba31-960fa627bba8: '{"state":"healthy","lastChecked":"2026-07-13T12:44:00Z","since":"2026-07-13T12:44:00Z","node":"ip-10-0-42-8.ec2.internal"}'
    csiaddons.openshift.io/volumehealth.7c4f36ac-b7f2-4eda-9fb4-a5ddb4126a86: '{"state":"healthy","lastChecked":"2026-07-13T12:42:59Z","since":"2026-07-13T12:42:59Z","node":"ip-10-0-89-115.ec2.internal"}'

// RWO
metadata:
  annotations:
    csiaddons.openshift.io/volumehealth.7c4f36ac-b7f2-4eda-9fb4-a5ddb4126a86: '{"state":"healthy","lastChecked":"2026-07-13T12:42:47Z","since":"2026-07-13T12:42:47Z","node":"ip-10-0-89-115.ec2.internal"}'
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"storage-type":"rbd","test":"volume-health-loadtest"},"name":"loadtest-rbd-pvc-0052","namespace":"volume-health-loadtest"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"ocs-storagecluster-ceph-rbd"}}
    pv.kubernetes.io/bind-completed: 'yes'
    pv.kubernetes.io/bound-by-controller: 'yes'
    volume.beta.kubernetes.io/storage-provisioner: openshift-storage.rbd.csi.ceph.com
    volume.kubernetes.io/storage-provisioner: openshift-storage.rbd.csi.ceph.com
  resourceVersion: '806844'
  name: loadtest-rbd-pvc-0052
```

##### PVC Annotations (when stale, not bound to a running pod, pod scaled down or deleted):
```
// RWX (replica scaled down to 1 only)
metadata:
  name: cephfs-rwx-health
  namespace: volume-health-test
  uid: 73a964ac-e133-4c8b-bc43-b999ee930f4c
  resourceVersion: '812682'
  creationTimestamp: '2026-07-13T10:19:26Z'
  annotations:
    csiaddons.openshift.io/volumehealth.6aed389b-2965-463d-ba31-960fa627bba8: '{"state":"healthy","lastChecked":"2026-07-13T12:45:54Z","since":"2026-07-13T12:45:54Z","node":"ip-10-0-42-8.ec2.internal"}'
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"name":"cephfs-rwx-health","namespace":"volume-health-test"},"spec":{"accessModes":["ReadWriteMany"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"ocs-storagecluster-cephfs"}}
    pv.kubernetes.io/bind-completed: 'yes'
    pv.kubernetes.io/bound-by-controller: 'yes'
    volume.beta.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com
    volume.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com

// RWO
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"annotations":{},"labels":{"storage-type":"rbd","test":"volume-health-loadtest"},"name":"loadtest-rbd-pvc-0052","namespace":"volume-health-loadtest"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"1Gi"}},"storageClassName":"ocs-storagecluster-ceph-rbd"}}
    pv.kubernetes.io/bind-completed: 'yes'
    pv.kubernetes.io/bound-by-controller: 'yes'
    volume.beta.kubernetes.io/storage-provisioner: openshift-storage.rbd.csi.ceph.com
    volume.kubernetes.io/storage-provisioner: openshift-storage.rbd.csi.ceph.com
  resourceVersion: '812430'
  name: loadtest-rbd-pvc-0052
  uid: e9fe8081-55e1-4ac9-8583-717eeab83139
```

## 2. Load Testing
Please refer to https://github.com/csi-addons/kubernetes-csi-addons/pull/1048#issue-4690946556.