### PR TITLE
ci: update the ceph image in e2e

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -2,11 +2,18 @@
 # codespell is a GitHub Actions that runs codespell tool to catch misspell
 # Reference https://github.com/codespell-project/actions-codespell
 name: Codespell
+# yamllint disable rule:line-length
 # yamllint disable-line rule:truthy
 on:
   pull_request:
     branches:
       - '*'
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   codespell:
     name: codespell

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,5 +1,6 @@
 ---
 name: golangci-lint
+# yamllint disable rule:line-length
 # yamllint disable-line rule:truthy
 on:
   push:
@@ -9,6 +10,11 @@ on:
 
 permissions:
   contents: read
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   golangci:

--- a/.github/workflows/kind-deploy.yaml
+++ b/.github/workflows/kind-deploy.yaml
@@ -1,6 +1,6 @@
 ---
 name: Test deploying controller
-
+# yamllint disable rule:line-length
 # yamllint disable-line rule:truthy
 on:
   pull_request:
@@ -8,6 +8,11 @@ on:
       - "*"
 env:
   TAG: test
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   kind_deploy:

--- a/.github/workflows/lint-extras.yaml
+++ b/.github/workflows/lint-extras.yaml
@@ -1,5 +1,6 @@
 ---
 name: Lint Code Base
+# yamllint disable rule:line-length
 # yamllint disable-line rule:truthy
 on:
   push:
@@ -10,6 +11,11 @@ on:
 permissions:
   contents: read
   statuses: write
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   test-lint:

--- a/.github/workflows/test-build.yaml
+++ b/.github/workflows/test-build.yaml
@@ -1,11 +1,16 @@
 ---
 name: Test building container images
-
+# yamllint disable rule:line-length
 # yamllint disable-line rule:truthy
 on:
   pull_request:
     branches:
       - "*"
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   build_bundle:

--- a/.github/workflows/test-golang.yaml
+++ b/.github/workflows/test-golang.yaml
@@ -1,11 +1,16 @@
 ---
 name: Run Golang tests
-
+# yamllint disable rule:line-length
 # yamllint disable-line rule:truthy
 on:
   pull_request:
     branches:
       - "*"
+
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   make_test:

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -1,8 +1,14 @@
 ---
 name: Yaml Lint
+# yamllint disable rule:line-length
 # yamllint disable-line rule:truthy
 on:
   pull_request:
+
+  # cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   yamllint:

--- a/internal/controller/csiaddons/persistentvolumeclaim_controller.go
+++ b/internal/controller/csiaddons/persistentvolumeclaim_controller.go
@@ -116,7 +116,7 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 	if pvc.Status.Phase != corev1.ClaimBound {
 		logger.Info("PVC is not in bound state", "PVCPhase", pvc.Status.Phase)
 		// requeue the request
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second * 1}, nil
 	}
 	// get the driver name from PV to check if it supports space reclamation.
 	pv := &corev1.PersistentVolume{}
@@ -607,7 +607,7 @@ func (r *PersistentVolumeClaimReconciler) processReclaimSpace(
 
 	schedule, err := r.determineScheduleAndRequeue(ctx, logger, pvc, pv.Spec.CSI.Driver, utils.RsCronJobScheduleTimeAnnotation)
 	if errors.Is(err, utils.ErrConnNotFoundRequeueNeeded) {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second * 1}, nil
 	}
 	if errors.Is(err, utils.ErrScheduleNotFound) {
 		// if schedule is not found,

--- a/internal/controller/csiaddons/pvc_new_controller.go
+++ b/internal/controller/csiaddons/pvc_new_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	"github.com/csi-addons/kubernetes-csi-addons/internal/connection"
@@ -74,7 +75,7 @@ func (r *PVCReconiler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 	if pvc.Status.Phase != corev1.ClaimBound {
 		logger.Info("PVC is not yet bound, requeue the request", "PVCInfo", req.NamespacedName)
 
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: time.Second * 1}, nil
 	}
 
 	// Fetch the PV and check if it is CSI provisioned, if not, do nothing

--- a/internal/controller/replication.storage/volumereplication_controller.go
+++ b/internal/controller/replication.storage/volumereplication_controller.go
@@ -426,7 +426,6 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 
 		return ctrl.Result{
-			Requeue: true,
 			// Setting Requeue time for 30 seconds as the resync can take time
 			// and having default Requeue exponential backoff time can affect
 			// the RTO time.
@@ -504,7 +503,6 @@ func (r *VolumeReplicationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if requeueForInfo {
 		reconcileInternal := getInfoReconcileInterval(parameters, logger)
 		return ctrl.Result{
-			Requeue:      true,
 			RequeueAfter: reconcileInternal,
 		}, nil
 	}

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/csiaddonsnode"
 	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/server"
 	sideutil "github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/util"
-	"github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition"
+	condition "github.com/csi-addons/kubernetes-csi-addons/sidecar/internal/volume-condition"
 
 	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
 	"github.com/kubernetes-csi/csi-lib-utils/standardflags"
@@ -200,10 +200,9 @@ func main() {
 	// CSIAddonNode object and then calling deploy()
 	go func() {
 		err := nodeMgr.DispatchWatcher()
-		if err != nil {
-			setupLog.Error(err, "Failed to start watcher")
-			os.Exit(1)
-		}
+		setupLog.Error(err, "Failed to start watcher")
+		os.Exit(1)
+
 	}()
 
 	// start the volume condition reporter

--- a/test/scripts/ceph/github-action-helper.sh
+++ b/test/scripts/ceph/github-action-helper.sh
@@ -17,6 +17,7 @@ source "${SCRIPT_DIR}/utils.sh"
 #############
 : "${FUNCTION:=${1}}"
 
+CEPH_IMAGE=${CEPH_IMAGE:-"quay.io/ceph/ceph:v19.2.5"}
 #############
 # WRAPPER FUNCTIONS - Delegate to Rook's script
 #############
@@ -87,7 +88,8 @@ function deploy_first_ceph_cluster() {
 	  with(select(.kind == "CephCluster");
 	    .spec.dashboard.enabled = false |
 	    .spec.storage.useAllDevices = false |
-	    .spec.storage.deviceFilter = strenv(DEVICE_NAME) + "1"
+	    .spec.storage.deviceFilter = strenv(DEVICE_NAME) + "1" |
+		.spec.image = strenv(CEPH_IMAGE)
 	  )
 	' cluster-test.yaml
 	kubectl_retry create -f cluster-test.yaml
@@ -108,7 +110,8 @@ function deploy_second_ceph_cluster() {
 	DEVICE_NAME="$DEVICE_NAME" yq e -i '
 	  with(select(.kind == "CephCluster");
 	    .spec.dataDirHostPath = "/var/lib/rook-external" |
-	    .spec.storage.deviceFilter = strenv(DEVICE_NAME) + "2"
+	    .spec.storage.deviceFilter = strenv(DEVICE_NAME) + "2" |
+		.spec.image = strenv(CEPH_IMAGE)
 	  )
 	' cluster-test.yaml
 	kubectl_retry create -f cluster-test.yaml


### PR DESCRIPTION
ceph 19 always pulls the latest version where we have change related to AES256 and current pinned Rook cannot handle it, for that reason pinning the ceph image to the old one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Ceph deployment validation to use Ceph version 19.2.5 by default.
  - Ensured both test cluster deployments consistently apply the configured Ceph image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->