### PR TITLE
ci: workaround for sudo error in e2e during Minikube Setup

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -42,6 +42,9 @@ jobs:
           sudo dpkg -i "cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb"
           rm -f "cri-dockerd_0.3.21.3-0.ubuntu-focal_${ARCH}.deb"
 
+      - name: Workaround for medyagh/setup-minikube#835
+        run: sudo mkdir -p /etc/cni/net.d
+
       - name: Setup Minikube
         uses: medyagh/setup-minikube@latest
         with:


### PR DESCRIPTION
The minikube e2e job fails with

    /usr/bin/sudo chmod 755 /etc/cni/net.d
    chmod: cannot access '/etc/cni/net.d': No such file or directory
    Error: The process '/usr/bin/sudo' failed with exit code 1

See-also: medyagh/setup-minikube#835


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test environment setup by ensuring required networking configuration is available before Minikube starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->