### PR TITLE
api: publish annotations as a part of API

### DIFF
--- a/api/csiaddons/v1alpha1/annotations.go
+++ b/api/csiaddons/v1alpha1/annotations.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// Public facing annotations recognized by the CSI-Addons.
+const (
+	RsEnableAnnotation              = "reclaimspace." + Group + "/enable"
+	RsCronJobScheduleTimeAnnotation = "reclaimspace." + Group + "/schedule"
+	RsCronJobNameAnnotation         = "reclaimspace." + Group + "/cronjob"
+
+	KrEnableAnnotation              = "keyrotation." + Group + "/enable"
+	KrCronJobScheduleTimeAnnotation = "keyrotation." + Group + "/schedule"
+	KrCronJobNameAnnotation         = "keyrotation." + Group + "/cronjob"
+
+	CSIAddonsStateAnnotation = Group + "/state"
+)
+
+// CSIAddonsStateManaged is the value of CSIAddonsStateAnnotation that marks a
+// resource as managed by the CSI-Addons.
+const CSIAddonsStateManaged = "managed"

--- a/api/csiaddons/v1alpha1/groupversion_info.go
+++ b/api/csiaddons/v1alpha1/groupversion_info.go
@@ -25,9 +25,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const (
+	// Group is the API group for the csiaddons objects.
+	Group = "csiaddons.openshift.io"
+
+	// Version is the API version for the csiaddons.
+	Version = "v1alpha1"
+)
+
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "csiaddons.openshift.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)

--- a/internal/controller/csiaddons/persistentvolumeclaim_controller.go
+++ b/internal/controller/csiaddons/persistentvolumeclaim_controller.go
@@ -292,10 +292,10 @@ func (r *PersistentVolumeClaimReconciler) storageClassEventHandler() handler.Eve
 			}
 
 			annotationsToWatch := []string{
-				utils.RsCronJobScheduleTimeAnnotation,
-				utils.KrcJobScheduleTimeAnnotation,
-				utils.KrEnableAnnotation,
-				utils.RsEnableAnnotation,
+				csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation,
+				csiaddonsv1alpha1.KrCronJobScheduleTimeAnnotation,
+				csiaddonsv1alpha1.KrEnableAnnotation,
+				csiaddonsv1alpha1.RsEnableAnnotation,
 			}
 
 			var requests []reconcile.Request
@@ -370,8 +370,8 @@ func (r *PersistentVolumeClaimReconciler) SetupWithManager(mgr ctrl.Manager, ctr
 		return err
 	}
 
