### PR TITLE
Introduce TLS config options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 # Copy the contents of the repository
 COPY . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons

--- a/build/Containerfile.sidecar
+++ b/build/Containerfile.sidecar
@@ -1,5 +1,5 @@
 # Build the sidecar binary
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 # Copy the contents of the repository
 COPY . /workspace/go/src/github.com/csi-addons/kubernetes-csi-addons

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csi-addons/kubernetes-csi-addons
 
-go 1.25.7
+go 1.26.0
 
 require (
 	github.com/container-storage-interface/spec v1.12.0

--- a/internal/controller/replication.storage/volumegroupreplication_controller.go
+++ b/internal/controller/replication.storage/volumegroupreplication_controller.go
@@ -195,8 +195,8 @@ func (r *VolumeGroupReplicationReconciler) Reconcile(ctx context.Context, req ct
 			return reconcile.Result{}, err
 		}
 		if len(pvcList) > r.MaxGroupPVCCount {
-			err = fmt.Errorf("more than %q PVCs match the given selector", r.MaxGroupPVCCount)
-			r.log.Error(err, "only %q PVCs are allowed for volume group replication", r.MaxGroupPVCCount)
+			err = fmt.Errorf("more than %d PVCs match the given selector", r.MaxGroupPVCCount)
+			r.log.Error(err, "only %d PVCs are allowed for volume group replication", r.MaxGroupPVCCount)
 			_ = r.setGroupReplicationFailure(instance, err)
 			return reconcile.Result{}, err
 		}

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -52,7 +52,7 @@ const (
 	SchedulePVC                    = "pvc"
 	MaxGroupPVCKey                 = "max-group-pvcs"
 	defaultMaxGroupPVC             = 100 // based on ceph's support/testing
-	defaultCSIAddonsNodeRetryDelay = 5   //seconds
+	defaultCSIAddonsNodeRetryDelay = 5   // seconds
 	CsiaddonsNodeRetryDelayKey     = "csi-addons-node-retry-delay"
 	defaultCronJobStaggerWindow    = 2
 	CronJobStaggerWindowKey        = "cronjob-stagger-window"
@@ -176,7 +176,7 @@ func (cfg *Config) validateAndSetCSIAddonsNodeRetryDelay(val string) error {
 	}
 
 	if delay < 1 {
-		return fmt.Errorf("got an invalid value: %q for key: %q", delay, CsiaddonsNodeRetryDelayKey)
+		return fmt.Errorf("got an invalid value: %d for key: %q", delay, CsiaddonsNodeRetryDelayKey)
 	}
 	cfg.CSIAddonsNodeRetryDelay = delay
 

--- a/internal/util/tls.go
+++ b/internal/util/tls.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+)
+
+type TLSOptions struct {
+	MinVersion       string
+	CipherSuites     string
+	CurvePreferences string
+}
+
+var tlsVersions = map[string]uint16{
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+var curveIDs = func() map[string]tls.CurveID {
+	ids := []tls.CurveID{
+		tls.CurveP256,
+		tls.CurveP384,
+		tls.CurveP521,
+		tls.X25519,
+		tls.X25519MLKEM768,
+		tls.SecP256r1MLKEM768,
+		tls.SecP384r1MLKEM1024,
+	}
+	m := make(map[string]tls.CurveID, len(ids))
+	for _, id := range ids {
+		m[id.String()] = id
+	}
+	return m
+}()
+
+// BuildTLSConfig validates the given TLSOptions and returns a *tls.Config.
+// Empty option values result in Go defaults being used.
+func BuildTLSConfig(opts TLSOptions) (*tls.Config, error) {
+	config := &tls.Config{}
+
+	if opts.MinVersion != "" {
+		v, ok := tlsVersions[opts.MinVersion]
+		if !ok {
+			return nil, fmt.Errorf(
+				"unsupported TLS version %q, supported values: VersionTLS12, VersionTLS13",
+				opts.MinVersion,
+			)
+		}
+		config.MinVersion = v
+	}
+
+	if opts.CipherSuites != "" {
+		supported := make(map[string]uint16)
+		for _, cs := range tls.CipherSuites() {
+			supported[cs.Name] = cs.ID
+		}
+
+		var suiteIDs []uint16
+		for name := range strings.SplitSeq(opts.CipherSuites, ",") {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			id, ok := supported[name]
+			if !ok {
+				return nil, fmt.Errorf("unsupported cipher suite %q", name)
+			}
+			suiteIDs = append(suiteIDs, id)
+		}
+		if len(suiteIDs) == 0 {
+			return nil, fmt.Errorf("no valid cipher suites specified")
+		}
+		config.CipherSuites = suiteIDs
+	}
+
+	if opts.CurvePreferences != "" {
+		var curves []tls.CurveID
+		for name := range strings.SplitSeq(opts.CurvePreferences, ",") {
+			name = strings.TrimSpace(name)
+			if name == "" {
+				continue
+			}
+			id, ok := curveIDs[name]
+			if !ok {
+				supported := make([]string, 0, len(curveIDs))
+				for k := range curveIDs {
+					supported = append(supported, k)
+				}
+				return nil, fmt.Errorf(
+					"unsupported curve %q, supported values: %s",
+					name, strings.Join(supported, ", "),
+				)
+			}
+			curves = append(curves, id)
+		}
+		if len(curves) == 0 {
+			return nil, fmt.Errorf("no valid curves specified")
+		}
+		config.CurvePreferences = curves
+	}
+
+	return config, nil
+}

--- a/internal/util/tls_test.go
+++ b/internal/util/tls_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		opts        TLSOptions
+		wantErr     string
+		checkConfig func(t *testing.T, cfg *tls.Config)
+	}{
+		{
+			name: "empty options use defaults",
+			opts: TLSOptions{},
+			checkConfig: func(t *testing.T, cfg *tls.Config) {
+				assert.Equal(t, uint16(0), cfg.MinVersion)
+				assert.Nil(t, cfg.CipherSuites)
+				assert.Nil(t, cfg.CurvePreferences)
+			},
+		},
+		{
+			name: "valid TLS 1.2",
+			opts: TLSOptions{MinVersion: "VersionTLS12"},
+			checkConfig: func(t *testing.T, cfg *tls.Config) {
+				assert.Equal(t, uint16(tls.VersionTLS12), cfg.MinVersion)
+			},
+		},
+		{
+			name: "valid TLS 1.3",
+			opts: TLSOptions{MinVersion: "VersionTLS13"},
+			checkConfig: func(t *testing.T, cfg *tls.Config) {
+				assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+			},
+		},
+		{
+			name:    "invalid TLS version",
+			opts:    TLSOptions{MinVersion: "VersionTLS11"},
+			wantErr: "unsupported TLS version",
+		},
+		{
+			name: "valid cipher suite",
+			opts: TLSOptions{CipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+			checkConfig: func(t *testing.T, cfg *tls.Config) {
+				assert.Len(t, cfg.CipherSuites, 1)
+			},
+		},
+		{
+			name: "multiple cipher suites",
+			opts: TLSOptions{CipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+			checkConfig: func(t *testing.T, cfg *tls.Config) {
+				assert.Len(t, cfg.CipherSuites, 2)
+			},
+		},
+		{
+			name:    "invalid cipher suite",
+			opts:    TLSOptions{CipherSuites: "TLS_INVALID_CIPHER"},
+			wantErr: "unsupported cipher suite",
+		},
+		{
+			name: "valid curve X25519",
+			opts: TLSOptions{CurvePreferences: "X25519"},
+			checkConfig: func(t *testing.T, cfg *tls.Config) {
+				if assert.Len(t, cfg.CurvePreferences, 1) {
+					assert.Equal(t, tls.X25519, cfg.CurvePreferences[0])
+				}
+			},
+		},
+		{
+			name: "multiple curves",
+			opts: TLSOptions{CurvePreferences: "X25519,CurveP256,CurveP384"},
+			checkConfig: func(t *testing.T, cfg *tls.Config) {
+				if assert.Len(t, cfg.CurvePreferences, 3) {
+					assert.Equal(t, tls.X25519, cfg.CurvePreferences[0])
+					assert.Equal(t, tls.CurveP256, cfg.CurvePreferences[1])
+					assert.Equal(t, tls.CurveP384, cfg.CurvePreferences[2])
+				}
+			},
+		},
+		{
+			name:    "invalid curve",
+			opts:    TLSOptions{CurvePreferences: "InvalidCurve"},
+			wantErr: "unsupported curve",
+		},
+		{
+			name: "all options set",
+			opts: TLSOptions{
+				MinVersion:       "VersionTLS13",
+				CipherSuites:     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+				CurvePreferences: "X25519,CurveP256",
+			},
+			checkConfig: func(t *testing.T, cfg *tls.Config) {
+				assert.Equal(t, uint16(tls.VersionTLS13), cfg.MinVersion)
+				assert.Len(t, cfg.CipherSuites, 1)
+				assert.Len(t, cfg.CurvePreferences, 2)
+			},
+		},
+		{
+			name: "whitespace in comma-separated values is trimmed",
+			opts: TLSOptions{CurvePreferences: "X25519 , CurveP256"},
+			checkConfig: func(t *testing.T, cfg *tls.Config) {
+				if assert.Len(t, cfg.CurvePreferences, 2) {
+					assert.Equal(t, tls.X25519, cfg.CurvePreferences[0])
+					assert.Equal(t, tls.CurveP256, cfg.CurvePreferences[1])
+				}
+			},
+		},
+		{
+			name: "trailing comma is ignored",
+			opts: TLSOptions{CurvePreferences: "X25519,"},
+			checkConfig: func(t *testing.T, cfg *tls.Config) {
+				if assert.Len(t, cfg.CurvePreferences, 1) {
+					assert.Equal(t, tls.X25519, cfg.CurvePreferences[0])
+				}
+			},
+		},
+		{
+			name:    "only commas in cipher suites yields error",
+			opts:    TLSOptions{CipherSuites: ",,"},
+			wantErr: "no valid cipher suites specified",
+		},
+		{
+			name:    "only whitespace in curves yields error",
+			opts:    TLSOptions{CurvePreferences: " , , "},
+			wantErr: "no valid curves specified",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg, err := BuildTLSConfig(tt.opts)
+			if tt.wantErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			if assert.NoError(t, err) && assert.NotNil(t, cfg) {
+				if tt.checkConfig != nil {
+					tt.checkConfig(t, cfg)
+				}
+			}
+		})
+	}
+}

--- a/sidecar/internal/server/server.go
+++ b/sidecar/internal/server/server.go
@@ -51,12 +51,13 @@ type SidecarServer struct {
 	server           *grpc.Server
 	services         []SidecarService
 	enableAuthChecks bool
+	tlsConfig        *tls.Config
 }
 
 // NewSidecarServer create a new SidecarServer on the given IP-address and
 // port. If the IP-address is an empty string, the server will listen on all
 // available IP-addresses. Only tcp ports are supported.
-func NewSidecarServer(ip, port string, client *k8s.Clientset, enableAuthChecks bool) *SidecarServer {
+func NewSidecarServer(ip, port string, client *k8s.Clientset, enableAuthChecks bool, tlsConfig *tls.Config) *SidecarServer {
 	ss := &SidecarServer{}
 
 	if ss.services == nil {
@@ -67,6 +68,7 @@ func NewSidecarServer(ip, port string, client *k8s.Clientset, enableAuthChecks b
 	ss.endpoint = ip + ":" + port
 	ss.client = client
 	ss.enableAuthChecks = enableAuthChecks
+	ss.tlsConfig = tlsConfig
 	return ss
 }
 
@@ -86,12 +88,13 @@ func (ss *SidecarServer) Start() {
 			panic("Failed to generate self-signed certificate: " + err.Error())
 		}
 
-		// Create TLS credentials
-		creds := credentials.NewTLS(&tls.Config{
-			Certificates: []tls.Certificate{cert},
-		})
-		// create the gRPC server and register services
-		ss.server = grpc.NewServer(grpc.UnaryInterceptor(token.AuthorizationInterceptor(*ss.client)), grpc.Creds(creds))
+		tlsConfig := ss.tlsConfig.Clone()
+		tlsConfig.Certificates = []tls.Certificate{cert}
+		creds := credentials.NewTLS(tlsConfig)
+
+		ss.server = grpc.NewServer(
+			grpc.UnaryInterceptor(token.AuthorizationInterceptor(*ss.client)),
+			grpc.Creds(creds))
 	} else {
 		ss.server = grpc.NewServer()
 	}

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -81,6 +81,10 @@ func main() {
 		leaderElectionRetryPeriod   = flag.Duration("leader-election-retry-period", 5*time.Second, "Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds.")
 		enableAuthChecks            = flag.Bool("enable-auth", true, "Enable Authorization checks and TLS communication (enabled by default)")
 
+		tlsMinVersion       = flag.String("tls-min-version", "", "Minimum TLS version (VersionTLS12, VersionTLS13). Empty uses Go default (TLS 1.2)")
+		tlsCipherSuites     = flag.String("tls-cipher-suites", "", "Comma-separated list of TLS 1.2 cipher suites using Go names. Empty uses Go defaults. Ignored for TLS 1.3 connections")
+		tlsCurvePreferences = flag.String("tls-curve-preferences", "", "Comma-separated list of preferred key exchange curves/groups using Go names (X25519, CurveP256, CurveP384, CurveP521, X25519MLKEM768, SecP256r1MLKEM768, SecP384r1MLKEM1024). Empty uses Go defaults")
+
 		// volume condition reporting
 		enableVolumeCondition    = flag.Bool("enable-volume-condition", false, "Enable reporting of the volume condition")
 		volumeConditionInterval  = flag.Duration("volume-condition-interval", 1*time.Minute, "Interval between volume condition checks")
@@ -142,6 +146,16 @@ func main() {
 	controllerEndpoint, err := sideutil.BuildEndpointURL(*controllerIP, *controllerPort, *podName, *podNamespace)
 	if err != nil {
 		setupLog.Error(err, "Failed to validate controller endpoint")
+		os.Exit(1)
+	}
+
+	tlsConfig, err := util.BuildTLSConfig(util.TLSOptions{
+		MinVersion:       *tlsMinVersion,
+		CipherSuites:     *tlsCipherSuites,
+		CurvePreferences: *tlsCurvePreferences,
+	})
+	if err != nil {
+		setupLog.Error(err, "Invalid TLS configuration")
 		os.Exit(1)
 	}
 
@@ -228,7 +242,7 @@ func main() {
 		}()
 	}
 
-	sidecarServer := server.NewSidecarServer(*controllerIP, *controllerPort, kubeClient, *enableAuthChecks)
+	sidecarServer := server.NewSidecarServer(*controllerIP, *controllerPort, kubeClient, *enableAuthChecks, tlsConfig)
 	sidecarServer.RegisterService(service.NewIdentityServer(csiClient.GetGRPCClient()))
 	sidecarServer.RegisterService(service.NewReclaimSpaceServer(csiClient.GetGRPCClient(), kubeClient, *stagingPath))
 	sidecarServer.RegisterService(service.NewNetworkFenceServer(csiClient.GetGRPCClient(), kubeClient))


### PR DESCRIPTION
## Summary

Add command-line flags to configure the sidecar gRPC server's TLS profile, allowing administrators to enforce minimum TLS versions, restrict cipher suites, and select preferred key exchange curves including post-quantum hybrid KEMs introduced in Go 1.26.

### New flags

| Flag | Description | Default |
|------|-------------|---------|
| `--tls-min-version` | Minimum TLS version (`VersionTLS12`, `VersionTLS13`) | Go default (TLS 1.2) |
| `--tls-cipher-suites` | Comma-separated list of TLS 1.2 cipher suites (Go names) | Go defaults |
| `--tls-curve-preferences` | Comma-separated preferred curves/groups (`X25519`, `CurveP256`, `CurveP384`, `CurveP521`, `X25519MLKEM768`, `SecP256r1MLKEM768`, `SecP384r1MLKEM1024`) | Go defaults |