### PR TITLE
ci: fix golangci-lint errors

### DIFF
--- a/internal/controller/csiaddons/persistentvolumeclaim_controller.go
+++ b/internal/controller/csiaddons/persistentvolumeclaim_controller.go
@@ -73,6 +73,11 @@ const (
 
 	relciamSpaceOp Operation = "reclaimspace"
 	keyRotationOp  Operation = "keyrotation"
+
+	// pvcRequeueDelay is the duration to wait before requeuing a PVC
+	// reconciliation when it is not yet ready (e.g. not bound, or no
+	// CSI connection available yet).
+	pvcRequeueDelay = 30 * time.Second
 )
 
 //+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;patch
@@ -116,7 +121,7 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 	if pvc.Status.Phase != corev1.ClaimBound {
 		logger.Info("PVC is not in bound state", "PVCPhase", pvc.Status.Phase)
 		// requeue the request
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: pvcRequeueDelay}, nil
 	}
 	// get the driver name from PV to check if it supports space reclamation.
 	pv := &corev1.PersistentVolume{}
@@ -607,7 +612,7 @@ func (r *PersistentVolumeClaimReconciler) processReclaimSpace(
 
 	schedule, err := r.determineScheduleAndRequeue(ctx, logger, pvc, pv.Spec.CSI.Driver, utils.RsCronJobScheduleTimeAnnotation)
 	if errors.Is(err, utils.ErrConnNotFoundRequeueNeeded) {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: pvcRequeueDelay}, nil
 	}
 	if errors.Is(err, utils.ErrScheduleNotFound) {
 		// if schedule is not found,

--- a/internal/controller/csiaddons/pvc_new_controller.go
+++ b/internal/controller/csiaddons/pvc_new_controller.go
@@ -74,7 +74,7 @@ func (r *PVCReconiler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 	if pvc.Status.Phase != corev1.ClaimBound {
 		logger.Info("PVC is not yet bound, requeue the request", "PVCInfo", req.NamespacedName)
 
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: pvcRequeueDelay}, nil
 	}
 
 	// Fetch the PV and check if it is CSI provisioned, if not, do nothing

--- a/sidecar/main.go
+++ b/sidecar/main.go
@@ -200,10 +200,8 @@ func main() {
 	// CSIAddonNode object and then calling deploy()
 	go func() {
 		err := nodeMgr.DispatchWatcher()
-		if err != nil {
-			setupLog.Error(err, "Failed to start watcher")
-			os.Exit(1)
-		}
+		setupLog.Error(err, "Failed to start watcher")
+		os.Exit(1)
 	}()
 
 	// start the volume condition reporter


### PR DESCRIPTION

ctrl.Result.Requeue is deprecated in favour of RequeueAfter.  Replace all
Requeue: true usages in the PVC controllers with RequeueAfter using a shared
pvcRequeueDelay constant (30s).

staticcheck SA4023 flagged that the error returned by nodeMgr.DispatchWatcher()
is never nil, making the `if err != nil` comparison always true. Remove the
redundant guard and call setupLog.Error and os.Exit unconditionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved persistent volume claim processing by retrying pending or unavailable connections after a consistent 30-second delay.
  - Reduced unnecessary immediate retry activity while claims are waiting to become ready.
  - Improved monitoring behavior when the storage watcher stops, including clear logging and controlled termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->