### PR TITLE
controller: fix for missed runs due to stagger window

### DIFF
--- a/internal/controller/csiaddons/encryptionkeyrotationcronjob_controller.go
+++ b/internal/controller/csiaddons/encryptionkeyrotationcronjob_controller.go
@@ -307,17 +307,22 @@ func getNextScheduleForKeyRotation(
 	} else {
 		earliestTime = krcJob.CreationTimestamp.Time
 	}
+
+	rawNext := sched.Next(now)
+	staggeredNext := utils.GetStaggeredNext(krcJob.UID, rawNext, sched, staggerWindow)
+	staggerOffset := staggeredNext.Sub(rawNext)
+
 	if krcJob.Spec.StartingDeadlineSeconds != nil {
-		// controller is not going to schedule anything below this point
-		schedulingDeadline := now.Add(-time.Second * time.Duration(*krcJob.Spec.StartingDeadlineSeconds))
+		// Account for the stagger offset so that the intentional
+		// delay does not count against the starting deadline.
+		deadline := time.Second * time.Duration(*krcJob.Spec.StartingDeadlineSeconds)
+		schedulingDeadline := now.Add(-deadline - staggerOffset)
 
 		if schedulingDeadline.After(earliestTime) {
 			earliestTime = schedulingDeadline
 		}
 	}
 
-	rawNext := sched.Next(now)
-	staggeredNext := utils.GetStaggeredNext(krcJob.UID, rawNext, sched, staggerWindow)
 	if earliestTime.After(now) {
 		return time.Time{}, staggeredNext, nil
 	}
@@ -338,7 +343,9 @@ func getNextScheduleForKeyRotation(
 					" delete and recreate encryptionkeyrotationjob")
 		}
 	}
-	return lastMissed, staggeredNext, nil
+
+	staggeredMissed := utils.GetStaggeredNext(krcJob.UID, lastMissed, sched, staggerWindow)
+	return staggeredMissed, staggeredNext, nil
 }
 
 // constructEncryptionKeyRotationJob forms an EncryptionKeyRotationJob for a given