-	pvcPred := createAnnotationPredicate(utils.RsCronJobScheduleTimeAnnotation, utils.KrcJobScheduleTimeAnnotation, utils.KrEnableAnnotation, utils.RsEnableAnnotation)
-	scPred := createAnnotationPredicate(utils.RsCronJobScheduleTimeAnnotation, utils.KrcJobScheduleTimeAnnotation, utils.KrEnableAnnotation, utils.RsEnableAnnotation)
+	pvcPred := createAnnotationPredicate(csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation, csiaddonsv1alpha1.KrCronJobScheduleTimeAnnotation, csiaddonsv1alpha1.KrEnableAnnotation, csiaddonsv1alpha1.RsEnableAnnotation)
+	scPred := createAnnotationPredicate(csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation, csiaddonsv1alpha1.KrCronJobScheduleTimeAnnotation, csiaddonsv1alpha1.KrEnableAnnotation, csiaddonsv1alpha1.RsEnableAnnotation)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.PersistentVolumeClaim{}).
@@ -473,7 +473,7 @@ func constructKRCronJob(name, namespace, schedule, pvcName string) *csiaddonsv1a
 			Name:      name,
 			Namespace: namespace,
 			Annotations: map[string]string{
-				utils.CSIAddonsStateAnnotation: utils.CSIAddonsStateManaged,
+				csiaddonsv1alpha1.CSIAddonsStateAnnotation: csiaddonsv1alpha1.CSIAddonsStateManaged,
 			},
 		},
 		Spec: csiaddonsv1alpha1.EncryptionKeyRotationCronJobSpec{
@@ -503,7 +503,7 @@ func constructRSCronJob(name, namespace, schedule, pvcName string) *csiaddonsv1a
 			Name:      name,
 			Namespace: namespace,
 			Annotations: map[string]string{
-				utils.CSIAddonsStateAnnotation: utils.CSIAddonsStateManaged,
+				csiaddonsv1alpha1.CSIAddonsStateAnnotation: csiaddonsv1alpha1.CSIAddonsStateManaged,
 			},
 		},
 		Spec: csiaddonsv1alpha1.ReclaimSpaceCronJobSpec{
@@ -580,13 +580,13 @@ func (r *PersistentVolumeClaimReconciler) processReclaimSpace(
 	}
 	if rsCronJob != nil {
 		*logger = logger.WithValues("ReclaimSpaceCronJobName", rsCronJob.Name)
-		if state, ok := rsCronJob.GetAnnotations()[utils.CSIAddonsStateAnnotation]; ok && state != utils.CSIAddonsStateManaged {
+		if state, ok := rsCronJob.GetAnnotations()[csiaddonsv1alpha1.CSIAddonsStateAnnotation]; ok && state != csiaddonsv1alpha1.CSIAddonsStateManaged {
 			logger.Info("ReclaimSpaceCronJob is not managed, exiting reconcile")
 			return ctrl.Result{}, nil
 		}
 	}
 
-	disabled, err := r.checkDisabledByAnnotation(ctx, logger, pvc, utils.RsEnableAnnotation)
+	disabled, err := r.checkDisabledByAnnotation(ctx, logger, pvc, csiaddonsv1alpha1.RsEnableAnnotation)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -605,7 +605,7 @@ func (r *PersistentVolumeClaimReconciler) processReclaimSpace(
 		return ctrl.Result{}, nil
 	}
 
-	schedule, err := r.determineScheduleAndRequeue(ctx, logger, pvc, pv.Spec.CSI.Driver, utils.RsCronJobScheduleTimeAnnotation)
+	schedule, err := r.determineScheduleAndRequeue(ctx, logger, pvc, pv.Spec.CSI.Driver, csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation)
 	if errors.Is(err, utils.ErrConnNotFoundRequeueNeeded) {
 		return ctrl.Result{RequeueAfter: time.Second * 1}, nil
 	}
@@ -619,10 +619,10 @@ func (r *PersistentVolumeClaimReconciler) processReclaimSpace(
 			}
 		}
 		// delete name from annotation.
-		_, nameFound := pvc.Annotations[utils.RsCronJobNameAnnotation]
+		_, nameFound := pvc.Annotations[csiaddonsv1alpha1.RsCronJobNameAnnotation]
 		if nameFound {
 			// remove name annotation by patching it to null.
-			patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q: null}}}`, utils.RsCronJobNameAnnotation))
+			patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q: null}}}`, csiaddonsv1alpha1.RsCronJobNameAnnotation))
 			err = r.Patch(ctx, pvc, client.RawPatch(types.StrategicMergePatchType, patch))
 			if err != nil {
 				logger.Error(err, "Failed to remove annotation")
@@ -659,7 +659,7 @@ func (r *PersistentVolumeClaimReconciler) processReclaimSpace(
 
 		// Update schedule on the pvc
 		err = r.patchAnnotationsToResource(ctx, logger, map[string]string{
-			utils.RsCronJobScheduleTimeAnnotation: schedule,
+			csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation: schedule,
 		}, pvc)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -674,8 +674,8 @@ func (r *PersistentVolumeClaimReconciler) processReclaimSpace(
 	// adding annotation is required for the case when pvc does not have
 	// have schedule annotation but namespace has.
 	err = r.patchAnnotationsToResource(ctx, logger, map[string]string{
-		utils.RsCronJobNameAnnotation:         rsCronJobName,
-		utils.RsCronJobScheduleTimeAnnotation: schedule,
+		csiaddonsv1alpha1.RsCronJobNameAnnotation:         rsCronJobName,
+		csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation: schedule,
 	}, pvc)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -748,13 +748,13 @@ func (r *PersistentVolumeClaimReconciler) processKeyRotation(
 	}
 	if krcJob != nil {
 		*logger = logger.WithValues("EncryptionKeyrotationCronJobName", krcJob.Name)
-		if state, ok := krcJob.GetAnnotations()[utils.CSIAddonsStateAnnotation]; ok && state != utils.CSIAddonsStateManaged {
+		if state, ok := krcJob.GetAnnotations()[csiaddonsv1alpha1.CSIAddonsStateAnnotation]; ok && state != csiaddonsv1alpha1.CSIAddonsStateManaged {
 			logger.Info("EncryptionKeyRotationCronJob is not managed, exiting reconcile")
 			return nil
 		}
 	}
 
-	disabled, err := r.checkDisabledByAnnotation(ctx, logger, pvc, utils.KrEnableAnnotation)
+	disabled, err := r.checkDisabledByAnnotation(ctx, logger, pvc, csiaddonsv1alpha1.KrEnableAnnotation)
 	if err != nil {
 		return err
 	}
@@ -774,7 +774,7 @@ func (r *PersistentVolumeClaimReconciler) processKeyRotation(
 	}
 
 	// Determine schedule
-	sched, err := r.determineScheduleAndRequeue(ctx, logger, pvc, pv.Spec.CSI.Driver, utils.KrcJobScheduleTimeAnnotation)
+	sched, err := r.determineScheduleAndRequeue(ctx, logger, pvc, pv.Spec.CSI.Driver, csiaddonsv1alpha1.KrCronJobScheduleTimeAnnotation)
 	if errors.Is(err, utils.ErrScheduleNotFound) {
 		// No schedule, delete the job
 		if krcJob != nil {
@@ -813,7 +813,7 @@ func (r *PersistentVolumeClaimReconciler) processKeyRotation(
 
 		// update the schedule on the pvc
 		err = r.patchAnnotationsToResource(ctx, logger, map[string]string{
-			utils.KrcJobScheduleTimeAnnotation: sched,
+			csiaddonsv1alpha1.KrCronJobScheduleTimeAnnotation: sched,
 		}, pvc)
 		if err != nil {
 			return err
@@ -824,8 +824,8 @@ func (r *PersistentVolumeClaimReconciler) processKeyRotation(
 	// Add the annotation to the pvc, this will help us optimize reconciles
 	krcJobName := generateCronJobName(req.Name)
 	err = r.patchAnnotationsToResource(ctx, logger, map[string]string{
-		utils.KrcJobNameAnnotation:         krcJobName,
-		utils.KrcJobScheduleTimeAnnotation: sched,
+		csiaddonsv1alpha1.KrCronJobNameAnnotation:         krcJobName,
+		csiaddonsv1alpha1.KrCronJobScheduleTimeAnnotation: sched,
 	}, pvc)
 	if err != nil {
 		return err
@@ -940,7 +940,7 @@ func (r *PersistentVolumeClaimReconciler) getScheduleFromNS(
 		// requeuing the request.
 		// Depending on requeue value, it will return ErrorConnNotFoundRequeueNeeded.
 		switch annotationKey {
-		case utils.KrcJobScheduleTimeAnnotation:
+		case csiaddonsv1alpha1.KrCronJobScheduleTimeAnnotation:
 			requeue, keyRotationSupported, err := r.checkDriverSupportCapability(logger, ns.Annotations, driverName, keyRotationOp)
 			if err != nil {
 				return "", err
@@ -951,7 +951,7 @@ func (r *PersistentVolumeClaimReconciler) getScheduleFromNS(
 			if requeue {
 				return "", utils.ErrConnNotFoundRequeueNeeded
 			}
-		case utils.RsCronJobScheduleTimeAnnotation:
+		case csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation:
 			requeue, supportReclaimspace, err := r.checkDriverSupportCapability(logger, ns.Annotations, driverName, relciamSpaceOp)
 			if err != nil {
 				return "", err

--- a/internal/controller/csiaddons/persistentvolumeclaim_controller_test.go
+++ b/internal/controller/csiaddons/persistentvolumeclaim_controller_test.go
@@ -186,7 +186,7 @@ func TestGetScheduleFromAnnotation(t *testing.T) {
 			args: args{
 				logger: &logger,
 				annotations: map[string]string{
-					utils.RsCronJobScheduleTimeAnnotation: "@weekly",
+					csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation: "@weekly",
 				},
 			},
 			want:  "@weekly",
@@ -197,7 +197,7 @@ func TestGetScheduleFromAnnotation(t *testing.T) {
 			args: args{
 				logger: &logger,
 				annotations: map[string]string{
-					utils.RsCronJobScheduleTimeAnnotation: "@daytime",
+					csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation: "@daytime",
 				},
 			},
 			want:  defaultSchedule,
@@ -206,7 +206,7 @@ func TestGetScheduleFromAnnotation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := getScheduleFromAnnotation(utils.RsCronJobScheduleTimeAnnotation, tt.args.logger, tt.args.annotations)
+			got, got1 := getScheduleFromAnnotation(csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation, tt.args.logger, tt.args.annotations)
 			assert.Equal(t, tt.want, got)
 			assert.Equal(t, tt.want1, got1)
 		})
@@ -227,22 +227,22 @@ func TestDetermineScheduleAndRequeue(t *testing.T) {
 		{
 			name: "pvc annotation set",
 			args: args{
-				pvcAnnotations: map[string]string{utils.RsCronJobScheduleTimeAnnotation: "@daily"},
+				pvcAnnotations: map[string]string{csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation: "@daily"},
 			},
 			want: "@daily",
 		},
 		{
 			name: "sc annotation set",
 			args: args{
-				scAnnotations: map[string]string{utils.RsCronJobScheduleTimeAnnotation: "@monthly"},
+				scAnnotations: map[string]string{csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation: "@monthly"},
 			},
 			want: "@monthly",
 		},
 		{
 			name: "pvc & sc annotation set",
 			args: args{
-				pvcAnnotations: map[string]string{utils.RsCronJobScheduleTimeAnnotation: "@daily"},
-				scAnnotations:  map[string]string{utils.RsCronJobScheduleTimeAnnotation: "@weekly"},
+				pvcAnnotations: map[string]string{csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation: "@daily"},
+				scAnnotations:  map[string]string{csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation: "@weekly"},
 			},
 			want: "@daily",
 		},
@@ -300,7 +300,7 @@ func TestDetermineScheduleAndRequeue(t *testing.T) {
 			err = r.Update(ctx, pvc)
 			assert.NoError(t, err)
 
-			schedule, error := r.determineScheduleAndRequeue(ctx, &logger, pvc, driverName, utils.RsCronJobScheduleTimeAnnotation)
+			schedule, error := r.determineScheduleAndRequeue(ctx, &logger, pvc, driverName, csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation)
 			assert.NoError(t, error)
 			assert.Equal(t, tt.want, schedule)
 		})
@@ -310,7 +310,7 @@ func TestDetermineScheduleAndRequeue(t *testing.T) {
 		emptyScName := ""
 		pvc.Spec.StorageClassName = &emptyScName
 		pvc.Annotations = nil
-		schedule, error := r.determineScheduleAndRequeue(ctx, &logger, pvc, driverName, utils.RsCronJobScheduleTimeAnnotation)
+		schedule, error := r.determineScheduleAndRequeue(ctx, &logger, pvc, driverName, csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation)
 		assert.ErrorIs(t, error, utils.ErrScheduleNotFound)
 		assert.Equal(t, "", schedule)
 	})
@@ -320,7 +320,7 @@ func TestDetermineScheduleAndRequeue(t *testing.T) {
 		sc.Name = "non-existent-sc"
 		pvc.Spec.StorageClassName = &sc.Name
 		pvc.Annotations = nil
-		schedule, error := r.determineScheduleAndRequeue(ctx, &logger, pvc, driverName, utils.RsCronJobScheduleTimeAnnotation)
+		schedule, error := r.determineScheduleAndRequeue(ctx, &logger, pvc, driverName, csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation)
 		assert.ErrorIs(t, error, utils.ErrScheduleNotFound)
 		assert.Equal(t, "", schedule)
 	})
@@ -329,7 +329,7 @@ func TestDetermineScheduleAndRequeue(t *testing.T) {
 	t.Run("StorageClassName is nil", func(t *testing.T) {
 		pvc.Spec.StorageClassName = nil
 		pvc.Annotations = nil
-		schedule, error := r.determineScheduleAndRequeue(ctx, &logger, pvc, driverName, utils.RsCronJobScheduleTimeAnnotation)
+		schedule, error := r.determineScheduleAndRequeue(ctx, &logger, pvc, driverName, csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation)
 		assert.ErrorIs(t, error, utils.ErrScheduleNotFound)
 		assert.Equal(t, "", schedule)
 	})
@@ -423,7 +423,7 @@ func TestConstructKRCronJob(t *testing.T) {
 					Name:      "test-kr-cron",
 					Namespace: "default",
 					Annotations: map[string]string{
-						utils.CSIAddonsStateAnnotation: utils.CSIAddonsStateManaged,
+						csiaddonsv1alpha1.CSIAddonsStateAnnotation: csiaddonsv1alpha1.CSIAddonsStateManaged,
 					},
 				},
 				Spec: csiaddonsv1alpha1.EncryptionKeyRotationCronJobSpec{
@@ -453,7 +453,7 @@ func TestConstructKRCronJob(t *testing.T) {
 					Name:      "empty-schedule-cron",
 					Namespace: "kube-system",
 					Annotations: map[string]string{
-						utils.CSIAddonsStateAnnotation: utils.CSIAddonsStateManaged,
+						csiaddonsv1alpha1.CSIAddonsStateAnnotation: csiaddonsv1alpha1.CSIAddonsStateManaged,
 					},
 				},
 				Spec: csiaddonsv1alpha1.EncryptionKeyRotationCronJobSpec{
@@ -483,7 +483,7 @@ func TestConstructKRCronJob(t *testing.T) {
 					Name:      "special-!@#$%^&*()-cron",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						utils.CSIAddonsStateAnnotation: utils.CSIAddonsStateManaged,
+						csiaddonsv1alpha1.CSIAddonsStateAnnotation: csiaddonsv1alpha1.CSIAddonsStateManaged,
 					},
 				},
 				Spec: csiaddonsv1alpha1.EncryptionKeyRotationCronJobSpec{
@@ -533,7 +533,7 @@ func TestConstructRSCronJob(t *testing.T) {
 					Name:      "test-rs-cron",
 					Namespace: "default",
 					Annotations: map[string]string{
-						utils.CSIAddonsStateAnnotation: utils.CSIAddonsStateManaged,
+						csiaddonsv1alpha1.CSIAddonsStateAnnotation: csiaddonsv1alpha1.CSIAddonsStateManaged,
 					},
 				},
 				Spec: csiaddonsv1alpha1.ReclaimSpaceCronJobSpec{
@@ -563,7 +563,7 @@ func TestConstructRSCronJob(t *testing.T) {
 					Name:      "empty-schedule-cron",
 					Namespace: "kube-system",
 					Annotations: map[string]string{
-						utils.CSIAddonsStateAnnotation: utils.CSIAddonsStateManaged,
+						csiaddonsv1alpha1.CSIAddonsStateAnnotation: csiaddonsv1alpha1.CSIAddonsStateManaged,
 					},
 				},
 				Spec: csiaddonsv1alpha1.ReclaimSpaceCronJobSpec{
@@ -593,7 +593,7 @@ func TestConstructRSCronJob(t *testing.T) {
 					Name:      "special-!@#$%^&*()-cron",
 					Namespace: "test-ns",
 					Annotations: map[string]string{
-						utils.CSIAddonsStateAnnotation: utils.CSIAddonsStateManaged,
+						csiaddonsv1alpha1.CSIAddonsStateAnnotation: csiaddonsv1alpha1.CSIAddonsStateManaged,
 					},
 				},
 				Spec: csiaddonsv1alpha1.ReclaimSpaceCronJobSpec{

--- a/internal/controller/csiaddons/pvc_new_controller.go
+++ b/internal/controller/csiaddons/pvc_new_controller.go
@@ -107,8 +107,8 @@ func (r *PVCReconiler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 	// Reconcile for dependent features
 	// Reconcile - Key rotation
 	keyRotationName := fmt.Sprintf("%s-keyrotation", pvc.Name)
-	keyRotationSched := sc.Annotations[utils.KrcJobScheduleTimeAnnotation]
-	keyRotationEnabled := sc.Annotations[utils.KrEnableAnnotation]
+	keyRotationSched := sc.Annotations[csiaddonsv1alpha1.KrCronJobScheduleTimeAnnotation]
+	keyRotationEnabled := sc.Annotations[csiaddonsv1alpha1.KrEnableAnnotation]
 	keyRotationChild := &csiaddonsv1alpha1.EncryptionKeyRotationCronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      keyRotationName,
@@ -122,8 +122,8 @@ func (r *PVCReconiler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 
 	// Reconcile - Reclaim space
 	reclaimSpaceName := fmt.Sprintf("%s-reclaimspace", pvc.Name)
-	reclaimSpaceSched := sc.Annotations[utils.RsCronJobScheduleTimeAnnotation]
-	reclaimSpaceEnabled := sc.Annotations[utils.RsEnableAnnotation]
+	reclaimSpaceSched := sc.Annotations[csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation]
+	reclaimSpaceEnabled := sc.Annotations[csiaddonsv1alpha1.RsEnableAnnotation]
 	reclaimSpaceChild := &csiaddonsv1alpha1.ReclaimSpaceCronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      reclaimSpaceName,

--- a/internal/controller/utils/annotations.go
+++ b/internal/controller/utils/annotations.go
@@ -21,25 +21,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	RsEnableAnnotation              = "reclaimspace." + csiaddonsv1alpha1.GroupVersion.Group + "/enable"
-	RsCronJobScheduleTimeAnnotation = "reclaimspace." + csiaddonsv1alpha1.GroupVersion.Group + "/schedule"
-	RsCronJobNameAnnotation         = "reclaimspace." + csiaddonsv1alpha1.GroupVersion.Group + "/cronjob"
-
-	KrEnableAnnotation           = "keyrotation." + csiaddonsv1alpha1.GroupVersion.Group + "/enable"
-	KrcJobScheduleTimeAnnotation = "keyrotation." + csiaddonsv1alpha1.GroupVersion.Group + "/schedule"
-	KrcJobNameAnnotation         = "keyrotation." + csiaddonsv1alpha1.GroupVersion.Group + "/cronjob"
-
-	CSIAddonsStateAnnotation = csiaddonsv1alpha1.GroupVersion.Group + "/state"
-)
-
 const (
 	// Index keys
 	StorageClassIndex = "spec.storageClassName"
 	JobOwnerKey       = ".metadata.controller"
-
-	// Represents the CRs that are managed by the PVC controller
-	CSIAddonsStateManaged = "managed"
 )
 
 // AnnotationValueChanged checks if any of the specified keys have different values
@@ -60,7 +45,7 @@ func AnnotationValueChanged(oldAnnotations, newAnnotations map[string]string, ke
 // It returns false if the object has the CSIAddonsStateAnnotation set to a value
 // other than CSIAddonsStateManaged. If the annotation is missing it returns true.
 func IsManagedByController(obj client.Object) bool {
-	if v, ok := obj.GetAnnotations()[CSIAddonsStateAnnotation]; ok && v != CSIAddonsStateManaged {
+	if v, ok := obj.GetAnnotations()[csiaddonsv1alpha1.CSIAddonsStateAnnotation]; ok && v != csiaddonsv1alpha1.CSIAddonsStateManaged {
 		return false
 	}
 	return true

--- a/internal/controller/utils/annotations_test.go
+++ b/internal/controller/utils/annotations_test.go
@@ -110,7 +110,7 @@ func TestIsManagedByController(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "No CSIAddonsStateAnnotation",
+			name: "No csiaddonsv1alpha1.CSIAddonsStateAnnotation",
 			obj: &csiaddonsv1alpha1.EncryptionKeyRotationCronJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{"other": "value"},
@@ -119,28 +119,28 @@ func TestIsManagedByController(t *testing.T) {
 			expected: true,
 		},
 		{
-			name: "CSIAddonsStateAnnotation set to managed",
+			name: "csiaddonsv1alpha1.CSIAddonsStateAnnotation set to managed",
 			obj: &csiaddonsv1alpha1.EncryptionKeyRotationCronJob{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{CSIAddonsStateAnnotation: CSIAddonsStateManaged},
+					Annotations: map[string]string{csiaddonsv1alpha1.CSIAddonsStateAnnotation: csiaddonsv1alpha1.CSIAddonsStateManaged},
 				},
 			},
 			expected: true,
 		},
 		{
-			name: "CSIAddonsStateAnnotation set to unmanaged",
+			name: "csiaddonsv1alpha1.CSIAddonsStateAnnotation set to unmanaged",
 			obj: &csiaddonsv1alpha1.EncryptionKeyRotationCronJob{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{CSIAddonsStateAnnotation: "unmanaged"},
+					Annotations: map[string]string{csiaddonsv1alpha1.CSIAddonsStateAnnotation: "unmanaged"},
 				},
 			},
 			expected: false,
 		},
 		{
-			name: "CSIAddonsStateAnnotation set to empty string",
+			name: "csiaddonsv1alpha1.CSIAddonsStateAnnotation set to empty string",
 			obj: &csiaddonsv1alpha1.EncryptionKeyRotationCronJob{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{CSIAddonsStateAnnotation: ""},
+					Annotations: map[string]string{csiaddonsv1alpha1.CSIAddonsStateAnnotation: ""},
 				},
 			},
 			expected: false,

--- a/internal/controller/utils/predicates.go
+++ b/internal/controller/utils/predicates.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"context"
 
+	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -65,10 +66,10 @@ func StorageClassPredicate() predicate.Predicate {
 
 			// Only trigger if relevant annotations change
 			relevantAnnotations := []string{
-				KrcJobScheduleTimeAnnotation,
-				KrEnableAnnotation,
-				RsCronJobScheduleTimeAnnotation,
-				RsEnableAnnotation,
+				csiaddonsv1alpha1.KrCronJobScheduleTimeAnnotation,
+				csiaddonsv1alpha1.KrEnableAnnotation,
+				csiaddonsv1alpha1.RsCronJobScheduleTimeAnnotation,
+				csiaddonsv1alpha1.RsEnableAnnotation,
 			}
 
 			return AnnotationValueChanged(oldSC.GetAnnotations(), newSC.GetAnnotations(), relevantAnnotations)

--- a/internal/controller/utils/reclaimspace_keyrotation.go
+++ b/internal/controller/utils/reclaimspace_keyrotation.go
@@ -69,7 +69,7 @@ func setKeyrotationSpec(v *csiaddonsv1alpha1.EncryptionKeyRotationCronJob, sched
 	if v.Annotations == nil {
 		v.Annotations = map[string]string{}
 	}
-	v.Annotations[CSIAddonsStateAnnotation] = CSIAddonsStateManaged
+	v.Annotations[csiaddonsv1alpha1.CSIAddonsStateAnnotation] = csiaddonsv1alpha1.CSIAddonsStateManaged
 
 	v.Spec.Schedule = schedule
 	v.Spec.FailedJobsHistoryLimit = &failedJobsHistoryLimit
@@ -95,7 +95,7 @@ func setReclaimspaceSpec(v *csiaddonsv1alpha1.ReclaimSpaceCronJob, schedule, pvc
 	if v.Annotations == nil {
 		v.Annotations = map[string]string{}
 	}
-	v.Annotations[CSIAddonsStateAnnotation] = CSIAddonsStateManaged
+	v.Annotations[csiaddonsv1alpha1.CSIAddonsStateAnnotation] = csiaddonsv1alpha1.CSIAddonsStateManaged
 
 	v.Spec.Schedule = schedule
 	v.Spec.FailedJobsHistoryLimit = &failedJobsHistoryLimit

--- a/internal/controller/utils/reclaimspace_keyrotation_test.go
+++ b/internal/controller/utils/reclaimspace_keyrotation_test.go
@@ -46,8 +46,8 @@ func TestSetSpec(t *testing.T) {
 					t.Errorf("expected pvcName 'test-pvc', got '%s'", ekrCronJob.Spec.JobSpec.Spec.Target.PersistentVolumeClaim)
 				}
 				// We set it by default when setting spec
-				if ekrCronJob.Annotations[CSIAddonsStateAnnotation] != CSIAddonsStateManaged {
-					t.Error("expected CSIAddonsStateManaged annotation")
+				if ekrCronJob.Annotations[csiaddonsv1alpha1.CSIAddonsStateAnnotation] != csiaddonsv1alpha1.CSIAddonsStateManaged {
+					t.Error("expected csiaddonsv1alpha1.CSIAddonsStateManaged annotation")
 				}
 			},
 		},
@@ -65,8 +65,8 @@ func TestSetSpec(t *testing.T) {
 					t.Errorf("expected pvcName 'another-pvc', got '%s'", rsCronJob.Spec.JobSpec.Spec.Target.PersistentVolumeClaim)
 				}
 				// We set it by default when setting spec
-				if rsCronJob.Annotations[CSIAddonsStateAnnotation] != CSIAddonsStateManaged {
-					t.Error("expected CSIAddonsStateManaged annotation")
+				if rsCronJob.Annotations[csiaddonsv1alpha1.CSIAddonsStateAnnotation] != csiaddonsv1alpha1.CSIAddonsStateManaged {
+					t.Error("expected csiaddonsv1alpha1.CSIAddonsStateManaged annotation")
 				}
 			},
 		},


### PR DESCRIPTION
This patch moves the annotations from the internal package 
to the public-facing API package, allowing other projects to use 
our definitions instead of hardcoding magic strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public CSI-Addons annotation definitions for reclaim-space, key-rotation, and controller-managed state.
  * Added the standard `managed` state value for identifying resources managed by CSI-Addons.
  * Added a shared CSI-Addons API group identifier.

* **Refactor**
  * Standardized controllers and utilities on the public annotation definitions.
  * Updated related tests to use shared API definitions, with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->