### PR TITLE
pvc_new_controller: Ignore unrelated events on the PVC

### DIFF
--- a/internal/controller/utils/predicates.go
+++ b/internal/controller/utils/predicates.go
@@ -40,29 +40,17 @@ func SilentPredicate() predicate.Predicate {
 	}
 }
 
-// PVCPredicate returns a predicate for PVC watch events.
-// Reconciliation on update is triggered only when
-// one of the relevant annotations changes value. Create and Delete
-// events are always reconciled.
+// PVCPredicate returns a predicate that only allows PVC Create events.
+// When schedule precedence is set to StorageClass, the controller reads
+// configuration from the StorageClass, not PVC annotations, so PVC
+// updates do not require reconciliation. Deletes are also ignored
+// because child resources are garbage-collected via owner references.
 func PVCPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc:  func(e event.CreateEvent) bool { return true },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
-		GenericFunc: func(e event.GenericEvent) bool { return true },
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			if e.ObjectNew == nil || e.ObjectOld == nil {
-				return false
-			}
-
-			relevantAnnotations := []string{
-				KrcJobScheduleTimeAnnotation,
-				KrEnableAnnotation,
-				RsCronJobScheduleTimeAnnotation,
-				RsEnableAnnotation,
-			}
-
-			return AnnotationValueChanged(e.ObjectOld.GetAnnotations(), e.ObjectNew.GetAnnotations(), relevantAnnotations)
-		},
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
 	}
 }
 

--- a/test/e2e/reclaimspace/reclaimspace_test.go
+++ b/test/e2e/reclaimspace/reclaimspace_test.go
@@ -320,5 +320,60 @@ var _ = ginkgo.Describe("ReclaimSpace", ginkgo.Ordered, func() {
 				return updatedCronJob.Status.LastScheduleTime
 			}, 60*time.Second, 2*time.Second).ShouldNot(gomega.BeNil(), "CronJob status was not updated in time")
 		})
+
+		ginkgo.It("should garbage collect ReclaimSpaceCronJob when owner PVC is deleted", func() {
+			ginkgo.By("Creating a filesystem PVC")
+			pvc := f.CreatePVC("test-pvc-gc", "", f.GetReclaimSpaceStorageClassName())
+			pvc = f.WaitForPVCBound(pvc.Name)
+			gomega.Expect(pvc.Status.Phase).To(gomega.Equal(corev1.ClaimBound))
+
+			ginkgo.By("Creating a ReclaimSpaceCronJob owned by the PVC")
+			isController := true
+			blockOwnerDeletion := true
+			cronJob := &csiaddonsv1alpha1.ReclaimSpaceCronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-rs-cronjob-gc",
+					Namespace: f.GetNamespaceName(),
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "v1",
+							Kind:               "PersistentVolumeClaim",
+							Name:               pvc.Name,
+							UID:                pvc.UID,
+							Controller:         &isController,
+							BlockOwnerDeletion: &blockOwnerDeletion,
+						},
+					},
+				},
+				Spec: csiaddonsv1alpha1.ReclaimSpaceCronJobSpec{
+					Schedule: "@weekly",
+					JobSpec: csiaddonsv1alpha1.ReclaimSpaceJobTemplateSpec{
+						Spec: csiaddonsv1alpha1.ReclaimSpaceJobSpec{
+							Target: csiaddonsv1alpha1.TargetSpec{
+								PersistentVolumeClaim: pvc.Name,
+							},
+							BackoffLimit:         3,
+							RetryDeadlineSeconds: 600,
+						},
+					},
+				},
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), f.GetTimeout("operation"))
+			defer cancel()
+			err := f.Client.Create(ctx, cronJob)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Failed to create ReclaimSpaceCronJob with owner reference")
+			f.TrackResource(cronJob)
+
+			ginkgo.By("Verifying the ReclaimSpaceCronJob exists")
+			cronJob = f.GetReclaimSpaceCronJob(cronJob.Name)
+			gomega.Expect(cronJob).NotTo(gomega.BeNil())
+
+			ginkgo.By("Deleting the owner PVC")
+			f.DeletePVC(pvc.Name)
+
+			ginkgo.By("Waiting for the ReclaimSpaceCronJob to be garbage collected")
+			f.WaitForResourceDeleted(cronJob, 60*time.Second)
+		})
 	})
 })


### PR DESCRIPTION
Since the new controller is only enabled when precedence is set to
"storageclass", meaning annotations are only read from SC, there
is no need to watch for events/annotations other than Create on the
PVC when this controller is running. The owner refs will GC the
child resources if PVC is deleted.

e2e is also added around this.