--- a/internal/controller/csiaddons/encryptionkeyrotationcronjob_controller_test.go
+++ b/internal/controller/csiaddons/encryptionkeyrotationcronjob_controller_test.go
@@ -18,15 +18,110 @@ package controller
 
 import (
 	"context"
+	"testing"
+	"time"
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
+	"github.com/csi-addons/kubernetes-csi-addons/internal/controller/utils"
 
 	"github.com/onsi/ginkgo/v2"
 	gomega "github.com/onsi/gomega"
+	"github.com/robfig/cron/v3"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
+
+func TestGetNextScheduleForKeyRotation(t *testing.T) {
+	now := time.Now()
+	expectedLastMissed := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	mustParse := func(sched string) cron.Schedule {
+		s, err := cron.ParseStandard(sched)
+		if err != nil {
+			t.Fatalf("Failed to parse cron spec %q: %v", sched, err)
+		}
+		return s
+	}
+
+	t.Run("Valid schedule, no deadline, last schedule time exists", func(t *testing.T) {
+		uid := types.UID("kr-valid-sched-1")
+		krcJob := &csiaddonsv1alpha1.EncryptionKeyRotationCronJob{
+			ObjectMeta: metav1.ObjectMeta{UID: uid},
+			Spec: csiaddonsv1alpha1.EncryptionKeyRotationCronJobSpec{
+				Schedule: "0 0 * * *",
+			},
+			Status: csiaddonsv1alpha1.EncryptionKeyRotationCronJobStatus{
+				LastScheduleTime: &metav1.Time{Time: now.Add(-24 * time.Hour).Truncate(24 * time.Hour).Local()},
+			},
+		}
+		gotLastMissed, gotNextSchedule, err := getNextScheduleForKeyRotation(krcJob, now, 2)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		sched := mustParse("0 0 * * *")
+		expectedStaggered := utils.GetStaggeredNext(uid, expectedLastMissed, sched, 2)
+		if !gotLastMissed.Equal(expectedStaggered) {
+			t.Errorf("got last missed = %v, want %v", gotLastMissed, expectedStaggered)
+		}
+		nextSchedule := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local).Add(24 * time.Hour)
+		expectedNext := utils.GetStaggeredNext(uid, nextSchedule, sched, 2)
+		if !gotNextSchedule.Equal(expectedNext) {
+			t.Errorf("got next schedule = %v, want %v", gotNextSchedule, expectedNext)
+		}
+	})
+
+	t.Run("Staggered lastMissed preserves StartingDeadlineSeconds validity", func(t *testing.T) {
+		schedule := "0 0 * * *"
+		staggerCap := 2
+		uid := types.UID("kr-stagger-deadline-1")
+		sched, err := cron.ParseStandard(schedule)
+		if err != nil {
+			t.Fatalf("Failed to parse schedule: %v", err)
+		}
+
+		midnight := time.Date(2026, 7, 15, 0, 0, 0, 0, time.Local)
+		prevMidnight := midnight.Add(-24 * time.Hour)
+		nextMidnight := midnight.Add(24 * time.Hour)
+
+		staggeredNext := utils.GetStaggeredNext(uid, nextMidnight, sched, staggerCap)
+		staggerOffset := staggeredNext.Sub(nextMidnight)
+
+		testNow := midnight.Add(staggerOffset + 10*time.Second)
+		startingDeadline := int64(staggerOffset.Seconds() / 2)
+		if startingDeadline < 60 {
+			startingDeadline = 60
+		}
+
+		krcJob := &csiaddonsv1alpha1.EncryptionKeyRotationCronJob{
+			ObjectMeta: metav1.ObjectMeta{UID: uid},
+			Spec: csiaddonsv1alpha1.EncryptionKeyRotationCronJobSpec{
+				Schedule:                schedule,
+				StartingDeadlineSeconds: ptr.To(startingDeadline),
+			},
+			Status: csiaddonsv1alpha1.EncryptionKeyRotationCronJobStatus{
+				LastScheduleTime: &metav1.Time{Time: prevMidnight},
+			},
+		}
+
+		gotLastMissed, _, err := getNextScheduleForKeyRotation(krcJob, testNow, staggerCap)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		expectedStaggered := utils.GetStaggeredNext(uid, midnight, sched, staggerCap)
+		if !gotLastMissed.Equal(expectedStaggered) {
+			t.Errorf("got last missed = %v, want %v (staggered from %v)", gotLastMissed, expectedStaggered, midnight)
+		}
+
+		deadline := time.Duration(startingDeadline) * time.Second
+		if gotLastMissed.Add(deadline).Before(testNow) {
+			t.Errorf("staggered lastMissed %v + deadline %v is before now %v; run would be incorrectly skipped",
+				gotLastMissed, deadline, testNow)
+		}
+	})
+}
 
 var _ = ginkgo.Describe("EncryptionKeyRotationCronJob Controller", func() {
 	ginkgo.Context("When reconciling a resource", func() {

--- a/internal/controller/csiaddons/reclaimspacecronjob_controller.go
+++ b/internal/controller/csiaddons/reclaimspacecronjob_controller.go
@@ -370,17 +370,22 @@ func getNextSchedule(
 	} else {
 		earliestTime = rsCronJob.CreationTimestamp.Time
 	}
+
+	rawNext := sched.Next(now)
+	staggeredNext := utils.GetStaggeredNext(rsCronJob.UID, rawNext, sched, staggerWindow)
+	staggerOffset := staggeredNext.Sub(rawNext)
+
 	if rsCronJob.Spec.StartingDeadlineSeconds != nil {
-		// controller is not going to schedule anything below this point
-		schedulingDeadline := now.Add(-time.Second * time.Duration(*rsCronJob.Spec.StartingDeadlineSeconds))
+		// Account for the stagger offset so that the intentional
+		// delay does not count against the starting deadline.
+		deadline := time.Second * time.Duration(*rsCronJob.Spec.StartingDeadlineSeconds)
+		schedulingDeadline := now.Add(-deadline - staggerOffset)
 
 		if schedulingDeadline.After(earliestTime) {
 			earliestTime = schedulingDeadline
 		}
 	}
 
-	rawNext := sched.Next(now)
-	staggeredNext := utils.GetStaggeredNext(rsCronJob.UID, rawNext, sched, staggerWindow)
 	if earliestTime.After(now) {
 		return time.Time{}, staggeredNext, nil
 	}
@@ -401,5 +406,7 @@ func getNextSchedule(
 					" delete and recreate reclaimspacecronjob")
 		}
 	}
-	return lastMissed, staggeredNext, nil
+
+	staggeredMissed := utils.GetStaggeredNext(rsCronJob.UID, lastMissed, sched, staggerWindow)
+	return staggeredMissed, staggeredNext, nil
 }

--- a/internal/controller/csiaddons/reclaimspacecronjob_controller_test.go
+++ b/internal/controller/csiaddons/reclaimspacecronjob_controller_test.go
@@ -163,7 +163,7 @@ func TestGetNextSchedule(t *testing.T) {
 					},
 					Spec: csiaddonsv1alpha1.ReclaimSpaceCronJobSpec{
 						Schedule:                "0 0 * * *",
-						StartingDeadlineSeconds: ptr.To(int64(3600)),
+						StartingDeadlineSeconds: ptr.To(int64(86400)),
 					},
 					Status: csiaddonsv1alpha1.ReclaimSpaceCronJobStatus{
 						LastScheduleTime: &metav1.Time{Time: now.Add(-24 * time.Hour).Truncate(24 * time.Hour).Local()},
@@ -184,7 +184,7 @@ func TestGetNextSchedule(t *testing.T) {
 					},
 					Spec: csiaddonsv1alpha1.ReclaimSpaceCronJobSpec{
 						Schedule:                "*/1 * * * *",
-						StartingDeadlineSeconds: ptr.To(int64(6000)),
+						StartingDeadlineSeconds: ptr.To(int64(5880)),
 					},
 					Status: csiaddonsv1alpha1.ReclaimSpaceCronJobStatus{
 						LastScheduleTime: &metav1.Time{Time: now.Add(-time.Hour * 2)},
@@ -205,7 +205,7 @@ func TestGetNextSchedule(t *testing.T) {
 					},
 					Spec: csiaddonsv1alpha1.ReclaimSpaceCronJobSpec{
 						Schedule:                "*/1 * * * *",
-						StartingDeadlineSeconds: ptr.To(int64(6060)),
+						StartingDeadlineSeconds: ptr.To(int64(6120)),
 					},
 					Status: csiaddonsv1alpha1.ReclaimSpaceCronJobStatus{
 						LastScheduleTime: &metav1.Time{Time: now.Add(-time.Hour * 2)},
@@ -230,15 +230,76 @@ func TestGetNextSchedule(t *testing.T) {
 				return
 			}
 
-			if !gotLastMissed.Equal(tt.lastMissed) && !gotLastMissed.Equal(time.Time{}) {
-				t.Errorf("getNextSchedule() got last missed = %v, want %v", gotLastMissed, tt.lastMissed)
+			sched := mustParse(tt.args.rsCronJob.Spec.Schedule)
+
+			if !tt.lastMissed.IsZero() {
+				expectedStaggered := utils.GetStaggeredNext(tt.args.rsCronJob.UID, tt.lastMissed, sched, 2)
+				if !gotLastMissed.Equal(expectedStaggered) {
+					t.Errorf("getNextSchedule() got last missed = %v, want %v (staggered from %v)", gotLastMissed, expectedStaggered, tt.lastMissed)
+				}
+			} else if !gotLastMissed.IsZero() {
+				t.Errorf("getNextSchedule() got last missed = %v, want zero", gotLastMissed)
 			}
 
-			sched := mustParse(tt.args.rsCronJob.Spec.Schedule)
 			staggered := utils.GetStaggeredNext(tt.args.rsCronJob.UID, tt.nextSchedule, sched, 2)
 			if !gotNextSchedule.Equal(staggered) {
 				t.Errorf("getNextSchedule() got next schedule = %v, want %v", gotNextSchedule, staggered)
 			}
 		})
+	}
+}
+
+func TestGetNextSchedule_StaggerPreservesStartingDeadline(t *testing.T) {
+	schedule := "0 0 * * *"
+	staggerCap := 2
+	uid := types.UID("stagger-deadline-rs")
+	sched, err := cron.ParseStandard(schedule)
+	if err != nil {
+		t.Fatalf("Failed to parse schedule: %v", err)
+	}
+
+	midnight := time.Date(2026, 7, 15, 0, 0, 0, 0, time.Local)
+	prevMidnight := midnight.Add(-24 * time.Hour)
+	nextMidnight := midnight.Add(24 * time.Hour)
+
+	staggeredNext := utils.GetStaggeredNext(uid, nextMidnight, sched, staggerCap)
+	staggerOffset := staggeredNext.Sub(nextMidnight)
+
+	// Simulate the controller waking up just after the staggered time.
+	testNow := midnight.Add(staggerOffset + 10*time.Second)
+	// Set StartingDeadlineSeconds smaller than the stagger offset.
+	// Without the fix, this would cause the scheduling deadline window
+	// to exclude midnight, silently skipping the run.
+	startingDeadline := int64(staggerOffset.Seconds() / 2)
+	if startingDeadline < 60 {
+		startingDeadline = 60
+	}
+
+	rsCronJob := &csiaddonsv1alpha1.ReclaimSpaceCronJob{
+		ObjectMeta: metav1.ObjectMeta{UID: uid},
+		Spec: csiaddonsv1alpha1.ReclaimSpaceCronJobSpec{
+			Schedule:                schedule,
+			StartingDeadlineSeconds: ptr.To(startingDeadline),
+		},
+		Status: csiaddonsv1alpha1.ReclaimSpaceCronJobStatus{
+			LastScheduleTime: &metav1.Time{Time: prevMidnight},
+		},
+	}
+
+	gotLastMissed, _, err := getNextSchedule(rsCronJob, testNow, staggerCap)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedStaggered := utils.GetStaggeredNext(uid, midnight, sched, staggerCap)
+	if !gotLastMissed.Equal(expectedStaggered) {
+		t.Errorf("got last missed = %v, want %v (staggered from %v)", gotLastMissed, expectedStaggered, midnight)
+	}
+
+	// The reconciler's "too late" check must not trigger.
+	deadline := time.Duration(startingDeadline) * time.Second
+	if gotLastMissed.Add(deadline).Before(testNow) {
+		t.Errorf("staggered lastMissed %v + deadline %v is before now %v; run would be incorrectly skipped",
+			gotLastMissed, deadline, testNow)
 	}
 }

--- a/internal/controller/utils/schedule.go
+++ b/internal/controller/utils/schedule.go
@@ -30,8 +30,8 @@ import (
 // GetStaggeredNext returns a deterministic, UID-based staggered time computed from a schedule.
 // The staggered window is capped at a maximum of `cap` but is adjusted for smaller intervals.
 func GetStaggeredNext(uid apiTypes.UID, nextTime time.Time, sched cron.Schedule, cap int) time.Time {
-	// if cap is set to 0, do not apply any stagger
-	if cap == 0 {
+	// Don't stagger when disabled(cap==0) or when nextTime is zero.
+	if cap == 0 || nextTime.IsZero() {
 		return nextTime
 	}
 


### PR DESCRIPTION
When we stagger a ReclaimSpace/KeyRotationJob, we ask the controller to wakeup later than the raw schedule. This caused a conflict with `StartingDeadlineSeconds` where the runs would be silently skipped.

This patch fixes it by:
- Widening the missed run search window by stagger offset.
- Appying the same stagger to the `lastMissed` so the "too late" check compares like with like.

Unit tests around this have also been added.